### PR TITLE
fix(functions): Configure Api security headers

### DIFF
--- a/src/Dfe.PlanTech.AzureFunctions/host.json
+++ b/src/Dfe.PlanTech.AzureFunctions/host.json
@@ -10,6 +10,19 @@
     }
   },
   "extensions": {
-    "serviceBus": {}
+    "serviceBus": {},
+    "http": {
+      "routePrefix": "api",
+      "customHeaders": {
+        "Server": null,
+        "Strict-Transport-Security": "max-age=31536000",
+        "Content-Security-Policy": "default-src 'self'; frame-ancestors 'none';",
+        "X-Frame-Options": "DENY",
+        "Cache-Control": "private",
+        "Content-Type": "application/json", 
+        "X-XSS-Protection": 1,
+        "X-Content-Type-Options": "nosniff"
+      }
+    }
   }
 }


### PR DESCRIPTION
### 207551 Verbose server headers
Removes the `Server` header that was previously showing Kestral

### 207521 Missing security headers
Adds the following headers that were identified as missing 
- Strict-Transport-Security
- Content-Security-Policy
- X-Frame-Options
- Cache-Control
- Content-Type
- X-XSS-Protection
- X-Content-Type-Options