### PR TITLE
docs(setup): Add Link to SignIn secrets in setup readme

### DIFF
--- a/src/Dfe.PlanTech.Web/README.md
+++ b/src/Dfe.PlanTech.Web/README.md
@@ -8,6 +8,7 @@ Uses ASP .NET Core MVC.
 
 ## Setup
 
+- Setup your SignIn secrets, using the instructions in the [Dfe.PlanTech.Infrastructure.SignIn](../Dfe.PlanTech.Infrastructure.SignIn/README.md) project
 - Setup your Contentful secrets, using the instructions in the [Dfe.PlanTech.Infrastructure.Contentful](../Dfe.PlanTech.Infrastructure.Contentful/README.md) project
 
 ## Project References


### PR DESCRIPTION
Add a link to the sign in secrets to ensure this isn't missed during setup