### PR TITLE
fix: Disable dynamic page validator tests

### DIFF
--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/dynamic-page-validator.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/dynamic-page-validator.cy.js
@@ -1,10 +1,14 @@
-import ContentfulData from "../helpers/contentful-data-loader";
 import ValidatePage from "../helpers/content-validators/page-validator";
 import { selfAssessmentSlug } from "../helpers/page-slugs";
 import ValidateContent from "../helpers/content-validators/content-validator";
 
 describe("Pages should have content", () => {
+  const ContentfulData = null;
   it("Should render navigation links", () => {
+    if (!ContentfulData) {
+      return;
+    }
+
     const navigationLinks = ContentfulData.contents["navigationLink"];
     if (!dataLoaded(navigationLinks)) {
       return;
@@ -18,7 +22,7 @@ describe("Pages should have content", () => {
   });
 
   it("Should validate self-assessment page", () => {
-    if (!dataLoaded(ContentfulData.pages)) {
+    if (!ContentfulData || !dataLoaded(ContentfulData.pages)) {
       return;
     }
 

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/helpers/contentful-data-loader.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/helpers/contentful-data-loader.js
@@ -2,6 +2,12 @@ import { contentful } from "./contentful";
 import { DataMapper } from "export-processor";
 
 const getContentfulData = () => {
+  if (!contentful ||
+    !contentful.contentTypes || contentful.contentTypes.length == 0 ||
+    !contentful.entries || contentful.entries.length == 0) {
+    return;
+  }
+
   return new DataMapper(contentful);
 };
 


### PR DESCRIPTION
Disables the above tests even earlier, speeding up the process. 

They aren't running in CI/CD pipelines anyway as:

1. They need updating
2. The data export is a manual process
