### PR TITLE
fix(e2e): :adhesive_bandage: Add videos on E2E failures again

### DIFF
--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -38,6 +38,7 @@ runs:
       with:
         name: cypress-screenshots
         path: ./tests/Dfe.PlanTech.Web.E2ETests/cypress/screenshots
+        if-no-files-found: ignore
 
     - name: Store videos
       uses: actions/upload-artifact@v4
@@ -45,3 +46,4 @@ runs:
       with:
         name: cypress-videos
         path: ./tests/Dfe.PlanTech.Web.E2ETests/cypress/videos
+        if-no-files-found: ignore

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress.config.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress.config.js
@@ -15,6 +15,7 @@ Object.assign(webpackOptions.webpackOptions, {
 
 module.exports = defineConfig({
   chromeWebSecurity: false,
+  video: true,
   reporter: "cypress-multi-reporters",
   reporterOptions: {
     "configFile": "reporter-config.json"
@@ -23,7 +24,7 @@ module.exports = defineConfig({
     runMode: 1
   },
   e2e: {
-    setupNodeEvents(on, config) {
+    setupNodeEvents(on, _) {
       on('task', {
         log(message) {
           console.log(message)


### PR DESCRIPTION
## Fixes

1. Add videos back in Cypress E2E tests on failure again. [^1]

2. Ignore "missing" videos/screenshots in E2E tests [^2]


[^1]: This was disabled by default in Cypress 13, meaning when we updated the packages recently they stopped being produced. This can make debugging more difficult and/or time consuming.


[^2]: If no screenshots or videos are found for artifact upload, by default it is treated as warning. This change ignores them instead, as we should not have anything on successes.