### PR TITLE
feat(iac): Add scaling options for container app to Terraform

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -44,6 +44,10 @@ env:
   TF_VAR_registry_username: ${{ github.repository_owner }}
   TF_VAR_registry_password: ${{ secrets.GITHUB_TOKEN }}
 
+  container_app_min_replicas: ${{secrets.CONTAINER_MIN_REPLICAS}}
+  container_app_max_replicas: ${{secrets.CONTAINER_MAX_REPLICAS}}
+  container_app_http_concurrency: ${{secrets.CONTAINER_HTTP_CONCURRENCY}}
+
   TF_WORKING_DIRECTORY: terraform/container-app
 
 jobs:
@@ -67,11 +71,6 @@ jobs:
         id: whats-my-ip
         uses: ./.github/actions/whats-my-ip-address
 
-      - name: Set GitHub Runner IP to TF Var
-        shell: bash
-        run: |
-          echo "TF_VAR_github_ip=${{ steps.whats-my-ip.outputs.ip}}" >> $GITHUB_ENV
-
       - name: Login with AZ
         uses: ./.github/actions/azure-login
         with:
@@ -86,6 +85,21 @@ jobs:
           azcliversion: 2.45.0
           inlineScript: |
             az keyvault network-rule add --name ${{ env.AZ_KEYVAULT_NAME }} --ip-address ${{ steps.whats-my-ip.outputs.ip }} &> /dev/null
+
+      - name: Set container app scaling env variables
+        run: |
+          declare -a env_vars=(
+            "container_app_min_replicas"
+            "container_app_max_replicas"
+            "container_app_http_concurrency"
+          )
+
+          for var in "${env_vars[@]}"; do
+            env_value="${!var}"
+            if [ -n "$env_value" ]; then
+              echo "TF_VAR_$var=$env_value" >> $GITHUB_ENV
+            fi
+          done
 
       - name: Terraform init
         id: init

--- a/terraform/container-app/locals.tf
+++ b/terraform/container-app/locals.tf
@@ -21,10 +21,13 @@ locals {
   #################
   # Container App #
   #################
-  container_app_image_name = "plan-tech-app"
-  kestrel_endpoint         = var.az_app_kestrel_endpoint
-  container_port           = var.az_container_port
-  image_tag                = var.image_tag
+  container_app_image_name       = "plan-tech-app"
+  kestrel_endpoint               = var.az_app_kestrel_endpoint
+  container_port                 = var.az_container_port
+  image_tag                      = var.image_tag
+  container_app_min_replicas     = var.container_app_min_replicas
+  container_app_max_replicas     = var.container_app_max_replicas
+  container_app_http_concurrency = var.container_app_http_concurrency
 
   ####################
   # Managed Identity #

--- a/terraform/container-app/main-hosting.tf
+++ b/terraform/container-app/main-hosting.tf
@@ -30,6 +30,10 @@ module "main_hosting" {
     identity_ids = [azurerm_user_assigned_identity.user_assigned_identity.id]
   }
 
+  container_max_replicas           = local.container_app_max_replicas
+  container_min_replicas           = local.container_app_min_replicas
+  container_scale_http_concurrency = local.container_app_http_concurrency
+
   #############
   # Azure SQL #
   #############

--- a/terraform/container-app/terraform-configuration.md
+++ b/terraform/container-app/terraform-configuration.md
@@ -38,7 +38,7 @@ We use two external modules to create the majority of the resources required:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.103.1 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.105.0 |
 
 ## Modules
 
@@ -66,7 +66,6 @@ We use two external modules to create the majority of the resources required:
 | [azurerm_key_vault_secret.vault_secret_contentful_spaceid](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.vault_secret_database_connectionstring](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_linux_function_app.contentful_function](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_function_app) | resource |
-| [azurerm_role_assignment.uami_storage_data_owner_role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_service_plan.function_plan](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/service_plan) | resource |
 | [azurerm_servicebus_namespace.service_bus](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/servicebus_namespace) | resource |
 | [azurerm_servicebus_queue.contentful_queue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/servicebus_queue) | resource |
@@ -91,6 +90,9 @@ We use two external modules to create the majority of the resources required:
 | <a name="input_azure_location"></a> [azure\_location](#input\_azure\_location) | Recourse location | `string` | n/a | yes |
 | <a name="input_cdn_create_custom_domain"></a> [cdn\_create\_custom\_domain](#input\_cdn\_create\_custom\_domain) | A flag to create the A and TXT records for the container app as part of setting up the cdn | `bool` | `false` | no |
 | <a name="input_container_app_blob_storage_public_access_enabled"></a> [container\_app\_blob\_storage\_public\_access\_enabled](#input\_container\_app\_blob\_storage\_public\_access\_enabled) | Enable app blob storage public access | `bool` | `false` | no |
+| <a name="input_container_app_http_concurrency"></a> [container\_app\_http\_concurrency](#input\_container\_app\_http\_concurrency) | Scale up at this number of HTTP requests | `number` | `10` | no |
+| <a name="input_container_app_max_replicas"></a> [container\_app\_max\_replicas](#input\_container\_app\_max\_replicas) | Maximum replicas for the container app | `number` | `2` | no |
+| <a name="input_container_app_min_replicas"></a> [container\_app\_min\_replicas](#input\_container\_app\_min\_replicas) | Minimum replicas for the container app | `number` | `1` | no |
 | <a name="input_container_app_storage_account_shared_access_key_enabled"></a> [container\_app\_storage\_account\_shared\_access\_key\_enabled](#input\_container\_app\_storage\_account\_shared\_access\_key\_enabled) | Enable shared access key | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name, used along with `project_name` as a prefix for all resources | `string` | n/a | yes |
 | <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Image tag | `string` | n/a | yes |

--- a/terraform/container-app/user-assigned-identity.tf
+++ b/terraform/container-app/user-assigned-identity.tf
@@ -3,9 +3,3 @@ resource "azurerm_user_assigned_identity" "user_assigned_identity" {
   location            = local.azure_location
   resource_group_name = module.main_hosting.azurerm_resource_group_default.name
 }
-
-resource "azurerm_role_assignment" "uami_storage_data_owner_role" {
-  scope                = azurerm_storage_account.function_storage.id
-  role_definition_name = "Storage Blob Data Owner"
-  principal_id         = azurerm_user_assigned_identity.user_assigned_identity.principal_id
-}

--- a/terraform/container-app/variables.tf
+++ b/terraform/container-app/variables.tf
@@ -93,6 +93,24 @@ variable "az_container_port" {
   default     = 8080
 }
 
+variable "container_app_min_replicas" {
+  description = "Minimum replicas for the container app"
+  type        = number
+  default     = 1
+}
+
+variable "container_app_max_replicas" {
+  description = "Maximum replicas for the container app"
+  type        = number
+  default     = 2
+}
+
+variable "container_app_http_concurrency" {
+  description = "Scale up at this number of HTTP requests"
+  type        = number
+  default     = 10
+}
+
 
 ##################
 # CDN/Front Door #


### PR DESCRIPTION
## Features

- Adds variable options to Terraform for scaling the container app
  - Minimum replicas
  - Maximum replicas
  - HTTP Concurrency

- Updates CI/CD pipeline to add new variables if existing as secrets.

## Chore

- Removes an unused MI that was accidentally added in with the recent update Terraform PR