### PR TITLE
fix(tf): Set storage access key + SQL SKU

### DIFF
--- a/terraform/container-app/functions.tf
+++ b/terraform/container-app/functions.tf
@@ -33,8 +33,10 @@ resource "azurerm_linux_function_app" "contentful_function" {
 
   service_plan_id = azurerm_service_plan.function_plan.id
 
-  storage_account_name          = azurerm_storage_account.function_storage.name
-  storage_uses_managed_identity = true
+  storage_account_name = azurerm_storage_account.function_storage.name
+
+  storage_account_access_key    = local.container_app_storage_account_shared_access_key_enabled ? azurerm_storage_account.function_storage.primary_access_key : null
+  storage_uses_managed_identity = local.container_app_storage_account_shared_access_key_enabled ? null : true
 
   key_vault_reference_identity_id = azurerm_user_assigned_identity.user_assigned_identity.id
 

--- a/terraform/container-app/main-hosting.tf
+++ b/terraform/container-app/main-hosting.tf
@@ -45,6 +45,7 @@ module "main_hosting" {
   mssql_azuread_admin_object_id      = local.az_sql_azuread_admin_objectid
   mssql_azuread_auth_only            = local.az_use_azure_ad_auth_only
   mssql_managed_identity_assign_role = false
+  mssql_sku_name                     = local.az_sql_sku
 
   ##############
   # Networking #


### PR DESCRIPTION
## Fixes

- Sets `storage_account_access_key` setting in the Azure Function App if `local.container_app_storage_account_shared_access_key_enabled` is enabled.
- Actually use the MSSQL SKU from previous PR