### PR TITLE
Feat: Show latest recommendation for restarted topics

### DIFF
--- a/src/Dfe.PlanTech.Application/Submissions/Queries/GetSubmissionStatusesQuery.cs
+++ b/src/Dfe.PlanTech.Application/Submissions/Queries/GetSubmissionStatusesQuery.cs
@@ -52,7 +52,7 @@ public class GetSubmissionStatusesQuery : IGetSubmissionStatusesQuery
     /// For each submission, convert to SectionStatus, 
     /// group by Section, 
     /// then return latest for each grouping
-    /// optionally choosing from only complete ones
+    /// optionally choosing from completed submissions first
     /// </summary>
     /// <param name="submissionStatuses"></param>
     /// <param name="completed"></param>
@@ -66,7 +66,9 @@ public class GetSubmissionStatusesQuery : IGetSubmissionStatusesQuery
         SectionId = submission.SectionId,
         Status = submission.Completed ? Status.Completed : submission.Responses.Count != 0 ? Status.InProgress : Status.NotStarted,
     })
-    .Where(submission => !completed || submission.Completed)
     .GroupBy(submission => submission.SectionId)
-    .Select(grouping => grouping.OrderByDescending(status => status.DateCreated).First());
+    .Select(grouping => grouping
+        .OrderByDescending(status => completed && status.Completed)
+        .ThenByDescending(status => status.DateCreated)
+        .First());
 }

--- a/src/Dfe.PlanTech.Application/Submissions/Queries/SubmissionStatusProcessor.cs
+++ b/src/Dfe.PlanTech.Application/Submissions/Queries/SubmissionStatusProcessor.cs
@@ -47,14 +47,25 @@ public class SubmissionStatusProcessor : ISubmissionStatusProcessor
         User = user;
     }
 
+    public async Task GetJourneyStatusForSection(string sectionSlug, CancellationToken cancellationToken)
+    {
+        await GetJourneyStatus(sectionSlug, false, cancellationToken);
+    }
+
+    public async Task GetJourneyStatusForSectionRecommendation(string sectionSlug, CancellationToken cancellationToken)
+    {
+        await GetJourneyStatus(sectionSlug, true, cancellationToken);
+    }
+
     /// <summary>
-    /// Get's the current status for the current user's establishment and the given section
+    /// Get's the current status or most recently completed status for the current user's establishment and the given section
     /// </summary>
     /// <param name="sectionSlug"></param>
+    /// <param name="complete"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     /// <exception cref="ContentfulDataUnavailableException"></exception>
-    public async Task GetJourneyStatusForSection(string sectionSlug, CancellationToken cancellationToken)
+    private async Task GetJourneyStatus(string sectionSlug, bool complete, CancellationToken cancellationToken)
     {
         var establishmentId = await User.GetEstablishmentId();
 
@@ -63,6 +74,7 @@ public class SubmissionStatusProcessor : ISubmissionStatusProcessor
 
         SectionStatus = await _getSubmissionStatusesQuery.GetSectionSubmissionStatusAsync(establishmentId,
                                                                                           Section,
+                                                                                          complete,
                                                                                           cancellationToken);
 
         var matchingStatusChecker = _statusCheckers.FirstOrDefault(statusChecker => statusChecker.IsMatchingSubmissionStatus(this)) ??

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240605_1030_UpdateGetSectionStatusesSproc.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240605_1030_UpdateGetSectionStatusesSproc.sql
@@ -1,0 +1,38 @@
+﻿ALTER PROCEDURE GetSectionStatuses
+    @splitStringVal NVARCHAR(255),
+    @establishmentId INT
+AS
+
+SELECT value AS sectionId
+INTO #SectionIds
+FROM STRING_SPLIT(@splitStringVal, ',')
+
+SELECT
+    CurrentSubmission.sectionId,
+    CAST(CurrentSubmission.completed AS INT) completed,
+    LastCompleteSubmission.maturity,
+    CurrentSubmission.dateCreated
+From #SectionIds Ids
+-- The current submission
+CROSS APPLY (
+    SELECT TOP 1 sectionId, completed, dateCreated
+    FROM [dbo].submission S
+    WHERE
+        Ids.sectionId = S.sectionId
+    AND S.establishmentId = @establishmentId
+    AND S.deleted = 0
+    ORDER BY
+        S.dateCreated DESC
+) CurrentSubmission
+-- Use maturity from most recent complete submission (if there is one) so that user always sees recommendation
+OUTER APPLY (
+    SELECT TOP 1 sectionId, completed, maturity, dateCreated
+    FROM [dbo].submission S
+    WHERE
+        Ids.sectionId = S.sectionId
+      AND S.establishmentId = @establishmentId
+      AND S.deleted = 0
+      AND s.completed = 1
+    ORDER BY
+        S.dateCreated DESC
+) LastCompleteSubmission

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240605_1030_UpdateGetSectionStatusesSproc.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240605_1030_UpdateGetSectionStatusesSproc.sql
@@ -10,7 +10,7 @@ FROM STRING_SPLIT(@splitStringVal, ',')
 SELECT
     CurrentSubmission.sectionId,
     CAST(CurrentSubmission.completed AS INT) completed,
-    LastCompleteSubmission.maturity,
+    LastCompleteSubmission.maturity as lastMaturity,
     CurrentSubmission.dateCreated
 From #SectionIds Ids
 -- The current submission

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240605_1030_UpdateGetSectionStatusesSproc.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240605_1030_UpdateGetSectionStatusesSproc.sql
@@ -26,13 +26,13 @@ CROSS APPLY (
 ) CurrentSubmission
 -- Use maturity from most recent complete submission (if there is one) so that user always sees recommendation
 OUTER APPLY (
-    SELECT TOP 1 sectionId, completed, maturity, dateCreated
+    SELECT TOP 1 maturity
     FROM [dbo].submission S
     WHERE
         Ids.sectionId = S.sectionId
-      AND S.establishmentId = @establishmentId
-      AND S.deleted = 0
-      AND s.completed = 1
+    AND S.establishmentId = @establishmentId
+    AND S.deleted = 0
+    AND s.completed = 1
     ORDER BY
         S.dateCreated DESC
 ) LastCompleteSubmission

--- a/src/Dfe.PlanTech.Domain/Interfaces/IGetSubmissionStatusesQuery.cs
+++ b/src/Dfe.PlanTech.Domain/Interfaces/IGetSubmissionStatusesQuery.cs
@@ -9,6 +9,7 @@ public interface IGetSubmissionStatusesQuery
 
     Task<SectionStatusNew> GetSectionSubmissionStatusAsync(int establishmentId,
                                                            ISectionComponent section,
+                                                           bool completed,
                                                            CancellationToken cancellationToken);
 }
 

--- a/src/Dfe.PlanTech.Domain/Submissions/Interfaces/ISubmissionStatusProcessor.cs
+++ b/src/Dfe.PlanTech.Domain/Submissions/Interfaces/ISubmissionStatusProcessor.cs
@@ -21,4 +21,5 @@ public interface ISubmissionStatusProcessor
     public SectionStatusNew? SectionStatus { get; }
 
     Task GetJourneyStatusForSection(string sectionSlug, CancellationToken cancellationToken);
+    Task GetJourneyStatusForSectionRecommendation(string sectionSlug, CancellationToken cancellationToken);
 }

--- a/src/Dfe.PlanTech.Domain/Submissions/Models/SectionStatus.cs
+++ b/src/Dfe.PlanTech.Domain/Submissions/Models/SectionStatus.cs
@@ -8,7 +8,7 @@ public class SectionStatusDto
 
     public int Completed { get; set; }
 
-    public string? Maturity { get; set; }
+    public string? LastMaturity { get; set; }
 
     public DateTime DateCreated { get; set; }
 }

--- a/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
@@ -23,7 +23,7 @@ public class GetRecommendationRouter(ISubmissionStatusProcessor router,
         if (string.IsNullOrEmpty(sectionSlug)) throw new ArgumentNullException(nameof(sectionSlug));
         if (string.IsNullOrEmpty(recommendationSlug)) throw new ArgumentNullException(nameof(recommendationSlug));
 
-        await _router.GetJourneyStatusForSection(sectionSlug, cancellationToken);
+        await _router.GetJourneyStatusForSectionRecommendation(sectionSlug, cancellationToken);
         return _router.Status switch
         {
             SubmissionStatus.Completed => await HandleCompleteStatus(controller, cancellationToken),

--- a/src/Dfe.PlanTech.Web/ViewComponents/RecommendationsViewComponent.cs
+++ b/src/Dfe.PlanTech.Web/ViewComponents/RecommendationsViewComponent.cs
@@ -24,12 +24,13 @@ public class RecommendationsViewComponent(
         var recommendationsAvailable = false;
         foreach (var category in categories)
         {
-            if (category.Completed >= 1)
+            var categoryElement = await RetrieveSectionStatuses(category);
+
+            if (category.SectionStatuses.Any(sectionStatus => sectionStatus.Maturity != null))
             {
                 recommendationsAvailable = true;
             }
 
-            var categoryElement = await RetrieveSectionStatuses(category);
             allSectionsOfCombinedCategories.AddRange(categoryElement.Sections);
             allSectionStatusesOfCombinedCategories.AddRange(categoryElement.SectionStatuses);
         }

--- a/src/Dfe.PlanTech.Web/ViewComponents/RecommendationsViewComponent.cs
+++ b/src/Dfe.PlanTech.Web/ViewComponents/RecommendationsViewComponent.cs
@@ -26,7 +26,7 @@ public class RecommendationsViewComponent(
         {
             var categoryElement = await RetrieveSectionStatuses(category);
 
-            if (category.SectionStatuses.Any(sectionStatus => sectionStatus.Maturity != null))
+            if (category.SectionStatuses.Any(sectionStatus => sectionStatus.LastMaturity != null))
             {
                 recommendationsAvailable = true;
             }
@@ -50,7 +50,7 @@ public class RecommendationsViewComponent(
         foreach (var section in sections)
         {
             var sectionMaturity = sectionStatusesList.Where(sectionStatus => sectionStatus.SectionId == section.Sys.Id)
-                                                    .Select(sectionStatus => sectionStatus.Maturity)
+                                                    .Select(sectionStatus => sectionStatus.LastMaturity)
                                                     .FirstOrDefault();
 
             if (string.IsNullOrEmpty(sectionMaturity)) continue;

--- a/src/Dfe.PlanTech.Web/ViewComponents/RecommendationsViewComponent.cs
+++ b/src/Dfe.PlanTech.Web/ViewComponents/RecommendationsViewComponent.cs
@@ -48,7 +48,7 @@ public class RecommendationsViewComponent(
     {
         foreach (var section in sections)
         {
-            var sectionMaturity = sectionStatusesList.Where(sectionStatus => sectionStatus.SectionId == section.Sys.Id && sectionStatus.Completed == 1)
+            var sectionMaturity = sectionStatusesList.Where(sectionStatus => sectionStatus.SectionId == section.Sys.Id)
                                                     .Select(sectionStatus => sectionStatus.Maturity)
                                                     .FirstOrDefault();
 

--- a/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/GetSubmissionStatusesQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/GetSubmissionStatusesQueryTests.cs
@@ -154,7 +154,7 @@ public class GetSubmissionStatusesQueryTests
     [Fact]
     public async Task GetSectionSubmissionStatusAsync_Returns_Status_InProgress_When_Found_Incomplete_With_Responses()
     {
-        var result = await CreateStrut().GetSectionSubmissionStatusAsync(establishmentId, inprogressSection,false, default);
+        var result = await CreateStrut().GetSectionSubmissionStatusAsync(establishmentId, inprogressSection, false, default);
 
         Assert.NotNull(result);
 
@@ -167,7 +167,7 @@ public class GetSubmissionStatusesQueryTests
     [Fact]
     public async Task GetSectionSubmissionStatusAsync_Returns_Status_NotStarted_When_Found_With_No_Responses()
     {
-        var result = await CreateStrut().GetSectionSubmissionStatusAsync(establishmentId, notstartedSection, false,default);
+        var result = await CreateStrut().GetSectionSubmissionStatusAsync(establishmentId, notstartedSection, false, default);
 
         Assert.NotNull(result);
 
@@ -188,7 +188,7 @@ public class GetSubmissionStatusesQueryTests
             }
         };
 
-        var result = await CreateStrut().GetSectionSubmissionStatusAsync(establishmentId, section, false,default);
+        var result = await CreateStrut().GetSectionSubmissionStatusAsync(establishmentId, section, false, default);
 
         Assert.NotNull(result);
 

--- a/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/GetSubmissionStatusesQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/GetSubmissionStatusesQueryTests.cs
@@ -16,7 +16,7 @@ public class GetSubmissionStatusesQueryTests
     private readonly IUser user = Substitute.For<IUser>();
 
     private readonly List<SectionStatusDto> SectionStatuses = [
-            new SectionStatusDto { Completed = 1, SectionId = "1", Maturity = "Low", DateCreated = DateTime.UtcNow },
+        new SectionStatusDto { Completed = 1, SectionId = "1", Maturity = "Low", DateCreated = DateTime.UtcNow },
         new SectionStatusDto { Completed = 1, SectionId = "2", Maturity = "High", DateCreated = DateTime.UtcNow },
         new SectionStatusDto { Completed = 0, SectionId = "3", DateCreated = DateTime.UtcNow },
         new SectionStatusDto { Completed = 0, SectionId = "4", DateCreated = DateTime.UtcNow },
@@ -141,7 +141,7 @@ public class GetSubmissionStatusesQueryTests
     [Fact]
     public async Task GetSectionSubmissionStatusAsync_Returns_Status_Completed_When_Found_With_Responses()
     {
-        var result = await CreateStrut().GetSectionSubmissionStatusAsync(establishmentId, completeSection, default);
+        var result = await CreateStrut().GetSectionSubmissionStatusAsync(establishmentId, completeSection, false, default);
 
         Assert.NotNull(result);
 
@@ -154,7 +154,7 @@ public class GetSubmissionStatusesQueryTests
     [Fact]
     public async Task GetSectionSubmissionStatusAsync_Returns_Status_InProgress_When_Found_Incomplete_With_Responses()
     {
-        var result = await CreateStrut().GetSectionSubmissionStatusAsync(establishmentId, inprogressSection, default);
+        var result = await CreateStrut().GetSectionSubmissionStatusAsync(establishmentId, inprogressSection,false, default);
 
         Assert.NotNull(result);
 
@@ -167,7 +167,7 @@ public class GetSubmissionStatusesQueryTests
     [Fact]
     public async Task GetSectionSubmissionStatusAsync_Returns_Status_NotStarted_When_Found_With_No_Responses()
     {
-        var result = await CreateStrut().GetSectionSubmissionStatusAsync(establishmentId, notstartedSection, default);
+        var result = await CreateStrut().GetSectionSubmissionStatusAsync(establishmentId, notstartedSection, false,default);
 
         Assert.NotNull(result);
 
@@ -188,7 +188,7 @@ public class GetSubmissionStatusesQueryTests
             }
         };
 
-        var result = await CreateStrut().GetSectionSubmissionStatusAsync(establishmentId, section, default);
+        var result = await CreateStrut().GetSectionSubmissionStatusAsync(establishmentId, section, false,default);
 
         Assert.NotNull(result);
 

--- a/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/GetSubmissionStatusesQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/GetSubmissionStatusesQueryTests.cs
@@ -16,8 +16,8 @@ public class GetSubmissionStatusesQueryTests
     private readonly IUser user = Substitute.For<IUser>();
 
     private readonly List<SectionStatusDto> SectionStatuses = [
-        new SectionStatusDto { Completed = 1, SectionId = "1", Maturity = "Low", DateCreated = DateTime.UtcNow },
-        new SectionStatusDto { Completed = 1, SectionId = "2", Maturity = "High", DateCreated = DateTime.UtcNow },
+        new SectionStatusDto { Completed = 1, SectionId = "1", LastMaturity = "Low", DateCreated = DateTime.UtcNow },
+        new SectionStatusDto { Completed = 1, SectionId = "2", LastMaturity = "High", DateCreated = DateTime.UtcNow },
         new SectionStatusDto { Completed = 0, SectionId = "3", DateCreated = DateTime.UtcNow },
         new SectionStatusDto { Completed = 0, SectionId = "4", DateCreated = DateTime.UtcNow },
     ];

--- a/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/SubmissionStatusProcessorTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/SubmissionStatusProcessorTests.cs
@@ -77,7 +77,7 @@ public class SubmissionStatusProcessorTests
                                                                              _getResponsesQuery,
                                                                              _user);
 
-        _getSubmissionStatusesQuery.GetSectionSubmissionStatusAsync(Arg.Any<int>(), Arg.Any<Section>(), Arg.Any<CancellationToken>())
+        _getSubmissionStatusesQuery.GetSectionSubmissionStatusAsync(Arg.Any<int>(), Arg.Any<Section>(), Arg.Any<bool>(),Arg.Any<CancellationToken>())
                                    .Returns(new SectionStatusNew());
 
         await processor.GetJourneyStatusForSection(SectionSlug, default);
@@ -102,7 +102,7 @@ public class SubmissionStatusProcessorTests
                                                                              _getResponsesQuery,
                                                                              _user);
 
-        _getSubmissionStatusesQuery.GetSectionSubmissionStatusAsync(Arg.Any<int>(), Arg.Any<Section>(), Arg.Any<CancellationToken>())
+        _getSubmissionStatusesQuery.GetSectionSubmissionStatusAsync(Arg.Any<int>(), Arg.Any<Section>(),Arg.Any<bool>(), Arg.Any<CancellationToken>())
                                    .Returns(new SectionStatusNew());
 
         await Assert.ThrowsAnyAsync<InvalidDataException>(() => processor.GetJourneyStatusForSection(SectionSlug, default));

--- a/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/SubmissionStatusProcessorTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/SubmissionStatusProcessorTests.cs
@@ -77,7 +77,7 @@ public class SubmissionStatusProcessorTests
                                                                              _getResponsesQuery,
                                                                              _user);
 
-        _getSubmissionStatusesQuery.GetSectionSubmissionStatusAsync(Arg.Any<int>(), Arg.Any<Section>(), Arg.Any<bool>(),Arg.Any<CancellationToken>())
+        _getSubmissionStatusesQuery.GetSectionSubmissionStatusAsync(Arg.Any<int>(), Arg.Any<Section>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
                                    .Returns(new SectionStatusNew());
 
         await processor.GetJourneyStatusForSection(SectionSlug, default);
@@ -102,7 +102,7 @@ public class SubmissionStatusProcessorTests
                                                                              _getResponsesQuery,
                                                                              _user);
 
-        _getSubmissionStatusesQuery.GetSectionSubmissionStatusAsync(Arg.Any<int>(), Arg.Any<Section>(),Arg.Any<bool>(), Arg.Any<CancellationToken>())
+        _getSubmissionStatusesQuery.GetSectionSubmissionStatusAsync(Arg.Any<int>(), Arg.Any<Section>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
                                    .Returns(new SectionStatusNew());
 
         await Assert.ThrowsAnyAsync<InvalidDataException>(() => processor.GetJourneyStatusForSection(SectionSlug, default));

--- a/tests/Dfe.PlanTech.Web.UnitTests/Routing/GetRecommendationRouterTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Routing/GetRecommendationRouterTests.cs
@@ -158,7 +158,7 @@ public class GetRecommendationRouterTests
     public async Task Should_Redirect_To_CheckAnswersPage_When_Status_CheckAnswers()
     {
         _submissionStatusProcessor.When(processor =>
-                processor.GetJourneyStatusForSection(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>()))
+                processor.GetJourneyStatusForSectionRecommendation(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>()))
             .Do((callinfo) => { _submissionStatusProcessor.Status = SubmissionStatus.CheckAnswers; });
 
         var result = await _router.ValidateRoute(_section.InterstitialPage.Slug, "recommendation-slug", _controller,
@@ -186,7 +186,7 @@ public class GetRecommendationRouterTests
         };
 
         _submissionStatusProcessor.When(processor =>
-                processor.GetJourneyStatusForSection(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>()))
+                processor.GetJourneyStatusForSectionRecommendation(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>()))
             .Do((callinfo) =>
             {
                 _submissionStatusProcessor.Status = SubmissionStatus.NextQuestion;
@@ -223,7 +223,7 @@ public class GetRecommendationRouterTests
         };
 
         _submissionStatusProcessor.When(processor =>
-                processor.GetJourneyStatusForSection(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>()))
+                processor.GetJourneyStatusForSectionRecommendation(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>()))
             .Do((callinfo) =>
             {
                 _submissionStatusProcessor.Status = SubmissionStatus.NotStarted;
@@ -249,7 +249,7 @@ public class GetRecommendationRouterTests
     public async Task Should_Throw_Exception_When_Maturity_Null()
     {
         _submissionStatusProcessor.When(processor =>
-                processor.GetJourneyStatusForSection(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>()))
+                processor.GetJourneyStatusForSectionRecommendation(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>()))
             .Do((callinfo) =>
             {
                 _submissionStatusProcessor.Status = SubmissionStatus.Completed;
@@ -267,7 +267,7 @@ public class GetRecommendationRouterTests
     public async Task Should_Throw_Exception_When_Recommendation_Not_In_Section()
     {
         _submissionStatusProcessor.When(processor =>
-                processor.GetJourneyStatusForSection(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>()))
+                processor.GetJourneyStatusForSectionRecommendation(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>()))
             .Do((callinfo) =>
             {
                 _submissionStatusProcessor.Status = SubmissionStatus.Completed;
@@ -297,7 +297,7 @@ public class GetRecommendationRouterTests
     public async Task Should_Throw_Exception_When_NotFind_Recommendation_For_Maturity()
     {
         _submissionStatusProcessor.When(processor =>
-                processor.GetJourneyStatusForSection(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>()))
+                processor.GetJourneyStatusForSectionRecommendation(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>()))
             .Do((callinfo) =>
             {
                 _submissionStatusProcessor.Status = SubmissionStatus.Completed;
@@ -331,7 +331,7 @@ public class GetRecommendationRouterTests
     public async Task Should_Show_RecommendationPage_When_Status_Is_Recommendation_And_All_Valid()
     {
         _submissionStatusProcessor.When(processor =>
-                processor.GetJourneyStatusForSection(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>()))
+                processor.GetJourneyStatusForSectionRecommendation(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>()))
             .Do((callinfo) =>
             {
                 _submissionStatusProcessor.Status = SubmissionStatus.Completed;

--- a/tests/Dfe.PlanTech.Web.UnitTests/ViewComponents/RecommendationsViewComponentTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/ViewComponents/RecommendationsViewComponentTests.cs
@@ -229,7 +229,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
             {
                 SectionId = "Section1",
                 Completed = 1,
-                Maturity = "High"
+                LastMaturity = "High"
             });
 
             Category[] categories = [_category];
@@ -270,13 +270,13 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
             {
                 SectionId = "Section1",
                 Completed = 1,
-                Maturity = "High"
+                LastMaturity = "High"
             });
             _categoryTwo.SectionStatuses.Add(new Domain.Submissions.Models.SectionStatusDto()
             {
                 SectionId = "Section2",
                 Completed = 1,
-                Maturity = "High"
+                LastMaturity = "High"
             });
 
             Category[] categories = [_category, _categoryTwo];
@@ -320,7 +320,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
             {
                 SectionId = "Section1",
                 Completed = 1,
-                Maturity = "High"
+                LastMaturity = "High"
             });
 
             Category[] categories = [_category];
@@ -361,7 +361,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
             {
                 SectionId = "Section1",
                 Completed = 1,
-                Maturity = "Low",
+                LastMaturity = "Low",
             });
 
             Category[] categories = new Category[] { _category };
@@ -400,7 +400,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
             {
                 SectionId = "Section1",
                 Completed = 0,
-                Maturity = null
+                LastMaturity = null
             });
 
             Category[] categories = [_category];
@@ -423,7 +423,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
             {
                 SectionId = "Section1",
                 Completed = 0,
-                Maturity = Maturity.High.ToString(),
+                LastMaturity = Maturity.High.ToString(),
                 DateCreated = DateTime.Now
             });
 

--- a/tests/Dfe.PlanTech.Web.UnitTests/ViewComponents/RecommendationsViewComponentTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/ViewComponents/RecommendationsViewComponentTests.cs
@@ -393,7 +393,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
         }
 
         [Fact]
-        public async Task DoesNotReturn_RecommendationInfo_If_Section_IsNot_Completed()
+        public async Task DoesNotReturn_RecommendationInfo_If_Section_IsNot_Started()
         {
             _category.Completed = 0;
             _category.SectionStatuses.Add(new Domain.Submissions.Models.SectionStatusDto()
@@ -414,6 +414,47 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
 
             var model = result.ViewData.Model;
             Assert.Null(model);
+        }
+
+        [Fact]
+        public async Task Returns_RecommendationInfo_If_Incomplete_Section_Is_Previously_Completed()
+        {
+            _category.SectionStatuses.Add(new Domain.Submissions.Models.SectionStatusDto()
+            {
+                SectionId = "Section1",
+                Completed = 0,
+                Maturity = Maturity.High.ToString(),
+                DateCreated = DateTime.Now
+            });
+
+            Category[] categories = [_category];
+
+            _getSubTopicRecommendationQuery.GetSubTopicRecommendation(Arg.Any<string>()).Returns(_subtopic);
+
+            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sections).Returns(_category.SectionStatuses.ToList());
+
+            var result = await _recommendationsComponent.InvokeAsync(categories) as ViewViewComponentResult;
+
+            Assert.NotNull(result);
+            Assert.NotNull(result.ViewData);
+
+            var model = result.ViewData.Model;
+            Assert.NotNull(model);
+
+            var unboxed = model as IAsyncEnumerable<RecommendationsViewComponentViewModel>;
+            Assert.NotNull(unboxed);
+
+            var list = new List<RecommendationsViewComponentViewModel>();
+            await foreach (var item in unboxed)
+            {
+                list.Add(item);
+            }
+
+            Assert.NotEmpty(list);
+            Assert.NotNull(_subtopic);
+            Assert.Equal(_subtopic.Intros[0].Slug, list.First().RecommendationSlug);
+            Assert.Equal(_subtopic.Intros[0].Header.Text, list.First().RecommendationDisplayName);
+            Assert.Null(list.First().NoRecommendationFoundErrorMessage);
         }
 
         [Fact]


### PR DESCRIPTION
## Description

This PR changes the self-assessment page to always show the most recent recommendation rather than it disappearing if a user restarts a topic and leaves it incomplete

This is done by changing the `GetSectionStatuses` SP to use the maturity from the most recent _complete_ submission, but leaving the completed state as is so the tag shown is correct

implemented by commit 1

### Note

This alone doesn't work as if you click on the recommendation link, the journey status processing is shared by Question answers/ Validation of recommendation route. So it just takes you to the incomplete topic

To workaround this a complete flag has been added to the functions that fetch the current status, to allow limiting to complete ones, and using this flag in the context of recommendations

implemented by commit 2