### PR TITLE
Fix: Remove redundant button

### DIFF
--- a/src/Dfe.PlanTech.Web/Views/Shared/_Header.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/_Header.cshtml
@@ -21,9 +21,6 @@
             }
         }
       </ul>
-      <div class="dfe-header__menu">
-        <button class="dfe-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-expanded="false">Menu</button>
-      </div>
     </div>
   </div>
 </header>


### PR DESCRIPTION
**Description**
Removing this button, as it shows up on smaller screens but does nothing, which is likely to be confusing. 