### PR TITLE
fix: Contentful Functions Querying

### DIFF
--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/QuestionMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/QuestionMapper.cs
@@ -38,6 +38,8 @@ public class QuestionMapper(EntityRetriever retriever, EntityUpdater updater, Cm
         var incomingEntity = ToEntity(payload);
 
         var existingEntity = await _db.Questions.Include(q => q.Answers)
+                                                .IgnoreQueryFilters()
+                                                .IgnoreAutoIncludes()
                                                 .FirstOrDefaultAsync(question => question.Id == incomingEntity.Id, cancellationToken: cancellationToken);
 
         var mappedEntity = _entityUpdater.UpdateEntity(incomingEntity, existingEntity, cmsEvent);
@@ -48,7 +50,7 @@ public class QuestionMapper(EntityRetriever retriever, EntityUpdater updater, Cm
         }
 
         var withoutOldQuestions = RemoveQuestionFromRemovedAnswers(mappedEntity);
-        await AddOrUpdateQuestions(existingEntity);
+        await AddOrUpdateQuestions(existingEntity!);
 
         return mappedEntity;
     }

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/SectionMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/SectionMapper.cs
@@ -26,16 +26,17 @@ public class SectionMapper(EntityRetriever retriever, EntityUpdater updater, Cms
         }
 
         values.Remove("recommendations");
-        
+
         return values;
     }
-
 
     public override async Task<MappedEntity> MapEntity(CmsWebHookPayload payload, CmsEvent cmsEvent, CancellationToken cancellationToken)
     {
         var incomingEntity = ToEntity(payload);
 
         var existingEntity = await _db.Sections.Include(q => q.Questions)
+                                                .IgnoreQueryFilters()
+                                                .IgnoreAutoIncludes()
                                                 .FirstOrDefaultAsync(section => section.Id == incomingEntity.Id, cancellationToken: cancellationToken);
 
         var mappedEntity = _entityUpdater.UpdateEntity(incomingEntity, existingEntity, cmsEvent);

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/SectionMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/SectionMapper.cs
@@ -25,6 +25,8 @@ public class SectionMapper(EntityRetriever retriever, EntityUpdater updater, Cms
             _incomingQuestions.Add(question);
         }
 
+        values.Remove("recommendations");
+        
         return values;
     }
 
@@ -50,7 +52,6 @@ public class SectionMapper(EntityRetriever retriever, EntityUpdater updater, Cms
             Logger.LogError("Section is not a section. Is type " + mappedEntity.ExistingEntity?.GetType());
             return mappedEntity;
         }
-
 
         await AddOrUpdateQuestions(existingSection);
 


### PR DESCRIPTION
## Fixes

1. Ignore `recommendations` field in `section`s
2. When querying for `section`s or `question`s from DB, ignore query filters and auto includes [^1]


[^1]: We have a query filter that excludes unpublished content. By not ignoring it, unpublished content was missed, and therefore was not updated/was trying to be re-added incorrectly.

Auto includes is just unnecessary for what is necessary.