### PR TITLE
Fix page mapping and logs

### DIFF
--- a/src/Dfe.PlanTech.Application/Mappings/MappingProfile.cs
+++ b/src/Dfe.PlanTech.Application/Mappings/MappingProfile.cs
@@ -11,7 +11,6 @@ public class CmsMappingProfile : Profile
 {
     public CmsMappingProfile()
     {
-        CreateMap<PageDbEntity, Page>();
 
         CreateMap<ContentComponentDbEntity, ContentComponent>()
         .Include<AnswerDbEntity, Answer>()
@@ -21,6 +20,7 @@ public class CmsMappingProfile : Profile
         .Include<CategoryDbEntity, Category>()
         .Include<HeaderDbEntity, Header>()
         .Include<InsetTextDbEntity, InsetText>()
+        .Include<PageDbEntity, Page>()
         .Include<QuestionDbEntity, Question>()
         .Include<RecommendationChunkDbEntity, RecommendationChunk>()
         .Include<RecommendationIntroDbEntity, RecommendationIntro>()
@@ -42,6 +42,7 @@ public class CmsMappingProfile : Profile
         CreateMap<CategoryDbEntity, Category>();
         CreateMap<HeaderDbEntity, Header>();
         CreateMap<InsetTextDbEntity, InsetText>();
+        CreateMap<PageDbEntity, Page>();
         CreateMap<QuestionDbEntity, Question>();
         CreateMap<RecommendationChunkDbEntity, RecommendationChunk>();
         CreateMap<RecommendationIntroDbEntity, RecommendationIntro>();

--- a/src/Dfe.PlanTech.Web/Controllers/QuestionsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/QuestionsController.cs
@@ -13,7 +13,6 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Dfe.PlanTech.Web.Controllers;
 
-[LogInvalidModelState]
 [Authorize]
 [Route("/")]
 public class QuestionsController : BaseController<QuestionsController>
@@ -35,6 +34,7 @@ public class QuestionsController : BaseController<QuestionsController>
         _user = user;
     }
 
+    [LogInvalidModelState]
     [HttpGet("{sectionSlug}/{questionSlug}")]
     public async Task<IActionResult> GetQuestionBySlug(string sectionSlug,
                                                         string questionSlug,
@@ -48,6 +48,7 @@ public class QuestionsController : BaseController<QuestionsController>
     }
 
 
+    [LogInvalidModelState]
     [HttpGet("{sectionSlug}/next-question")]
     public async Task<IActionResult> GetNextUnansweredQuestion(string sectionSlug,
                                                                 [FromServices] IGetNextUnansweredQuestionQuery getQuestionQuery,

--- a/src/Dfe.PlanTech.Web/Helpers/LogInvalidModelState.cs
+++ b/src/Dfe.PlanTech.Web/Helpers/LogInvalidModelState.cs
@@ -10,8 +10,8 @@ public sealed class LogInvalidModelState : ActionFilterAttribute
         var logger = svc.GetService<ILogger<LogInvalidModelState>>();
         if (!context.ModelState.IsValid)
         {
-            var routeName = context.ActionDescriptor.AttributeRouteInfo?.Name;
-            logger?.LogError("Not able to validate model state for route: {routeName}", routeName);
+            var displayName = context.ActionDescriptor.DisplayName;
+            logger?.LogError("Not able to validate model state for controller method: {displayName}", displayName);
         }
     }
 }

--- a/tests/Dfe.PlanTech.Web.UnitTests/Helpers/LogInvalidModelStateTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Helpers/LogInvalidModelStateTests.cs
@@ -1,0 +1,41 @@
+using Dfe.PlanTech.Web.Helpers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Dfe.PlanTech.Web.UnitTests.Helpers;
+
+public class LogInvalidModelStateTests
+{
+    [Fact]
+    public void Should_Call_Logger_When_Invalid_Model_State()
+    {
+        var logger = Substitute.For<ILogger<LogInvalidModelState>>();
+        var filters = new List<IFilterMetadata>();
+        var actionArguments = new Dictionary<string, object?>();
+        var controller = Substitute.For<Controller>();
+
+        var context = Substitute.For<HttpContext>();
+        context.RequestServices.GetService(typeof(ILogger<LogInvalidModelState>)).Returns(logger);
+
+        var actionContext = new ActionContext
+        {
+            HttpContext = context,
+            RouteData = Substitute.For<RouteData>(),
+            ActionDescriptor = Substitute.For<ActionDescriptor>(),
+        };
+
+        var actionExecutingContext = new ActionExecutingContext(actionContext, filters, actionArguments, controller);
+        actionExecutingContext.ModelState.AddModelError("Property", "Is Missing");
+
+        var filter = new LogInvalidModelState();
+        filter.OnActionExecuting(actionExecutingContext);
+
+        Assert.Single(logger.ReceivedCalls());
+    }
+}


### PR DESCRIPTION
## Changes/Fixes
1. Improve the logging message by displaying whole controller method rather than route name (which is often null)
2. Fix the mapping of PageDbEntity -> Page so that the logging stops happening when pages are fetched from the db
3. Remove logging from the check answers endpoint as this already checks state
4. Tests