### PR TITLE
fix(dsi): Use x-forward-host header if available

### DIFF
--- a/src/Dfe.PlanTech.Infrastructure.SignIn/DfeOpenIdConnectEvents.cs
+++ b/src/Dfe.PlanTech.Infrastructure.SignIn/DfeOpenIdConnectEvents.cs
@@ -1,7 +1,6 @@
 using Dfe.PlanTech.Domain.SignIns.Models;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Primitives;
 
 namespace Dfe.PlanTech.Infrastructure.SignIns;
 
@@ -25,20 +24,6 @@ public static class DfeOpenIdConnectEvents
         return Task.FromResult(0);
     }
 
-    private static string GetOriginUrl(RedirectContext context, IDfeSignInConfiguration config)
-    {
-        var forwardHostHeader = context.HttpContext.Request.Headers
-                                                            .Where(header => string.Equals(ForwardHostHeader, header.Key, StringComparison.InvariantCultureIgnoreCase))
-                                                            .Select(header => header.Value.FirstOrDefault())
-                                                            .FirstOrDefault();
-
-        if(forwardHostHeader != null){
-            return $"https://{forwardHostHeader}/";
-        }
-
-        return config.FrontDoorUrl;
-    }
-
     /// <summary>
     /// Re-writes the signout redirect URI
     /// </summary>
@@ -56,5 +41,20 @@ public static class DfeOpenIdConnectEvents
         }
 
         return Task.FromResult(0);
+    }
+
+    
+    public static string GetOriginUrl(RedirectContext context, IDfeSignInConfiguration config)
+    {
+        var forwardHostHeader = context.HttpContext.Request.Headers
+                                                            .Where(header => string.Equals(ForwardHostHeader, header.Key, StringComparison.InvariantCultureIgnoreCase))
+                                                            .Select(header => header.Value.FirstOrDefault())
+                                                            .FirstOrDefault();
+
+        if(forwardHostHeader != null){
+            return $"https://{forwardHostHeader}/";
+        }
+
+        return config.FrontDoorUrl;
     }
 }

--- a/src/Dfe.PlanTech.Infrastructure.SignIn/DfeOpenIdConnectEvents.cs
+++ b/src/Dfe.PlanTech.Infrastructure.SignIn/DfeOpenIdConnectEvents.cs
@@ -43,7 +43,7 @@ public static class DfeOpenIdConnectEvents
         return Task.FromResult(0);
     }
 
-    
+
     public static string GetOriginUrl(RedirectContext context, IDfeSignInConfiguration config)
     {
         var forwardHostHeader = context.HttpContext.Request.Headers
@@ -51,7 +51,8 @@ public static class DfeOpenIdConnectEvents
                                                             .Select(header => header.Value.FirstOrDefault())
                                                             .FirstOrDefault();
 
-        if(forwardHostHeader != null){
+        if (forwardHostHeader != null)
+        {
             return $"https://{forwardHostHeader}/";
         }
 

--- a/tests/Dfe.PlanTech.Infrastructure.SignIn.UnitTests/DfeOpenIdConnectEventsTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.SignIn.UnitTests/DfeOpenIdConnectEventsTests.cs
@@ -390,11 +390,12 @@ public class DfeOpenIdConnectEventsTests
     }
 
     [Fact]
-    public void GetOriginUrl_Should_Return_XForwardedHost_If_Found(){
+    public void GetOriginUrl_Should_Return_XForwardedHost_If_Found()
+    {
         var host = "www.should-return-this.com";
 
         var httpContext = Substitute.For<HttpContext>();
-        var context = new RedirectContext(httpContext, new AuthenticationScheme("", "", typeof(DummyAuthHandler)), new OpenIdConnectOptions(), new AuthenticationProperties(){} );
+        var context = new RedirectContext(httpContext, new AuthenticationScheme("", "", typeof(DummyAuthHandler)), new OpenIdConnectOptions(), new AuthenticationProperties() { });
 
         var request = Substitute.For<HttpRequest>();
         var headers = new HeaderDictionary
@@ -410,11 +411,12 @@ public class DfeOpenIdConnectEventsTests
     }
 
     [Fact]
-    public void GetOriginUrl_Should_Return_FrontDoorURL_If_Header_Not_Found(){
+    public void GetOriginUrl_Should_Return_FrontDoorURL_If_Header_Not_Found()
+    {
         var host = "www.should-return-this.com";
 
         var httpContext = Substitute.For<HttpContext>();
-        var context = new RedirectContext(httpContext, new AuthenticationScheme("", "", typeof(DummyAuthHandler)), new OpenIdConnectOptions(), new AuthenticationProperties(){} );
+        var context = new RedirectContext(httpContext, new AuthenticationScheme("", "", typeof(DummyAuthHandler)), new OpenIdConnectOptions(), new AuthenticationProperties() { });
 
         var request = Substitute.For<HttpRequest>();
         var headers = new HeaderDictionary

--- a/tests/Dfe.PlanTech.Infrastructure.SignIn.UnitTests/DfeOpenIdConnectEventsTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.SignIn.UnitTests/DfeOpenIdConnectEventsTests.cs
@@ -1,4 +1,5 @@
 using Dfe.PlanTech.Application.SignIns.Interfaces;
+using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Domain.SignIns.Enums;
 using Dfe.PlanTech.Domain.SignIns.Models;
 using Dfe.PlanTech.Domain.Users.Exceptions;
@@ -386,5 +387,50 @@ public class DfeOpenIdConnectEventsTests
 
         await Assert.ThrowsAnyAsync<KeyNotFoundException>(() =>
             OnUserInformationReceivedEvent.OnUserInformationReceived(context));
+    }
+
+    [Fact]
+    public void GetOriginUrl_Should_Return_XForwardedHost_If_Found(){
+        var host = "www.should-return-this.com";
+
+        var httpContext = Substitute.For<HttpContext>();
+        var context = new RedirectContext(httpContext, new AuthenticationScheme("", "", typeof(DummyAuthHandler)), new OpenIdConnectOptions(), new AuthenticationProperties(){} );
+
+        var request = Substitute.For<HttpRequest>();
+        var headers = new HeaderDictionary
+        {
+            { "X-Forwarded-Host", host }
+        };
+
+        request.Headers.Returns(headers);
+        context.Request.Returns(request);
+        var originUrl = DfeOpenIdConnectEvents.GetOriginUrl(context, new DfeSignInConfiguration());
+
+        Assert.Contains(host, originUrl);
+    }
+
+    [Fact]
+    public void GetOriginUrl_Should_Return_FrontDoorURL_If_Header_Not_Found(){
+        var host = "www.should-return-this.com";
+
+        var httpContext = Substitute.For<HttpContext>();
+        var context = new RedirectContext(httpContext, new AuthenticationScheme("", "", typeof(DummyAuthHandler)), new OpenIdConnectOptions(), new AuthenticationProperties(){} );
+
+        var request = Substitute.For<HttpRequest>();
+        var headers = new HeaderDictionary
+        {
+        };
+
+        request.Headers.Returns(headers);
+        context.Request.Returns(request);
+
+        var config = new DfeSignInConfiguration()
+        {
+            FrontDoorUrl = host
+        };
+
+        var originUrl = DfeOpenIdConnectEvents.GetOriginUrl(context, config);
+
+        Assert.Contains(host, originUrl);
     }
 }


### PR DESCRIPTION
# Change

- Use the `x-forward-host` header (if available) for redirect URI to DSI