### PR TITLE
fix(dsi): Remove extra forward slash if existing

### DIFF
--- a/src/Dfe.PlanTech.Infrastructure.SignIn/DfeOpenIdConnectEvents.cs
+++ b/src/Dfe.PlanTech.Infrastructure.SignIn/DfeOpenIdConnectEvents.cs
@@ -51,9 +51,10 @@ public static class DfeOpenIdConnectEvents
                                                             .Select(header => header.Value.FirstOrDefault())
                                                             .FirstOrDefault();
 
-        if (forwardHostHeader != null)
-        {
-            return $"https://{forwardHostHeader}/";
+        var originUrl = forwardHostHeader ?? config.FrontDoorUrl;
+
+        if(originUrl.Last() != '/'){
+            originUrl += '/';
         }
 
         return config.FrontDoorUrl;


### PR DESCRIPTION
## Fixes

- Removes a forward slash from the end of the origin URL _if_ the callback path also starts with a forward slash[^1]

[^1]: The `x-forwarded-host` header ends with a forward slash from Azure Front Door. Our config variables for the callbacks start with a forward slash `/auth/cb`.

This could be fixed by tweaking our environment variables slightly, but I think this gives us a bit more security.