### PR TITLE
chore: Update Azure Identity to 1.11.4

### DIFF
--- a/src/Dfe.PlanTech.AzureFunctions/Dfe_PlanTech_AzureFunctions.csproj
+++ b/src/Dfe.PlanTech.AzureFunctions/Dfe_PlanTech_AzureFunctions.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
-    <PackageReference Include="Azure.Identity" Version="1.11.0" />
+    <PackageReference Include="Azure.Identity" Version="1.11.4" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.5" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.21.0" />

--- a/src/Dfe.PlanTech.Web/Dfe.PlanTech.Web.csproj
+++ b/src/Dfe.PlanTech.Web/Dfe.PlanTech.Web.csproj
@@ -24,7 +24,7 @@
         <PackageReference Include="Automapper" Version="13.0.1" />
         <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
         <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.2.3" />
-        <PackageReference Include="Azure.Identity" Version="1.11.0" />
+        <PackageReference Include="Azure.Identity" Version="1.11.4" />
         <PackageReference Include="EFCoreSecondLevelCacheInterceptor" Version="4.4.1" />
         <PackageReference Include="GovUk.Frontend.AspNetCore" Version="1.5.0" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />


### PR DESCRIPTION
There is a [vulnerability in version 1.11.0](https://github.com/advisories/GHSA-m5vv-6r4h-3vj9)