### PR TITLE
Feat: Support headings in rich text

### DIFF
--- a/src/Dfe.PlanTech.Domain/Content/Enums/RichTextNodeType.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Enums/RichTextNodeType.cs
@@ -14,4 +14,5 @@ public enum RichTextNodeType
     TableRow,
     TableHeaderCell,
     TableCell,
+    Heading
 }

--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/IRichTextContent.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/IRichTextContent.cs
@@ -27,12 +27,12 @@ public partial interface IRichTextContent
     });
 
     public bool MatchesNodeType(string? enumName)
-    => string.Equals(enumName, RemoveHyphensRegEx().Replace(NodeType, ""), StringComparison.OrdinalIgnoreCase);
+    => string.Equals(enumName, RemoveHyphensAndNumbersRegEx().Replace(NodeType, ""), StringComparison.OrdinalIgnoreCase);
 
     public string? GetNameForNodeType(RichTextNodeType value) => Enum.GetName(value);
 
-    [GeneratedRegex("-")]
-    private static partial Regex RemoveHyphensRegEx();
+    [GeneratedRegex("-|\\d")]
+    private static partial Regex RemoveHyphensAndNumbersRegEx();
 }
 
 public interface IRichTextContent<TMark, TContentType, TData> : IRichTextContent

--- a/src/Dfe.PlanTech.Infrastructure.Contentful/Content/Renderers/Models/PartRenderers/HeadingRenderer.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Contentful/Content/Renderers/Models/PartRenderers/HeadingRenderer.cs
@@ -1,0 +1,28 @@
+using Dfe.PlanTech.Domain.Content.Enums;
+using Dfe.PlanTech.Domain.Content.Interfaces;
+using Dfe.PlanTech.Domain.Content.Models;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Dfe.PlanTech.Infrastructure.Contentful.Content.Renderers.Models.PartRenderers;
+
+public partial class HeadingRenderer : BaseRichTextContentPartRender
+{
+    public HeadingRenderer() : base(RichTextNodeType.Heading)
+    {
+    }
+
+    public override StringBuilder AddHtml(RichTextContent content, IRichTextContentPartRendererCollection rendererCollection, StringBuilder stringBuilder)
+    {
+        var tag = GetHeaderTag().Replace(content.NodeType,"$1$2");
+
+        stringBuilder.Append($"<{tag}>");
+        rendererCollection.RenderChildren(content, stringBuilder);
+        stringBuilder.Append($"</{tag}>");
+
+        return stringBuilder;
+    }
+
+    [GeneratedRegex("(h)eading-(\\d)")]
+    private static partial Regex GetHeaderTag();
+}

--- a/src/Dfe.PlanTech.Infrastructure.Contentful/Content/Renderers/Models/PartRenderers/HeadingRenderer.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Contentful/Content/Renderers/Models/PartRenderers/HeadingRenderer.cs
@@ -14,7 +14,7 @@ public partial class HeadingRenderer : BaseRichTextContentPartRender
 
     public override StringBuilder AddHtml(RichTextContent content, IRichTextContentPartRendererCollection rendererCollection, StringBuilder stringBuilder)
     {
-        var tag = GetHeaderTag().Replace(content.NodeType,"$1$2");
+        var tag = GetHeaderTag().Replace(content.NodeType, "$1$2");
 
         stringBuilder.Append($"<{tag}>");
         rendererCollection.RenderChildren(content, stringBuilder);

--- a/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Content/Renderers/Models/PartRenderers/HeadingRendererTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Content/Renderers/Models/PartRenderers/HeadingRendererTests.cs
@@ -1,0 +1,71 @@
+using Dfe.PlanTech.Domain.Content.Interfaces;
+using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Domain.Content.Models.Options;
+using Dfe.PlanTech.Infrastructure.Contentful.Content.Renderers.Models;
+using Dfe.PlanTech.Infrastructure.Contentful.Content.Renderers.Models.PartRenderers;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Text;
+
+namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Content.Renderers.Models.PartRenderers;
+
+public class HeadingRendererTests
+{
+    [Theory]
+    [InlineData("heading-1")]
+    [InlineData("heading-2")]
+    [InlineData("heading-3")]
+    [InlineData("heading-4")]
+    [InlineData("heading-5")]
+    [InlineData("heading-6")]
+    public void Should_Accept_When_ContentIsHeading(string nodeType)
+    {
+        var content = new RichTextContent()
+        {
+            NodeType = nodeType,
+            Value = "",
+            Content = []
+        };
+
+        var renderer = new HeadingRenderer();
+        var accepted = renderer.Accepts(content);
+        Assert.True(accepted);
+    }
+
+    [Fact]
+    public void Should_Reject_When_Not_Heading()
+    {
+        var content = new RichTextContent()
+        {
+            NodeType = "paragraph",
+            Value = "paragraph text"
+        };
+
+        var renderer = new HeadingRenderer();
+        var accepted = renderer.Accepts(content);
+
+        Assert.False(accepted);
+    }
+
+    [Theory]
+    [InlineData("heading-1", "<h1></h1>")]
+    [InlineData("heading-2", "<h2></h2>")]
+    [InlineData("heading-3", "<h3></h3>")]
+    [InlineData("heading-4", "<h4></h4>")]
+    [InlineData("heading-5", "<h5></h5>")]
+    [InlineData("heading-6", "<h6></h6>")]
+    public void Should_Generate_Correct_Header_Tags(string nodeType, string expected)
+    {
+        var renderer = new HeadingRenderer();
+        var rendererCollection = new RichTextRenderer(new NullLogger<IRichTextRenderer>(), new[] { renderer });
+        var content = new RichTextContent()
+        {
+            NodeType = nodeType,
+            Content = []
+        };
+
+        var result = renderer.AddHtml(content, rendererCollection, new StringBuilder());
+        var html = result.ToString();
+
+        Assert.Equal(expected, html);
+    }
+}

--- a/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Content/Renderers/Models/PartRenderers/HeadingRendererTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Content/Renderers/Models/PartRenderers/HeadingRendererTests.cs
@@ -68,4 +68,39 @@ public class HeadingRendererTests
 
         Assert.Equal(expected, html);
     }
+
+    [Theory]
+    [InlineData("heading-1", "<h1>test</h1>")]
+    [InlineData("heading-2", "<h2>test</h2>")]
+    [InlineData("heading-3", "<h3>test</h3>")]
+    [InlineData("heading-4", "<h4>test</h4>")]
+    [InlineData("heading-5", "<h5>test</h5>")]
+    [InlineData("heading-6", "<h6>test</h6>")]
+    public void Should_Generate_Correct_Header_Tags_With_Text_Rendering_Within(string nodeType, string expected)
+    {
+        var headingRenderer = new HeadingRenderer();
+        var textRenderer = new TextRenderer(new TextRendererOptions(new NullLogger<TextRendererOptions>(), []));
+
+        var rendererCollection = new RichTextRenderer(
+            new NullLogger<IRichTextRenderer>(),
+            new List<BaseRichTextContentPartRender> { headingRenderer, textRenderer }
+        );
+
+        var content = new RichTextContent()
+        {
+            NodeType = nodeType,
+            Content = [
+                new RichTextContent()
+                {
+                    NodeType = "text",
+                    Value = "test"
+                }
+            ]
+        };
+
+        var result = headingRenderer.AddHtml(content, rendererCollection, new StringBuilder());
+        var html = result.ToString();
+
+        Assert.Equal(expected, html);
+    }
 }


### PR DESCRIPTION
## Features

Adds support for rendering headers within Rich content. 
The h1-h6 tags use the dfe classes which are all sized to line up with the XL/L/M/S ones so left as is.