### PR TITLE
feat: Ignore invalid content relationships

### DIFF
--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/IHasContentComponent.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/IHasContentComponent.cs
@@ -1,0 +1,12 @@
+using Dfe.PlanTech.Domain.Content.Models;
+
+namespace Dfe.PlanTech.Domain.Questionnaire.Models;
+
+public interface IHasContentComponent
+{
+  public long Id { get; set; }
+
+  public string? ContentComponentId { get; set; }
+
+  public ContentComponentDbEntity? ContentComponent { get; set; }
+}

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/IHasContentComponent.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/IHasContentComponent.cs
@@ -4,9 +4,9 @@ namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
 public interface IHasContentComponent
 {
-  public long Id { get; set; }
+    public long Id { get; set; }
 
-  public string? ContentComponentId { get; set; }
+    public string? ContentComponentId { get; set; }
 
-  public ContentComponentDbEntity? ContentComponent { get; set; }
+    public ContentComponentDbEntity? ContentComponent { get; set; }
 }

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationChunkContentDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationChunkContentDbEntity.cs
@@ -4,7 +4,7 @@ using Dfe.PlanTech.Domain.Content.Models;
 
 namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
-public class RecommendationChunkContentDbEntity
+public class RecommendationChunkContentDbEntity : IHasContentComponent
 {
     [Key]
     [DatabaseGenerated(DatabaseGeneratedOption.Identity)]

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationIntroContentDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationIntroContentDbEntity.cs
@@ -4,7 +4,7 @@ using Dfe.PlanTech.Domain.Content.Models;
 
 namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
-public class RecommendationIntroContentDbEntity
+public class RecommendationIntroContentDbEntity : IHasContentComponent
 {
     [Key]
     [DatabaseGenerated(DatabaseGeneratedOption.Identity)]

--- a/src/Dfe.PlanTech.Infrastructure.Data/Dfe.PlanTech.Infrastructure.Data.csproj
+++ b/src/Dfe.PlanTech.Infrastructure.Data/Dfe.PlanTech.Infrastructure.Data.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Dfe.PlanTech.Infrastructure.Data/Repositories/RecommendationsRepository.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Data/Repositories/RecommendationsRepository.cs
@@ -51,7 +51,8 @@ public class RecommendationsRepository(ICmsDbContext db, ILogger<IRecommendation
                                                     .OrderBy(chunk => chunk.Order)
                                                     .ToListAsync(cancellationToken);
 
-        var introContent = await _db.RecommendationIntroContents.Where(introContent => introContent.RecommendationIntro.SubtopicRecommendations.Any(rec => rec.Id == recommendation.Id))
+        var introContent = await _db.RecommendationIntroContents.Where(introContent => introContent.RecommendationIntro != null &&
+                                                                                       introContent.RecommendationIntro.SubtopicRecommendations.Any(rec => rec.Id == recommendation.Id))
                                                                 .Select(introContent => new RecommendationIntroContentDbEntity()
                                                                 {
                                                                     RecommendationIntroId = introContent.RecommendationIntroId,
@@ -61,7 +62,8 @@ public class RecommendationsRepository(ICmsDbContext db, ILogger<IRecommendation
                                                                 })
                                                                 .ToListAsync(cancellationToken);
 
-        var chunkContent = await _db.RecommendationChunkContents.Where(chunkContent => chunkContent.RecommendationChunk.RecommendationSections.Any(section => section.Id == recommendation.SectionId))
+        var chunkContent = await _db.RecommendationChunkContents.Where(chunkContent => chunkContent.RecommendationChunk != null &&
+                                                                                       chunkContent.RecommendationChunk.RecommendationSections.Any(section => section.Id == recommendation.SectionId))
                                                                 .Select(chunkContent => new RecommendationChunkContentDbEntity()
                                                                 {
                                                                     RecommendationChunkId = chunkContent.RecommendationChunkId,

--- a/tests/Dfe.PlanTech.Infrastructure.Data.UnitTests/Repositories/RecommendationsRepositoryTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Data.UnitTests/Repositories/RecommendationsRepositoryTests.cs
@@ -1,3 +1,4 @@
+using Castle.Core.Logging;
 using Dfe.PlanTech.Application.Persistence.Interfaces;
 using Dfe.PlanTech.Domain.Content.Enums;
 using Dfe.PlanTech.Domain.Content.Models;
@@ -5,7 +6,7 @@ using Dfe.PlanTech.Domain.Questionnaire.Enums;
 using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 using Dfe.PlanTech.Domain.Questionnaire.Models;
 using Dfe.PlanTech.Infrastructure.Data.Repositories;
-using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging;
 using MockQueryable.NSubstitute;
 using NSubstitute;
 
@@ -13,6 +14,8 @@ namespace Dfe.PlanTech.Infrastructure.Data.UnitTests;
 
 public class RecommendationsRepositoryTests
 {
+    private const string RecChunkOneId = "recommendation-chunk-one";
+    private const string RecIntroOneId = "Intro-One-Low";
 #pragma warning disable CA1859 // Use concrete type
     private readonly IRecommendationsRepository _repository;
 #pragma warning disable CA1859 // Use concrete type
@@ -31,18 +34,48 @@ public class RecommendationsRepositoryTests
     private readonly List<RecommendationChunkContentDbEntity> _chunkContent = [];
     private readonly List<RichTextContentWithSubtopicRecommendationId> _richTexts = [];
 
+    private readonly ILogger<IRecommendationsRepository> _logger = Substitute.For<ILogger<IRecommendationsRepository>>();
+
+    private readonly List<string> LoggedMessages = [];
+
     public RecommendationsRepositoryTests()
     {
         _subtopicRecommendation = CreateSubtopicRecommendationDbEntity();
         _subtopicRecommendations.Add(_subtopicRecommendation);
-
-        _answers.AddRange([.. _subtopicRecommendation.Section.Answers, .. _subtopicRecommendation.Section.Chunks.SelectMany(chunk => chunk.Answers)]);
-        _chunks.AddRange(_subtopicRecommendation.Section.Chunks);
-        _intros.AddRange(_subtopicRecommendation.Section.RecommendationIntro);
         _sections.Add(_subtopicRecommendation.Subtopic);
 
-        var testing = new List<SubtopicRecommendationDbEntity>() { new() { Id = "One" } };
-        var queryable = testing.AsQueryable();
+        foreach (var intro in _subtopicRecommendation.Intros)
+        {
+            intro.SubtopicRecommendations.Add(_subtopicRecommendation);
+        }
+        _intros.AddRange(_subtopicRecommendation.Intros);
+        _introContent.AddRange(_subtopicRecommendation.Intros.SelectMany((intro, introIndex) => intro.Content
+                                                                                             .Select((content, contentIndex) => new RecommendationIntroContentDbEntity()
+                                                                                             {
+                                                                                                 Id = introIndex + contentIndex,
+                                                                                                 RecommendationIntro = intro,
+                                                                                                 RecommendationIntroId = intro.Id,
+                                                                                                 ContentComponent = content,
+                                                                                                 ContentComponentId = content.Id
+                                                                                             })));
+
+        foreach (var chunk in _subtopicRecommendation.Section.Chunks)
+        {
+            chunk.RecommendationSections.Add(_subtopicRecommendation.Section);
+        }
+        _chunks.AddRange(_subtopicRecommendation.Section.Chunks);
+        _chunkContent.AddRange(_subtopicRecommendation.Section.Chunks.SelectMany((chunk, chunkIndex) => chunk.Content
+                                                                                                             .Select((content, contentIndex) => new RecommendationChunkContentDbEntity()
+                                                                                                             {
+                                                                                                                 Id = chunkIndex + contentIndex,
+                                                                                                                 RecommendationChunk = chunk,
+                                                                                                                 RecommendationChunkId = chunk.Id,
+                                                                                                                 ContentComponent = content,
+                                                                                                                 ContentComponentId = content.Id
+                                                                                                             })));
+
+
+        _answers.AddRange([.. _subtopicRecommendation.Section.Answers, .. _subtopicRecommendation.Section.Chunks.SelectMany(chunk => chunk.Answers)]);
 
         var mockContext = Substitute.For<ICmsDbContext>();
 
@@ -67,10 +100,10 @@ public class RecommendationsRepositoryTests
         var richTextsMock = _richTexts.BuildMock();
         _db.RichTextContentWithSubtopicRecommendationIds.Returns(richTextsMock);
 
-        _repository = new RecommendationsRepository(_db, new NullLogger<IRecommendationsRepository>());
+        _repository = new RecommendationsRepository(_db, _logger);
     }
 
-    private SubtopicRecommendationDbEntity CreateSubtopicRecommendationDbEntity()
+    private static SubtopicRecommendationDbEntity CreateSubtopicRecommendationDbEntity()
     {
         var recommendationSectionOne = new RecommendationSectionDbEntity()
         {
@@ -92,7 +125,7 @@ public class RecommendationsRepositoryTests
               [
               new RecommendationChunkDbEntity()
               {
-                  Id = "recommendation-chunk-one",
+                  Id = RecChunkOneId,
                   Answers =
                     [
                         new AnswerDbEntity()
@@ -232,7 +265,7 @@ public class RecommendationsRepositoryTests
               new RecommendationIntroDbEntity()
               {
                   Maturity = "Low",
-                  Id = "Intro-One-Low",
+                  Id = RecIntroOneId,
                   Slug = "Low-Maturity",
                   Header = new HeaderDbEntity() { Text = "Low maturity header", Id = "Intro-header-one" },
                   Content = [
@@ -346,10 +379,89 @@ public class RecommendationsRepositoryTests
     {
         var recommendation = await _repository.GetCompleteRecommendationsForSubtopic(_subtopicRecommendation.Subtopic.Id, CancellationToken.None);
 
+        Validate_GetCompleteRecommendationsForSubtopic_Success(recommendation);
+    }
+
+    [Fact]
+    public async Task GetCompleteRecommendationsForSubtopic_Should_Return_Null_When_NotFound()
+    {
+        var recommendation = await _repository.GetCompleteRecommendationsForSubtopic("Not a real subtopic", CancellationToken.None);
+
+        Assert.Null(recommendation);
+    }
+
+    [Fact]
+    public async Task GetCompleteRecommendationsForSubtopic_Should_Log_InvalidContentRows()
+    {
+        var recChunk = _subtopicRecommendation.Section.Chunks.FirstOrDefault(chunk => chunk.Id == RecChunkOneId);
+        Assert.NotNull(recChunk);
+
+        int[] invalidChunkRowIds = [12345, 123456];
+        foreach (var id in invalidChunkRowIds)
+        {
+            _chunkContent.Add(new()
+            {
+                Id = id,
+                RecommendationChunkId = RecChunkOneId,
+                RecommendationChunk = recChunk
+            });
+        }
+
+        var recIntro = _subtopicRecommendation.Intros.FirstOrDefault(intro => intro.Id == RecIntroOneId);
+        Assert.NotNull(recIntro);
+        int[] invalidIntroIds = [99999, 342, 1823];
+        foreach (var id in invalidIntroIds)
+        {
+            _introContent.Add(new()
+            {
+                Id = id,
+                RecommendationIntro = recIntro,
+                RecommendationIntroId = recIntro.Id
+            });
+        }
+
+        var recommendation = await _repository.GetCompleteRecommendationsForSubtopic(_subtopicRecommendation.Subtopic.Id, CancellationToken.None);
+
+        Validate_GetCompleteRecommendationsForSubtopic_Success(recommendation);
+
+        var logMessages = _logger.ReceivedCalls().ToArray();
+        Assert.Equal(2, logMessages.Length);
+
+        var containsIntroMessage = false;
+        var containsChunkMessage = false;
+        foreach (var message in logMessages)
+        {
+            var arguments = message.GetArguments();
+            var loggedMessage = arguments[2]?.ToString();
+            Assert.NotNull(loggedMessage);
+
+            var idsToCheckFor = loggedMessage.Contains("Chunk") ? invalidChunkRowIds : invalidIntroIds;
+
+            if (loggedMessage.Contains("Chunk"))
+            {
+                containsChunkMessage = true;
+            }
+            else
+            {
+                containsIntroMessage = true;
+            }
+
+            foreach (var id in idsToCheckFor)
+            {
+                Assert.Contains(id.ToString(), loggedMessage);
+            }
+        }
+
+        Assert.True(containsIntroMessage);
+        Assert.True(containsChunkMessage);
+    }
+
+    private void Validate_GetCompleteRecommendationsForSubtopic_Success(SubtopicRecommendationDbEntity? recommendation)
+    {
         Assert.NotNull(recommendation);
         Assert.Equal(_subtopicRecommendation.Id, recommendation.Id);
 
-        //Validate content ordering
+        Assert.Equal(_subtopicRecommendation.Intros.Count, recommendation.Intros.Count);
 
         //Intro content
         for (var x = 0; x < recommendation.Intros.Count; x++)
@@ -371,6 +483,7 @@ public class RecommendationsRepositoryTests
             }
         }
 
+        Assert.Equal(_subtopicRecommendation.Section.Chunks.Count, recommendation.Section.Chunks.Count);
         //Chunks
         for (var x = 0; x < recommendation.RecommendationChunk.Count; x++)
         {
@@ -396,11 +509,4 @@ public class RecommendationsRepositoryTests
         }
     }
 
-    [Fact]
-    public async Task GetCompleteRecommendationsForSubtopic_Should_Return_Null_When_NotFound()
-    {
-        var recommendation = await _repository.GetCompleteRecommendationsForSubtopic("Not a real subtopic", CancellationToken.None);
-
-        Assert.Null(recommendation);
-    }
 }

--- a/tests/Dfe.PlanTech.Infrastructure.Data.UnitTests/Repositories/RecommendationsRepositoryTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Data.UnitTests/Repositories/RecommendationsRepositoryTests.cs
@@ -5,6 +5,7 @@ using Dfe.PlanTech.Domain.Questionnaire.Enums;
 using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 using Dfe.PlanTech.Domain.Questionnaire.Models;
 using Dfe.PlanTech.Infrastructure.Data.Repositories;
+using Microsoft.Extensions.Logging.Abstractions;
 using MockQueryable.NSubstitute;
 using NSubstitute;
 
@@ -66,7 +67,7 @@ public class RecommendationsRepositoryTests
         var richTextsMock = _richTexts.BuildMock();
         _db.RichTextContentWithSubtopicRecommendationIds.Returns(richTextsMock);
 
-        _repository = new RecommendationsRepository(_db);
+        _repository = new RecommendationsRepository(_db, new NullLogger<IRecommendationsRepository>());
     }
 
     private SubtopicRecommendationDbEntity CreateSubtopicRecommendationDbEntity()


### PR DESCRIPTION
## Changes

- Adds validation/error handling in case of a join for a `ContentComponent` has a null value. Logs errors if any found.
- Improves tests for `RecommendationsRepository`. Some tests were not actually doing anything, so the code has been modified to ensure that the tests work as expected.