### PR TITLE
chore: Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,6 +34,10 @@ Release requirement one description
 - Step two
 - ...
 
+# Additional notes
+
+Any additional notes, comments, etc. that might be required here.
+
 # Checklist
 
 - [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,26 +4,29 @@ Addresses ticket [#TICKET-NUMBER](www.ticket-link.com)
 
 High level overview of changes; one or two sentences.
 
-## Changes
+The design for the ticket is based on:
+![This design from XXXXXX](screenshot-of-design.png)
 
-### Major
+# Changes
+
+## Major
 
 - Major change one
 - Major change two
 - ...
 
-### Minor
+## Minor
 
 - Minor change one
 - Minor change two
 - Minor change three
 - ...
 
-## Release requirements
+# Release requirements
 
 What steps are required for release, if any? E.g. Key Vault secrets, Terraform changes, etc.
 
-### Release requirement one title
+## Release requirement one title
 
 Release requirement one description
 
@@ -31,11 +34,12 @@ Release requirement one description
 - Step two
 - ...
 
-## Checklist
+# Checklist
 
 - [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
 - [ ] Unit tests have been added/updated
 - [ ] E2E tests have been added/updated
+- [ ] GitHub workflows/actions have been updated
 - [ ] Terraform has been updated
 - [ ] Documentation has been updated
 - [ ] Key Vault secrets have been added to dev

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+# Overview
+
+Addresses ticket [#TICKET-NUMBER](www.ticket-link.com)
+
+High level overview of changes; one or two sentences.
+
+## Changes
+
+### Major
+
+- Major change one
+- Major change two
+- ...
+
+### Minor
+
+- Minor change one
+- Minor change two
+- Minor change three
+- ...
+
+## Release requirements
+
+What steps are required for release, if any? E.g. Key Vault secrets, Terraform changes, etc.
+
+### Release requirement one title
+
+Release requirement one description
+
+- Step one
+- Step two
+- ...
+
+## Checklist
+
+- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
+- [ ] Unit tests have been added/updated
+- [ ] E2E tests have been added/updated
+- [ ] Terraform has been updated
+- [ ] Documentation has been updated
+- [ ] Key Vault secrets have been added to dev

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-# Overview
+## Overview
 
 Addresses ticket [#TICKET-NUMBER](www.ticket-link.com)
 
@@ -7,30 +7,42 @@ High level overview of changes; one or two sentences.
 The design for the ticket is based on:
 ![This design from XXXXXX](screenshot-of-design.png)
 
-# Changes
+## Changes
 
-## Major
+### Major
 
 - Major change one
 - Major change two
 - ...
 
-## Minor
+### Minor
 
 - Minor change one
 - Minor change two
 - Minor change three
 - ...
 
-## Non-functional changes (e.g. documentation)
+### Non-functional changes (e.g. documentation)
 
 - Docs change one
 
-# Release requirements
+## How to review the PR
+
+Guidance/instructions for reviewing the PR. Linking to existing documentation, DevOps tickets, etc. is acceptable, but as much information as is required for testing the PR should be included/referenced.
+
+Include things such as:
+- Setting up the PR. E.g.
+  - Any instructions required for running the web app
+  - If Contentful content is required, what the changes are, what existing content could be used, etc
+
+- Where to test, e.g. "recommendations".
+- If the PR is to address a bug, how to replicate the bug
+
+## Release requirements
 
 What steps are required for release, if any? E.g. Key Vault secrets, Terraform changes, etc.
 
-## Release requirement one title
+### Release requirement one title
 
 Release requirement one description
 
@@ -38,17 +50,19 @@ Release requirement one description
 - Step two
 - ...
 
-# Additional notes
+## Additional notes
 
 Any additional notes, comments, etc. that might be required here.
 
-# Checklist
+## Checklist
+
+Delete any rows that do not apply to the PR.
 
 - [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
 - [ ] PR targets development branch
 - [ ] Unit tests have been added/updated
 - [ ] E2E tests have been added/updated
-- [ ] GitHub workflows/actions have been updated
+- [ ] GitHub workflows/actions have been added/updated
 - [ ] Terraform has been updated
-- [ ] Documentation has been updated
-- [ ] Key Vault secrets have been added to dev
+- [ ] Documentation has been updated where relevant
+- [ ] Any Key Vault secrets have been added to the development Key Vault

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,6 +22,10 @@ The design for the ticket is based on:
 - Minor change three
 - ...
 
+## Non-functional changes (e.g. documentation)
+
+- Docs change one
+
 # Release requirements
 
 What steps are required for release, if any? E.g. Key Vault secrets, Terraform changes, etc.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -37,6 +37,7 @@ Release requirement one description
 # Checklist
 
 - [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
+- [ ] PR targets development branch
 - [ ] Unit tests have been added/updated
 - [ ] E2E tests have been added/updated
 - [ ] GitHub workflows/actions have been updated


### PR DESCRIPTION
# Overview

Adds a `pull_request_template.md` to:
1. Ensure PRs descriptions are consistent, and contain all necessary information
2. Provide a checklist for developers when creating the PR, to try and ensure that all requirements have been completed

# Changes

## Non-functional changes (e.g. documentation)

- Adds `pull_request_template.md` to project

# Additional notes

Tried to match what we've generally been doing for PRs, as well as adding a few other bits to ensure all information is included.

Please feel free to either suggest, or just make, edits. Comments welcome etc..

# Checklist

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch