### PR TITLE
feat: Retain hyphens in Recommendation Chunk slugs

### DIFF
--- a/src/Dfe.PlanTech.Domain/Extensions/StringHelpers.cs
+++ b/src/Dfe.PlanTech.Domain/Extensions/StringHelpers.cs
@@ -4,14 +4,14 @@ namespace Dfe.PlanTech;
 
 public static partial class StringHelpers
 {
-    private const string RemoveNonAlphanumericCharactersRegexPattern = @"[^a-zA-Z0-9\s]";
+    private const string RemoveNonAlphanumericExceptHyphensRegexPattern = @"[^a-zA-Z0-9\s-]";
 
-    // Extension method to slugify a string by removing non-alphanumeric characters, replacing spaces with hyphens, and converting to lowercase.
+    // Extension method to slugify a string by removing non-alphanumeric characters (except hyphens to preserve hyphenated words), replacing spaces with hyphens, and converting to lowercase.
     public static string Slugify(this string text)
-    => RemoveNonAlphaNumericCharactersPattern().Replace(text, "").Replace(" ", "-").ToLower();
+    => RemoveNonAlphaNumericExceptHyphensPattern().Replace(text, "").Replace(" ", "-").ToLower();
 
     public static string TruncateIfOverLength(this string text, int maxLength) => text.Length < maxLength ? text : text[..maxLength];
 
-    [GeneratedRegex(RemoveNonAlphanumericCharactersRegexPattern)]
-    private static partial Regex RemoveNonAlphaNumericCharactersPattern();
+    [GeneratedRegex(RemoveNonAlphanumericExceptHyphensRegexPattern)]
+    private static partial Regex RemoveNonAlphaNumericExceptHyphensPattern();
 }

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/dynamic-page-validator/helpers/slugify-chunks.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/dynamic-page-validator/helpers/slugify-chunks.js
@@ -1,5 +1,5 @@
 export const slugifyChunks = (text) => {
-    const removeNonAlphanumericCharactersRegexPattern = /[^a-zA-Z0-9\s]/g
+    const removeNonAlphanumericExceptHyphensRegexPattern = /[^a-zA-Z0-9\s-]/g
 
-    return text.replace(removeNonAlphanumericCharactersRegexPattern, "").trim().replace(/ /g, "-").toLowerCase();
+    return text.replace(removeNonAlphanumericExceptHyphensRegexPattern, "").trim().replace(/ /g, "-").toLowerCase();
 }

--- a/tests/Dfe.PlanTech.Web.UnitTests/Models/ComponentModelTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Models/ComponentModelTests.cs
@@ -76,6 +76,7 @@ namespace Dfe.PlanTech.Web.UnitTests.Models
         [Theory]
         [InlineData("Random test Topic", "random-test-topic")]
         [InlineData("Y867as ()&ycj Cool Thing", "y867as-ycj-cool-thing")]
+        [InlineData("Save a back-up...", "save-a-back-up")]
         public void Slugify_Should_Slugify_Strings(string header, string expectedResult)
         {
             var recommendationChunk = ComponentBuilder.BuildRecommendationChunk(header);


### PR DESCRIPTION
Ticket: [220949](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/220949)

Make RecommendationChunk slugs (which are the only slugs produced programmatically) with the slugs defined in Contentful by retaining hyphens (so "back-up broadband" becomes "back-up-broadband", not "backup-broadband").