### PR TITLE
feat: Add Key Vault IConfiguration provider

### DIFF
--- a/src/Dfe.PlanTech.AzureFunctions/Dfe.PlanTech.AzureFunctions.csproj
+++ b/src/Dfe.PlanTech.AzureFunctions/Dfe.PlanTech.AzureFunctions.csproj
@@ -9,13 +9,15 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
-    <PackageReference Include="Azure.Identity" Version="1.11.4" />
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.5" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.21.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.17.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.2" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />

--- a/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
@@ -12,6 +12,7 @@ using Dfe.PlanTech.Domain.Persistence.Models;
 using Dfe.PlanTech.Infrastructure.Data;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Dfe.PlanTech.AzureFunctions;
 
@@ -24,6 +25,16 @@ public class QueueReceiver(
     ICacheHandler cacheHandler)
     : BaseFunction(loggerFactory.CreateLogger<QueueReceiver>())
 {
+    public QueueReceiver(IOptions<ContentfulOptions> contentfulOptions,
+    ILoggerFactory loggerFactory,
+    CmsDbContext db,
+    JsonToEntityMappers mappers,
+    IMessageRetryHandler messageRetryHandler,
+    ICacheHandler cacheHandler) : this(contentfulOptions.Value, loggerFactory, db, mappers, messageRetryHandler, cacheHandler)
+    {
+
+    }
+
     /// <summary>
     /// Azure Function App function that processes messages from a Service Bus queue, converts them
     /// to the appropriate <see cref="ContentComponentDbEntity"/> class, and adds/updates the database where appropriate.

--- a/src/Dfe.PlanTech.AzureFunctions/Program.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Program.cs
@@ -1,11 +1,29 @@
+using Azure.Identity;
 using Dfe.PlanTech.AzureFunctions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
 var host = new HostBuilder()
     .ConfigureFunctionsWorkerDefaults()
+    .ConfigureAppConfiguration((context, builder) =>
+    {
+        var configuration = builder.Build();
+        var keyvaultName = configuration["Azure_KeyVault_Name"];
+
+        //If there's no Key Vault name provided then don't add it as a configuration provider - For local testing
+        if (string.IsNullOrEmpty(keyvaultName))
+        {
+            Console.WriteLine($"Couldn't find Key Vault name with key Azure_KeyVault_Name");
+            return;
+        }
+
+        var keyVaultUri = new Uri($"https://{keyvaultName}.vault.azure.net");
+        var keyVaultCredential = new DefaultAzureCredential();
+        builder.AddAzureKeyVault(keyVaultUri, keyVaultCredential);
+    })
     .ConfigureServices((context, services) =>
     {
-        Startup.ConfigureServices(services, context.Configuration);
+        services.ConfigureServices(context.Configuration);
     })
     .Build();
 

--- a/src/Dfe.PlanTech.AzureFunctions/README.md
+++ b/src/Dfe.PlanTech.AzureFunctions/README.md
@@ -1,0 +1,28 @@
+# Dfe.PlanTech.AzureFunctions
+
+Azure Function App that receives Contentful webhook calls, and save the content updates to an SQL database.
+
+## Setup
+
+### Environment variables
+
+You can add environment variables to the `Values` key in your `local.settings.json` file.
+
+**If you are able to connect to the Azure Key Vault locally:**
+
+Simply set a value `Key_Vault_Name`, which matches the simple name of the Key Vault for the environment.
+
+**If you are _unable_ to connect to the Key Vault locally:**
+
+The following environment values should be set:
+
+- **ConnectionStrings__Database**: The SQL connection string for the SQL database
+- **Contentful__UsePreview**: Whether the Azure Function should process non-published messages
+
+The following environment values _can_ be set, but are optional:
+
+- **CacheClear__Endpoint**: The URL endpoint for clearing the container app cache
+- **CacheClear__ApiKeyName**: The header name for the cache clear route's authorisation
+- **CacheClear__ApiKeyValue**: The value for the cache clear route's authorisation
+- **MessageRetryHandlingOptions__MaxMessageDeliveryAttempts**: How many times a failed message should be retried before dead lettering
+- **MessageRetryHandlingOptions__MessageDeliveryDelayInSeconds**: Minimum amount of delay before a failed message should be tried again

--- a/src/Dfe.PlanTech.AzureFunctions/Services/CacheHandler.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Services/CacheHandler.cs
@@ -1,5 +1,6 @@
 using Dfe.PlanTech.Domain.Persistence.Models;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Dfe.PlanTech.AzureFunctions.Services;
 
@@ -8,6 +9,14 @@ public class CacheHandler(
     CacheRefreshConfiguration cacheRefreshConfiguration,
     ILogger<CacheHandler> logger) : ICacheHandler
 {
+
+    public CacheHandler(HttpClient httpClient,
+    IOptions<CacheRefreshConfiguration> cacheRefreshConfigurationOptions,
+    ILogger<CacheHandler> logger) : this(httpClient, cacheRefreshConfigurationOptions.Value, logger)
+    {
+
+    }
+
     /// <summary>
     /// Makes a call to the plan tech web app that invalidates the database cache.
     /// </summary>

--- a/src/Dfe.PlanTech.AzureFunctions/Startup.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Startup.cs
@@ -20,11 +20,11 @@ namespace Dfe.PlanTech.AzureFunctions
     [ExcludeFromCodeCoverage]
     public static class Startup
     {
-        public static void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+        public static void ConfigureServices(this IServiceCollection services, IConfiguration configuration)
         {
             services.AddDbContext<CmsDbContext>(options =>
             {
-                options.UseSqlServer(configuration["AZURE_SQL_CONNECTIONSTRING"]);
+                options.UseSqlServer(configuration["ConnectionStrings:Database"]);
             });
 
             services.AddAzureClients(builder =>
@@ -45,26 +45,47 @@ namespace Dfe.PlanTech.AzureFunctions
                 Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
             });
 
-            services.AddSingleton(new ContentfulOptions(bool.Parse(configuration["Contentful:UsePreview"] ?? bool.FalseString)));
-            services.AddSingleton(new CacheRefreshConfiguration(
-                configuration["WEBSITE_CACHE_CLEAR_ENDPOINT"],
-                configuration["WEBSITE_CACHE_CLEAR_APIKEY_NAME"],
-                configuration["WEBSITE_CACHE_CLEAR_APIKEY_VALUE"]));
+            ConfigureCaching(services);
+            ConfigureContentful(services);
+            ConfigureRetryHandling(services);
+
+            AddMappers(services);
+            AddMessageRetryHandler(services);
+        }
+
+        private static void ConfigureRetryHandling(IServiceCollection services)
+        {
+            services.AddOptions<MessageRetryHandlingOptions>()
+                    .Configure<IConfiguration>((settings, configuration) =>
+                    {
+                        configuration.GetSection("MessageRetryHandlingOptions").Bind(settings);
+                    });
+        }
+
+        private static void ConfigureContentful(IServiceCollection services)
+        {
+            services.AddOptions<ContentfulOptions>()
+                    .Configure<IConfiguration>((settings, configuration) =>
+                    {
+                        configuration.GetSection("Contentful").Bind(settings);
+                    });
+        }
+
+        private static void ConfigureCaching(IServiceCollection services)
+        {
+            services.AddOptions<CacheRefreshConfiguration>()
+                    .Configure<IConfiguration>((settings, configuration) =>
+                    {
+                        configuration.GetSection("CacheClear").Bind(settings);
+                    });
+
             services.AddHttpClient<CacheHandler>()
                 .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler()
                 {
                     PooledConnectionLifetime = TimeSpan.FromMinutes(5)
                 });
+
             services.AddTransient<ICacheHandler, CacheHandler>();
-
-            services.AddOptions<MessageRetryHandlingOptions>()
-                .Configure<IConfiguration>((settings, configuration) =>
-                {
-                    configuration.GetSection("MessageRetryHandlingOptions").Bind(settings);
-                });
-
-            AddMappers(services);
-            AddMessageRetryHandler(services);
         }
 
         /// <summary>

--- a/src/Dfe.PlanTech.Domain/Persistence/Models/CacheRefreshConfiguration.cs
+++ b/src/Dfe.PlanTech.Domain/Persistence/Models/CacheRefreshConfiguration.cs
@@ -1,3 +1,9 @@
 namespace Dfe.PlanTech.Domain.Persistence.Models;
 
-public record CacheRefreshConfiguration(string? Endpoint, string? ApiKeyName, string? ApiKeyValue);
+public record CacheRefreshConfiguration(string? Endpoint, string? ApiKeyName, string? ApiKeyValue)
+{
+  public CacheRefreshConfiguration() : this(null, null, null)
+  {
+
+  }
+}

--- a/src/Dfe.PlanTech.Domain/Persistence/Models/CacheRefreshConfiguration.cs
+++ b/src/Dfe.PlanTech.Domain/Persistence/Models/CacheRefreshConfiguration.cs
@@ -2,8 +2,8 @@ namespace Dfe.PlanTech.Domain.Persistence.Models;
 
 public record CacheRefreshConfiguration(string? Endpoint, string? ApiKeyName, string? ApiKeyValue)
 {
-  public CacheRefreshConfiguration() : this(null, null, null)
-  {
+    public CacheRefreshConfiguration() : this(null, null, null)
+    {
 
-  }
+    }
 }

--- a/src/Dfe.PlanTech.Domain/Persistence/Models/ContentfulOptions.cs
+++ b/src/Dfe.PlanTech.Domain/Persistence/Models/ContentfulOptions.cs
@@ -1,3 +1,8 @@
 namespace Dfe.PlanTech.Domain.Persistence.Models;
 
-public record ContentfulOptions(bool UsePreview);
+public record ContentfulOptions(bool UsePreview)
+{
+  public ContentfulOptions() : this(false)
+  {
+  }
+}

--- a/src/Dfe.PlanTech.Domain/Persistence/Models/ContentfulOptions.cs
+++ b/src/Dfe.PlanTech.Domain/Persistence/Models/ContentfulOptions.cs
@@ -2,7 +2,7 @@ namespace Dfe.PlanTech.Domain.Persistence.Models;
 
 public record ContentfulOptions(bool UsePreview)
 {
-  public ContentfulOptions() : this(false)
-  {
-  }
+    public ContentfulOptions() : this(false)
+    {
+    }
 }

--- a/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
@@ -7,6 +7,7 @@ using Dfe.PlanTech.Domain.Persistence.Models;
 using Dfe.PlanTech.Domain.Questionnaire.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Options;
 
 namespace Dfe.PlanTech.Infrastructure.Data;
 
@@ -122,7 +123,9 @@ public class CmsDbContext : DbContext, ICmsDbContext
 
     public CmsDbContext(DbContextOptions<CmsDbContext> options) : base(options)
     {
-        _contentfulOptions = this.GetService<ContentfulOptions>();
+        _contentfulOptions = this.GetService<ContentfulOptions>() ??
+                                this.GetService<IOptions<ContentfulOptions>>()?.Value ??
+                                throw new Exception($"Couldn't find required service {typeof(CmsDbContext).Name}");
     }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)


### PR DESCRIPTION
## Overview

Addresses ticket #222301.

Amends the Azure Function App to retrieve secrets from the Key Vault directly, by adding the Azure Key Vault IConfiguration provider.

## Changes

### Major

- Add Key Vault IConfiguration provider to the Function App

### Minor

- Amends a couple of configuration/option classes to use the [options pattern](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/options?view=aspnetcore-8.0) where appropriate.
    - Whilst this isn't needed, it simplifies the process with injecting these classes, especially when the appropriate secrets already follow the correct _naming_ convention required.

### Other

- Adds initial `README.md` to the project, which needs to be expanded in future.

## How to review the PR

1. Ensure that you can access the Key Vault locally.
    1. You will need to be logged in with a user with appropriate permissions
    2. The Key Vault will need to be set to allow public network access from set virtual networks and public IP addresses
    3. You will need to add your IP address to the whitelist
2. Add `Key_Vault_Name` to your `local.settings.json`
3. Run the function app. If it reads and saves from the database like normal, then it is working as intended.

## Release requirements

None

## Checklist

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [x] Documentation has been updated where relevant