### PR TITLE
Feat: Allow incomplete content in database

### DIFF
--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240806_1500_MakeContentColumnsNullable.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240806_1500_MakeContentColumnsNullable.sql
@@ -21,8 +21,6 @@ ALTER TABLE Contentful.[Answers] ALTER COLUMN [Maturity] NVARCHAR(MAX) NULL;
 ALTER TABLE Contentful.[RecommendationIntros] ALTER COLUMN [Maturity] NVARCHAR(40) NULL;
 ALTER TABLE Contentful.[RecommendationIntros] ALTER COLUMN [Slug] NVARCHAR(MAX) NULL;
 ALTER TABLE Contentful.[PageContents] ALTER COLUMN [PageId] NVARCHAR(30) NULL;
-ALTER TABLE Contentful.[Textareas] ALTER COLUMN [Label] NVARCHAR(256) NULL;
-ALTER TABLE Contentful.[Textareas] ALTER COLUMN [Readonly] BIT NULL;
 ALTER TABLE Contentful.[Buttons] ALTER COLUMN [Value] NVARCHAR(MAX) NULL;
 ALTER TABLE Contentful.[Buttons] ALTER COLUMN [IsStartButton] BIT NULL;
 ALTER TABLE Contentful.[Headers] ALTER COLUMN [Text] NVARCHAR(MAX) NULL;

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240806_1500_MakeContentColumnsNullable.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240806_1500_MakeContentColumnsNullable.sql
@@ -1,0 +1,67 @@
+ALTER TABLE Contentful.[Sections] DROP CONSTRAINT FK_Sections_Pages_InterstitialPageId;
+ALTER TABLE Contentful.[Warnings] DROP CONSTRAINT FK_Warnings_TextBodies_TextId;
+ALTER TABLE Contentful.[PageContents] DROP CONSTRAINT FK_PageContents_Pages_PageId;
+ALTER TABLE Contentful.[ComponentDropDowns] DROP CONSTRAINT FK_ComponentDropDowns_RichTextContents_RichTextContentId;
+ALTER TABLE Contentful.[TextBodies] DROP CONSTRAINT FK_TextBodies_RichTextContents_RichTextId;
+GO
+
+DROP INDEX IX_Sections_InterstitialPageId ON Contentful.[Sections]
+DROP INDEX IX_Warnings_TextId ON Contentful.[Warnings]
+DROP INDEX IX_PageContents_BeforeContentComponentId_PageId ON Contentful.[PageContents]
+DROP INDEX IX_ComponentDropDowns_RichTextContentId ON Contentful.[ComponentDropDowns]
+DROP INDEX IX_TextBodies_RichTextId ON Contentful.[TextBodies]
+GO
+
+ALTER TABLE Contentful.[Sections] ALTER COLUMN [InterstitialPageId] NVARCHAR(30) NULL;
+ALTER TABLE Contentful.[Warnings] ALTER COLUMN [TextId] NVARCHAR(30) NULL;
+ALTER TABLE Contentful.[Questions] ALTER COLUMN [Text] NVARCHAR(MAX) NULL;
+ALTER TABLE Contentful.[Questions] ALTER COLUMN [Slug] NVARCHAR(MAX) NULL;
+ALTER TABLE Contentful.[Answers] ALTER COLUMN [Text] NVARCHAR(MAX) NULL;
+ALTER TABLE Contentful.[Answers] ALTER COLUMN [Maturity] NVARCHAR(MAX) NULL;
+ALTER TABLE Contentful.[RecommendationIntros] ALTER COLUMN [Maturity] NVARCHAR(40) NULL;
+ALTER TABLE Contentful.[RecommendationIntros] ALTER COLUMN [Slug] NVARCHAR(MAX) NULL;
+ALTER TABLE Contentful.[PageContents] ALTER COLUMN [PageId] NVARCHAR(30) NULL;
+ALTER TABLE Contentful.[Textareas] ALTER COLUMN [Label] NVARCHAR(256) NULL;
+ALTER TABLE Contentful.[Textareas] ALTER COLUMN [Readonly] BIT NULL;
+ALTER TABLE Contentful.[Buttons] ALTER COLUMN [Value] NVARCHAR(MAX) NULL;
+ALTER TABLE Contentful.[Buttons] ALTER COLUMN [IsStartButton] BIT NULL;
+ALTER TABLE Contentful.[Headers] ALTER COLUMN [Text] NVARCHAR(MAX) NULL;
+ALTER TABLE Contentful.[Headers] ALTER COLUMN [Tag] INT NULL;
+ALTER TABLE Contentful.[Headers] ALTER COLUMN [Size] INT NULL;
+ALTER TABLE Contentful.[InsetTexts] ALTER COLUMN [Text] NVARCHAR(MAX) NULL;
+ALTER TABLE Contentful.[NavigationLink] ALTER COLUMN [DisplayText] NVARCHAR(MAX) NULL;
+ALTER TABLE Contentful.[NavigationLink] ALTER COLUMN [Href] NVARCHAR(MAX) NULL;
+ALTER TABLE Contentful.[NavigationLink] ALTER COLUMN [OpenInNewTab] BIT NULL;
+ALTER TABLE Contentful.[ButtonWithLinks] ALTER COLUMN [Href] NVARCHAR(MAX) NULL;
+ALTER TABLE Contentful.[Titles] ALTER COLUMN [Text] NVARCHAR(MAX) NULL;
+ALTER TABLE Contentful.[Categories] ALTER COLUMN [InternalName] NVARCHAR(MAX) NULL;
+ALTER TABLE Contentful.[RichTextContents] ALTER COLUMN [Value] NVARCHAR(MAX) NULL;
+ALTER TABLE Contentful.[RichTextContents] ALTER COLUMN [NodeType] NVARCHAR(MAX) NULL;
+ALTER TABLE Contentful.[Pages] ALTER COLUMN [InternalName] NVARCHAR(MAX) NULL;
+ALTER TABLE Contentful.[Pages] ALTER COLUMN [Slug] NVARCHAR(MAX) NULL;
+ALTER TABLE Contentful.[Pages] ALTER COLUMN [DisplayBackButton] BIT NULL;
+ALTER TABLE Contentful.[Pages] ALTER COLUMN [DisplayHomeButton] BIT NULL;
+ALTER TABLE Contentful.[Pages] ALTER COLUMN [DisplayTopicTitle] BIT NULL;
+ALTER TABLE Contentful.[Pages] ALTER COLUMN [DisplayOrganisationName] BIT NULL;
+ALTER TABLE Contentful.[Pages] ALTER COLUMN [RequiresAuthorisation] BIT NULL;
+ALTER TABLE Contentful.[CSLinks] ALTER COLUMN [LinkText] NVARCHAR(256) NULL;
+ALTER TABLE Contentful.[CSLinks] ALTER COLUMN [Url] NVARCHAR(256) NULL;
+ALTER TABLE Contentful.[ComponentDropDowns] ALTER COLUMN [Title] NVARCHAR(MAX) NULL;
+ALTER TABLE Contentful.[ComponentDropDowns] ALTER COLUMN [RichTextContentId] BIGINT NULL;
+ALTER TABLE Contentful.[RichTextMarkDbEntity] ALTER COLUMN [Type] NVARCHAR(MAX) NULL;
+ALTER TABLE Contentful.[TextBodies] ALTER COLUMN [RichTextId] BIGINT NULL;
+GO
+
+CREATE UNIQUE INDEX IX_Sections_InterstitialPageId On Contentful.[Sections](InterstitialPageId) WHERE [InterstitialPageId] IS NOT NULL;
+CREATE INDEX IX_Warnings_TextId On Contentful.[Warnings](TextId);
+CREATE INDEX IX_PageContents_BeforeContentComponentId_PageId On Contentful.[PageContents] (BeforeContentComponentId) include (PageId)
+CREATE UNIQUE INDEX IX_ComponentDropDowns_RichTextContentId On Contentful.[ComponentDropDowns](RichTextContentId) WHERE [RichTextContentId] IS NOT NULL;
+CREATE INDEX IX_TextBodies_RichTextId On Contentful.[TextBodies](RichTextId);
+GO
+
+ALTER TABLE Contentful.[Sections] ADD CONSTRAINT FK_Sections_Pages_InterstitialPageId FOREIGN KEY (InterstitialPageId) REFERENCES Contentful.Pages(Id);
+ALTER TABLE Contentful.[Warnings] ADD CONSTRAINT FK_Warnings_TextBodies_TextId FOREIGN KEY (TextId) REFERENCES Contentful.TextBodies(Id);
+ALTER TABLE Contentful.[PageContents] ADD CONSTRAINT FK_PageContents_Pages_PageId FOREIGN KEY (PageId) REFERENCES Contentful.Pages(Id);
+ALTER TABLE Contentful.[ComponentDropDowns] ADD CONSTRAINT FK_ComponentDropDowns_RichTextContents_RichTextContentId FOREIGN KEY (RichTextContentId) REFERENCES Contentful.RichTextContents(Id) ON DELETE CASCADE;
+ALTER TABLE Contentful.[TextBodies] ADD CONSTRAINT FK_TextBodies_RichTextContents_RichTextId FOREIGN KEY (RichTextId) REFERENCES Contentful.RichTextContents(Id) ON DELETE CASCADE;
+GO

--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/IButton.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/IButton.cs
@@ -8,7 +8,7 @@ public interface IButton
     /// <summary>
     /// Text value of the button
     /// </summary>
-    public string Value { get; }
+    public string? Value { get; }
 
     /// <summary>
     /// Whether this button is a start button or not; see GDS button for information

--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/IButtonWithLink.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/IButtonWithLink.cs
@@ -8,7 +8,7 @@ public interface IButtonWithLink
     /// <summary>
     /// HREF for the button - the URL where it should link to
     /// </summary>
-    public string Href { get; }
+    public string? Href { get; }
 }
 
 public interface IButtonWithLink<out TButton> : IButtonWithLink

--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/IComponentDropDown.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/IComponentDropDown.cs
@@ -8,7 +8,7 @@ public interface IComponentDropDown
     /// <summary>
     /// The title to display.
     /// </summary>
-    public string Title { get; }
+    public string? Title { get; }
 }
 
 public interface IComponentDropDown<out TContent> : IComponentDropDown
@@ -18,5 +18,5 @@ where TContent : IRichTextContent
     /// <summary>
     /// The Content to display.
     /// </summary>
-    public TContent Content { get; }
+    public TContent? Content { get; }
 }

--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/IHasRichText.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/IHasRichText.cs
@@ -4,6 +4,6 @@ namespace Dfe.PlanTech.Domain.Content.Interfaces;
 
 public interface IHasRichText
 {
-    public RichTextContentDbEntity RichText { get; set; }
-    public long RichTextId { get; }
+    public RichTextContentDbEntity? RichText { get; set; }
+    public long? RichTextId { get; }
 }

--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/IHasSlug.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/IHasSlug.cs
@@ -2,5 +2,5 @@ namespace Dfe.PlanTech.Domain.Content.Interfaces;
 
 public interface IHasSlug
 {
-    public string Slug { get; set; }
+    public string? Slug { get; set; }
 }

--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/IHeader.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/IHeader.cs
@@ -10,15 +10,15 @@ public interface IHeader
     /// <summary>
     /// The text to display
     /// </summary>
-    public string Text { get; }
+    public string? Text { get; }
 
     /// <summary>
     /// What tag should be used for header (e.g. H1, H2, etc.)
     /// </summary>
-    public HeaderTag Tag { get; }
+    public HeaderTag? Tag { get; }
 
     /// <summary>
     /// Actual size of header to use (for accessibility)
     /// </summary>
-    public HeaderSize Size { get; }
+    public HeaderSize? Size { get; }
 }

--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/IInsetText.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/IInsetText.cs
@@ -8,5 +8,5 @@ public interface IInsetText
     /// <summary>
     /// The body of the component
     /// </summary>
-    public string Text { get; }
+    public string? Text { get; }
 }

--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/INavigationLink.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/INavigationLink.cs
@@ -11,12 +11,12 @@ public interface INavigationLink
     /// <summary>
     /// Display text (i.e. <a>{DisplayText}</a>)
     /// </summary>
-    public string DisplayText { get; set; }
+    public string? DisplayText { get; set; }
 
     /// <summary>
     /// Href value (i.e. <a href="{Href}"></a>)
     /// </summary>
-    public string Href { get; set; }
+    public string? Href { get; set; }
 
     /// <summary>
     /// Should this link open in a new tab?

--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/IPage.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/IPage.cs
@@ -4,9 +4,9 @@ namespace Dfe.PlanTech.Domain.Content.Interfaces;
 
 public interface IPage
 {
-    public string InternalName { get; }
+    public string? InternalName { get; }
 
-    public string Slug { get; }
+    public string? Slug { get; }
 
     public bool DisplayBackButton { get; }
 

--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/ITextBody.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/ITextBody.cs
@@ -10,5 +10,5 @@ public interface ITextBody
 public interface ITextBody<out TContent> : ITextBody
 where TContent : IRichTextContent
 {
-    public TContent RichText { get; }
+    public TContent? RichText { get; }
 }

--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/ITitle.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/ITitle.cs
@@ -2,5 +2,5 @@ namespace Dfe.PlanTech.Domain.Content.Interfaces;
 
 public interface ITitle
 {
-    public string Text { get; }
+    public string? Text { get; }
 }

--- a/src/Dfe.PlanTech.Domain/Content/Models/Buttons/Button.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/Buttons/Button.cs
@@ -4,7 +4,7 @@ namespace Dfe.PlanTech.Domain.Content.Models.Buttons;
 
 public class Button : ContentComponent, IButton
 {
-    public string Value { get; init; } = null!;
+    public string? Value { get; init; }
 
     public bool IsStartButton { get; init; }
 }

--- a/src/Dfe.PlanTech.Domain/Content/Models/Buttons/ButtonDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/Buttons/ButtonDbEntity.cs
@@ -4,7 +4,7 @@ namespace Dfe.PlanTech.Domain.Content.Models.Buttons;
 
 public class ButtonDbEntity : ContentComponentDbEntity, IButton
 {
-    public string Value { get; set; } = null!;
+    public string? Value { get; set; }
 
     public bool IsStartButton { get; set; }
 }

--- a/src/Dfe.PlanTech.Domain/Content/Models/Buttons/ButtonWithLinkDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/Buttons/ButtonWithLinkDbEntity.cs
@@ -3,7 +3,7 @@ using Dfe.PlanTech.Domain.Content.Interfaces;
 namespace Dfe.PlanTech.Domain.Content.Models.Buttons;
 
 /// <summary>
-/// Class for the table for the <see cref="ButtonWithLink"/> button that links somewhere 
+/// Class for the table for the <see cref="ButtonWithLink"/> button that links somewhere
 /// </summary>
 /// <inheritdoc/>
 public class ButtonWithLinkDbEntity : ContentComponentDbEntity, IButtonWithLink<ButtonDbEntity>
@@ -13,5 +13,5 @@ public class ButtonWithLinkDbEntity : ContentComponentDbEntity, IButtonWithLink<
 
     public string ButtonId { get; set; } = null!;
 
-    public string Href { get; set; } = null!;
+    public string? Href { get; set; }
 }

--- a/src/Dfe.PlanTech.Domain/Content/Models/ComponentDropDown.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/ComponentDropDown.cs
@@ -8,7 +8,7 @@ namespace Dfe.PlanTech.Domain.Content.Models;
 /// <inheritdoc/>
 public class ComponentDropDown : ContentComponent, IComponentDropDown<RichTextContent>
 {
-    public string Title { get; set; } = null!;
+    public string? Title { get; set; }
 
-    public RichTextContent Content { get; set; } = null!;
+    public RichTextContent? Content { get; set; }
 }

--- a/src/Dfe.PlanTech.Domain/Content/Models/ComponentDropDownDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/ComponentDropDownDbEntity.cs
@@ -11,13 +11,13 @@ public class ComponentDropDownDbEntity : ContentComponentDbEntity, IComponentDro
     /// <summary>
     /// The title to display.
     /// </summary>
-    public string Title { get; set; } = null!;
+    public string? Title { get; set; } = null!;
 
-    [ForeignKey("RichTextContentId")]
     /// <summary>
     /// The Content to display.
     /// </summary>
-    public RichTextContentDbEntity Content { get; set; } = null!;
+    [ForeignKey("RichTextContentId")]
+    public RichTextContentDbEntity? Content { get; set; }
 
-    public long RichTextContentId { get; set; }
+    public long? RichTextContentId { get; set; }
 }

--- a/src/Dfe.PlanTech.Domain/Content/Models/Header.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/Header.cs
@@ -11,7 +11,7 @@ public class Header : ContentComponent, IHeader
 {
     public string Text { get; init; } = null!;
 
-    public HeaderTag Tag { get; init; }
+    public HeaderTag? Tag { get; init; }
 
-    public HeaderSize Size { get; init; }
+    public HeaderSize? Size { get; init; }
 }

--- a/src/Dfe.PlanTech.Domain/Content/Models/HeaderDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/HeaderDbEntity.cs
@@ -9,9 +9,9 @@ namespace Dfe.PlanTech.Domain.Content.Models;
 /// <inheritdoc/>
 public class HeaderDbEntity : ContentComponentDbEntity, IHeader
 {
-    public string Text { get; set; } = null!;
+    public string? Text { get; set; }
 
-    public HeaderTag Tag { get; set; }
+    public HeaderTag? Tag { get; set; }
 
-    public HeaderSize Size { get; set; }
+    public HeaderSize? Size { get; set; }
 }

--- a/src/Dfe.PlanTech.Domain/Content/Models/InsetText.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/InsetText.cs
@@ -8,5 +8,5 @@ namespace Dfe.PlanTech.Domain.Content.Models;
 /// <inheritdoc/>
 public class InsetText : ContentComponent, IInsetText
 {
-    public string Text { get; init; } = null!;
+    public string? Text { get; init; }
 }

--- a/src/Dfe.PlanTech.Domain/Content/Models/InsetTextDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/InsetTextDbEntity.cs
@@ -8,5 +8,5 @@ namespace Dfe.PlanTech.Domain.Content.Models;
 /// <inheritdoc/>
 public class InsetTextDbEntity : ContentComponentDbEntity, IInsetText
 {
-    public string Text { get; init; } = null!;
+    public string? Text { get; init; }
 }

--- a/src/Dfe.PlanTech.Domain/Content/Models/NavigationLink.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/NavigationLink.cs
@@ -13,12 +13,12 @@ public class NavigationLink : ContentComponent, INavigationLink
     /// <summary>
     /// Display text (i.e. <a>{DisplayText}</a>)
     /// </summary>
-    public string DisplayText { get; set; } = null!;
+    public string? DisplayText { get; set; }
 
     /// <summary>
     /// Href value (i.e. <a href="{Href}"></a>)
     /// </summary>
-    public string Href { get; set; } = null!;
+    public string? Href { get; set; }
 
     /// <summary>
     /// Should this link open in a new tab?

--- a/src/Dfe.PlanTech.Domain/Content/Models/NavigationLinkDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/NavigationLinkDbEntity.cs
@@ -13,12 +13,12 @@ public class NavigationLinkDbEntity : ContentComponentDbEntity, INavigationLink
     /// <summary>
     /// Display text (i.e. <a>{DisplayText}</a>)
     /// </summary>
-    public string DisplayText { get; set; } = null!;
+    public string? DisplayText { get; set; }
 
     /// <summary>
     /// Href value (i.e. <a href="{Href}"></a>)
     /// </summary>
-    public string Href { get; set; } = null!;
+    public string? Href { get; set; }
 
     /// <summary>
     /// Should this link open in a new tab?

--- a/src/Dfe.PlanTech.Domain/Content/Models/Page.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/Page.cs
@@ -4,9 +4,9 @@ namespace Dfe.PlanTech.Domain.Content.Models;
 
 public class Page : ContentComponent, IPageContent
 {
-    public string InternalName { get; init; } = null!;
+    public string? InternalName { get; init; }
 
-    public string Slug { get; init; } = null!;
+    public string? Slug { get; init; }
 
     public bool DisplayBackButton { get; init; }
 

--- a/src/Dfe.PlanTech.Domain/Content/Models/PageContentDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/PageContentDbEntity.cs
@@ -9,7 +9,7 @@ public class PageContentDbEntity
     [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
     public long Id { get; set; }
 
-    public string PageId { get; set; } = null!;
+    public string? PageId { get; set; }
     public PageDbEntity Page { get; set; } = null!;
 
     public string? ContentComponentId { get; set; }

--- a/src/Dfe.PlanTech.Domain/Content/Models/PageDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/PageDbEntity.cs
@@ -6,9 +6,9 @@ namespace Dfe.PlanTech.Domain.Content.Models;
 
 public class PageDbEntity : ContentComponentDbEntity, IPage<ContentComponentDbEntity, TitleDbEntity>, IHasSlug
 {
-    public string InternalName { get; set; } = null!;
+    public string? InternalName { get; set; }
 
-    public string Slug { get; set; } = null!;
+    public string? Slug { get; set; }
 
     public bool DisplayBackButton { get; set; }
 
@@ -37,7 +37,7 @@ public class PageDbEntity : ContentComponentDbEntity, IPage<ContentComponentDbEn
     public SectionDbEntity? Section { get; set; }
 
     /// <summary>
-    /// Combined joins for <see cref="Content"/> and <see cref="BeforeTitleContent"/> 
+    /// Combined joins for <see cref="Content"/> and <see cref="BeforeTitleContent"/>
     /// </summary>
     [DontCopyValue]
     public List<PageContentDbEntity> AllPageContents { get; set; } = [];

--- a/src/Dfe.PlanTech.Domain/Content/Models/TextBodyDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/TextBodyDbEntity.cs
@@ -9,9 +9,9 @@ namespace Dfe.PlanTech.Domain.Content.Models;
 /// <inheritdoc/>
 public class TextBodyDbEntity : ContentComponentDbEntity, ITextBody<RichTextContentDbEntity>, IHasRichText
 {
-    public RichTextContentDbEntity RichText { get; set; } = null!;
+    public RichTextContentDbEntity? RichText { get; set; }
 
-    public long RichTextId { get; set; }
+    public long? RichTextId { get; set; }
 
     public List<WarningComponentDbEntity> Warnings { get; set; } = new();
 }

--- a/src/Dfe.PlanTech.Domain/Content/Models/TitleDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/TitleDbEntity.cs
@@ -7,7 +7,7 @@ namespace Dfe.PlanTech.Domain.Content.Models;
 /// </summary>
 public class TitleDbEntity : ContentComponentDbEntity, ITitle
 {
-    public string Text { get; set; } = null!;
+    public string? Text { get; set; }
 
     public List<PageDbEntity> Pages { get; set; } = new();
 }

--- a/src/Dfe.PlanTech.Domain/Content/Models/WarningComponentDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/WarningComponentDbEntity.cs
@@ -5,20 +5,24 @@ namespace Dfe.PlanTech.Domain.Content.Models;
 
 public class WarningComponentDbEntity : ContentComponentDbEntity, IWarningComponent<TextBodyDbEntity>, IHasRichText
 {
-    public string TextId { get; set; } = null!;
-    public TextBodyDbEntity Text { get; set; } = null!;
+    public string? TextId { get; set; }
+    public TextBodyDbEntity? Text { get; set; }
 
     [NotMapped]
     [DontCopyValue]
-    public RichTextContentDbEntity RichText
+    public RichTextContentDbEntity? RichText
     {
-        get => Text.RichText;
-        set => Text.RichText = value;
+        get => Text?.RichText;
+        set
+        {
+            if (Text != null && value != null)
+                Text.RichText = value;
+        }
     }
 
     [NotMapped]
     [DontCopyValue]
-    public long RichTextId => Text.RichTextId;
+    public long? RichTextId => Text?.RichTextId;
 }
 
 public interface IRichTextContentWithPageSlug : IHasRichText

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IAnswer.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IAnswer.cs
@@ -2,9 +2,9 @@ namespace Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
 public interface IAnswer
 {
-    public string Text { get; }
+    public string? Text { get; }
 
-    public string Maturity { get; }
+    public string? Maturity { get; }
 }
 
 

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/ICSLink.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/ICSLink.cs
@@ -2,7 +2,7 @@ namespace Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
 public interface ICSLink
 {
-    public string Url { get; }
+    public string? Url { get; }
 
-    public string LinkText { get; }
+    public string? LinkText { get; }
 }

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IQuestion.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IQuestion.cs
@@ -2,11 +2,11 @@ namespace Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
 public interface IQuestion
 {
-    public string Text { get; }
+    public string? Text { get; }
 
     public string? HelpText { get; }
 
-    public string Slug { get; }
+    public string? Slug { get; }
 }
 
 public interface IQuestion<TAnswer> : IQuestion

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationIntro.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationIntro.cs
@@ -4,7 +4,7 @@ namespace Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
 public interface IRecommendationIntro
 {
-    public string Maturity { get; }
+    public string? Maturity { get; }
 }
 
 public interface IRecommendationIntro<THeader, TContentComponent> : IRecommendationIntro

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/AnswerDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/AnswerDbEntity.cs
@@ -5,14 +5,14 @@ namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
 public class AnswerDbEntity : ContentComponentDbEntity, IAnswer<QuestionDbEntity>
 {
-    public string Text { get; set; } = null!;
+    public string? Text { get; set; }
 
     public string? NextQuestionId { get; set; }
 
     [DontCopyValue]
     public QuestionDbEntity? NextQuestion { get; set; }
 
-    public string Maturity { get; set; } = null!;
+    public string? Maturity { get; set; }
 
     [DontCopyValue]
     public string? ParentQuestionId { get; set; }

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/CSLinkDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/CSLinkDbEntity.cs
@@ -5,7 +5,7 @@ namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
 public class CSLinkDbEntity : ContentComponentDbEntity, ICSLink
 {
-    public string Url { get; set; } = null!;
+    public string? Url { get; set; } = null!;
 
-    public string LinkText { get; set; } = null!;
+    public string? LinkText { get; set; } = null!;
 }

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/CategoryDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/CategoryDbEntity.cs
@@ -10,7 +10,7 @@ public class CategoryDbEntity : ContentComponentDbEntity, ICategory<HeaderDbEnti
     [DontCopyValue]
     public HeaderDbEntity Header { get; set; } = null!;
 
-    public string InternalName { get; set; } = null!;
+    public string? InternalName { get; set; }
 
     [DontCopyValue]
     public List<SectionDbEntity> Sections { get; set; } = [];

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/Question.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/Question.cs
@@ -8,7 +8,7 @@ public class Question : ContentComponent, IQuestion<Answer>
     /// <summary>
     /// Actual question text
     /// </summary>
-    public string Text { get; init; } = null!;
+    public string? Text { get; init; }
 
     /// <summary>
     /// Optional help text
@@ -17,5 +17,5 @@ public class Question : ContentComponent, IQuestion<Answer>
 
     public List<Answer> Answers { get; init; } = new();
 
-    public string Slug { get; set; } = null!;
+    public string? Slug { get; set; }
 }

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/QuestionDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/QuestionDbEntity.cs
@@ -6,14 +6,14 @@ namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
 public class QuestionDbEntity : ContentComponentDbEntity, IQuestion<AnswerDbEntity>, IHasSlug
 {
-    public string Text { get; set; } = null!;
+    public string? Text { get; set; }
 
     public string? HelpText { get; set; }
 
     [DontCopyValue]
     public List<AnswerDbEntity> Answers { get; set; } = [];
 
-    public string Slug { get; set; } = null!;
+    public string? Slug { get; set; }
 
     [DontCopyValue]
     public List<AnswerDbEntity> PreviousAnswers { get; set; } = [];

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationIntro.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationIntro.cs
@@ -6,11 +6,11 @@ namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
 public class RecommendationIntro : ContentComponent, IRecommendationIntro<Header, ContentComponent>, IHeaderWithContent
 {
-    public string Slug { get; init; } = null!;
+    public string? Slug { get; init; }
 
     public Header Header { get; init; } = null!;
 
-    public string Maturity { get; init; } = null!;
+    public string? Maturity { get; init; }
 
     [NotMapped]
     public List<ContentComponent> Content { get; init; } = [];

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationIntroDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationIntroDbEntity.cs
@@ -5,13 +5,13 @@ namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
 public class RecommendationIntroDbEntity : ContentComponentDbEntity, IRecommendationIntro<HeaderDbEntity, ContentComponentDbEntity>
 {
-    public string Slug { get; init; } = null!;
+    public string? Slug { get; init; }
 
     public string HeaderId { get; set; } = null!;
 
     public HeaderDbEntity Header { get; init; } = null!;
 
-    public string Maturity { get; init; } = null!;
+    public string? Maturity { get; init; }
 
 
     [DontCopyValue]

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/Section.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/Section.cs
@@ -14,7 +14,7 @@ public class Section : ContentComponent, ISectionComponent
 
     public string FirstQuestionId => Questions.Select(question => question.Sys.Id).FirstOrDefault() ?? "";
 
-    public Page InterstitialPage { get; init; } = null!;
+    public Page? InterstitialPage { get; init; }
 
     public IEnumerable<QuestionWithAnswer> GetOrderedResponsesForJourney(IEnumerable<QuestionWithAnswer> responses)
     {

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/SectionDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/SectionDbEntity.cs
@@ -4,7 +4,7 @@ using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
 /// <summary>
-/// Class for the <see cref="Section"/> table in the database 
+/// Class for the <see cref="Section"/> table in the database
 /// </summary>
 public class SectionDbEntity : ContentComponentDbEntity, ISection<QuestionDbEntity, PageDbEntity>
 {
@@ -14,9 +14,9 @@ public class SectionDbEntity : ContentComponentDbEntity, ISection<QuestionDbEnti
     public List<QuestionDbEntity> Questions { get; set; } = [];
 
     [DontCopyValue]
-    public PageDbEntity InterstitialPage { get; set; } = null!;
+    public PageDbEntity? InterstitialPage { get; set; }
 
-    public string InterstitialPageId { get; set; } = null!;
+    public string? InterstitialPageId { get; set; }
 
     [DontCopyValue]
     public CategoryDbEntity? Category { get; set; }

--- a/tests/Dfe.PlanTech.CmsDbDataValidator/Comparators/BaseComparator.cs
+++ b/tests/Dfe.PlanTech.CmsDbDataValidator/Comparators/BaseComparator.cs
@@ -275,7 +275,7 @@ public abstract class BaseComparator(CmsDbContext db, ContentfulContent contentf
         }
     }
 
-    public DataValidationError? ValidateEnumValue<TEnum, TDbEntity>(JsonNode contentfulEntry, string key, TDbEntity dbEntry, TEnum dbValue)
+    public DataValidationError? ValidateEnumValue<TEnum, TDbEntity>(JsonNode contentfulEntry, string key, TDbEntity? dbEntry, TEnum? dbValue)
       where TEnum : struct, Enum
       where TDbEntity : ContentComponentDbEntity
     {


### PR DESCRIPTION
## Overview

Addresses ticket [#220759](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/220759)

Supports having invalid/incomplete content held in the database to mitigate contentful relationships not coming through

## Changes

### Major

- Makes all non-nullable non-primary key columns nullable
- Updates the DbEntity and Model classes related to each change

## How to review the PR

- Disable the Azure function in dev (& let dev team know) 
- Run it locally
- Change your `appsettings.json` in the Web project and set the `UsePreview` option under the contentful settings to true
- Change your `local.settings.json` in the AzureFunctions project and set `Contentful__UsePreview` to true
- Create or edit content in the dev environment that is invalid due to missing fields
- Verify that it makes it into the database (can check in db directly)
- Check the app behaves as would be expected
  - It doesn't break existing complete content
  - ? open to opinions, it might show an error page if you're trying to look at a totally invalid page, but, I think this is OK
- *THEN* set usepreview in web to false
- Make sure that no matter how much invalid content is in the db, nothing in `UsePreview=false` dev is broken

## Additional notes

- The SQL script is very easy to revert, all the `NULL`s can just be replaced with `NOT NULL` 
- To test locally I generated a script of the whole contentful schema before and after applying it, only changes were the nullability of columns
- Will need a documentation update as its a change to many tables

## Checklist

- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch
- [ ] Documentation has been updated where relevant
