### PR TITLE
feat(tf): Virtual network setup 

### DIFF
--- a/.github/workflows/deploy-azure-function.yml
+++ b/.github/workflows/deploy-azure-function.yml
@@ -42,6 +42,11 @@ jobs:
           az_client_id: ${{ secrets.AZ_CLIENT_ID }}
           az_client_secret: ${{ secrets.AZ_CLIENT_SECRET }}
 
+      - name: Set storage account name var
+        shell: bash
+        run: echo "STORAGE_ACCOUNT=$(echo ${{ env.AZURE_STORAGEACCOUNT_NAME }} | sed -e "s/-//g")" >> $GITHUB_ENV
+          
+
       - name: Get workflow IP address
         id: whats-my-ip
         uses: ./.github/actions/whats-my-ip-address
@@ -51,8 +56,9 @@ jobs:
         # The Azure Storage Account's name contains no hyphens, unlike almost all of our other resources
         # Therefore remove hyphens from the string before using it as the account name
         run: |
+          az storage account update --name $STORAGE_ACCOUNT --resource-group ${{ env.AZURE_RESOURCEGROUP_NAME }} --public-network-access Enabled &> /dev/null
           az storage account network-rule add --resource-group ${{ env.AZURE_RESOURCEGROUP_NAME }} \
-                                              --account-name $(echo ${{ env.AZURE_STORAGEACCOUNT_NAME }} | sed -e "s/-//g") \
+                                              --account-name $STORAGE_ACCOUNT \
                                               --ip-address ${{ steps.whats-my-ip.outputs.ip }} &> /dev/null
 
       - name: Deploy Azure Function App
@@ -66,5 +72,6 @@ jobs:
         if: always()
         run: |
           az storage account network-rule remove --resource-group ${{ env.AZURE_RESOURCEGROUP_NAME }} \
-                                                 --account-name $(echo ${{ env.AZURE_STORAGEACCOUNT_NAME }} | sed -e "s/-//g") \
+                                                 --account-name $STORAGE_ACCOUNT \
                                                  --ip-address ${{ steps.whats-my-ip.outputs.ip }} &> /dev/null
+          az storage account update --name $STORAGE_ACCOUNT --resource-group ${{ env.AZURE_RESOURCEGROUP_NAME }} --public-network-access Disabled &> /dev/null

--- a/terraform/container-app/20240816-dev_plan_output.txt
+++ b/terraform/container-app/20240816-dev_plan_output.txt
@@ -1,0 +1,1037 @@
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+  ~ update in-place
+  - destroy
+-/+ destroy and then create replacement
+ <= read (data resources)
+
+Terraform will perform the following actions:
+
+  # azapi_resource.contentful_function will be created
+  + resource "azapi_resource" "contentful_function" {
+      + body                      = (sensitive value)
+      + id                        = (known after apply)
+      + ignore_casing             = false
+      + ignore_missing_property   = true
+      + location                  = "northeurope"
+      + name                      = "s190d01-plantechcontentfulfunction"
+      + output                    = (known after apply)
+      + parent_id                 = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech"
+      + removing_special_chars    = false
+      + schema_validation_enabled = false
+      + tags                      = {
+          + "Environment"      = "Dev"
+          + "Product"          = "Plan Technology for your School"
+          + "Service Offering" = "Plan Technology for your School"
+        }
+      + type                      = "Microsoft.Web/sites@2023-12-01"
+
+      + identity {
+          + identity_ids = [
+              + "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.ManagedIdentity/userAssignedIdentities/s190d01-plantech-mi",
+            ]
+          + principal_id = (known after apply)
+          + tenant_id    = (known after apply)
+          + type         = "UserAssigned"
+        }
+    }
+
+  # azurerm_app_service_connection.azurekeyvaultconnector will be destroyed
+  # (because azurerm_app_service_connection.azurekeyvaultconnector is not in configuration)
+   resource "azurerm_app_service_connection" "azurekeyvaultconnector" {
+       app_service_id     = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Web/sites/s190d01-plantechcontentfulfunction" -> null
+       client_type        = "dotnet" -> null
+       id                 = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Web/sites/s190d01-plantechcontentfulfunction/providers/Microsoft.ServiceLinker/linkers/azurekeyvaultconnection" -> null
+       name               = "azurekeyvaultconnection" -> null
+       target_resource_id = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.KeyVault/vaults/s190d01-plantech-kv" -> null
+
+       authentication {
+           client_id       = "e4d19ac5-d0c2-4151-ba7e-3ccbc8b5da29" -> null
+           subscription_id = "01ca3b42-9780-4628-806b-79279e3c7e89" -> null
+           type            = "userAssignedIdentity" -> null
+        }
+    }
+
+  # azurerm_app_service_connection.azuresqlconnector will be destroyed
+  # (because azurerm_app_service_connection.azuresqlconnector is not in configuration)
+   resource "azurerm_app_service_connection" "azuresqlconnector" {
+       app_service_id     = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Web/sites/s190d01-plantechcontentfulfunction" -> null
+       client_type        = "dotnet" -> null
+       id                 = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Web/sites/s190d01-plantechcontentfulfunction/providers/Microsoft.ServiceLinker/linkers/azuresqlconnection" -> null
+       name               = "azuresqlconnection" -> null
+       target_resource_id = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Sql/servers/s190d01-plantech/databases/s190d01-plantech-sqldb" -> null
+
+       authentication {
+           client_id       = "e4d19ac5-d0c2-4151-ba7e-3ccbc8b5da29" -> null
+           subscription_id = "01ca3b42-9780-4628-806b-79279e3c7e89" -> null
+           type            = "userAssignedIdentity" -> null
+        }
+    }
+
+  # azurerm_key_vault_access_policy.vault_access_policy_mi will be updated in-place
+  ~ resource "azurerm_key_vault_access_policy" "vault_access_policy_mi" {
+      ~ certificate_permissions = [
+           "Get",
+        ]
+        id                      = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.KeyVault/vaults/s190d01-plantech-kv/objectId/a2860d8c-4f4a-4261-8a5a-599277cb5752"
+      ~ key_permissions         = [
+          + "List",
+            "Get",
+          + "WrapKey",
+          + "UnwrapKey",
+        ]
+      ~ secret_permissions      = [
+          + "List",
+            "Get",
+        ]
+        # (4 unchanged attributes hidden)
+    }
+
+  # azurerm_linux_function_app.contentful_function will be destroyed
+  # (because azurerm_linux_function_app.contentful_function is not in configuration)
+   resource "azurerm_linux_function_app" "contentful_function" {
+       app_settings                                   = {
+           "AZURE_CLIENT_ID"                                         = "e4d19ac5-d0c2-4151-ba7e-3ccbc8b5da29"
+           "AZURE_KEYVAULT_AZUREKEYVAULTCONNECTION_CLIENTID"         = "e4d19ac5-d0c2-4151-ba7e-3ccbc8b5da29"
+           "AZURE_KEYVAULT_AZUREKEYVAULTCONNECTION_RESOURCEENDPOINT" = "https://s190d01-plantech-kv.vault.azure.net/"
+           "AZURE_KEYVAULT_AZUREKEYVAULTCONNECTION_SCOPE"            = "https://vault.azure.net/.default"
+           "AZURE_KEYVAULT_CLIENTID"                                 = "e4d19ac5-d0c2-4151-ba7e-3ccbc8b5da29"
+           "AZURE_KEYVAULT_RESOURCEENDPOINT"                         = "https://s190d01-plantech-kv.vault.azure.net/"
+           "AZURE_KEYVAULT_SCOPE"                                    = "https://vault.azure.net/.default"
+           "AZURE_SQL_AZURESQLCONNECTION_CONNECTIONSTRING"           = "Data Source=s190d01-plantech.database.windows.net,1433;Initial Catalog=s190d01-plantech-sqldb;User ID=e4d19ac5-d0c2-4151-ba7e-3ccbc8b5da29;Authentication=ActiveDirectoryManagedIdentity"
+           "AZURE_SQL_CONNECTIONSTRING"                              = "@Microsoft.KeyVault(VaultName=s190d01-plantech-kv;SecretName=connectionstrings--database)"
+           "AzureWebJobsServiceBus"                                  = (sensitive value)
+           "KeyVaultReferenceIdentity"                               = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.ManagedIdentity/userAssignedIdentities/s190d01-plantech-mi"
+           "WEBSITE_ENABLE_SYNC_UPDATE_SITE"                         = "true"
+           "WEBSITE_MOUNT_ENABLED"                                   = "1"
+           "WEBSITE_RUN_FROM_PACKAGE"                                = ""
+        } -> null
+       builtin_logging_enabled                        = true -> null
+       client_certificate_enabled                     = false -> null
+       client_certificate_mode                        = "Optional" -> null
+       content_share_force_disabled                   = false -> null
+       custom_domain_verification_id                  = (sensitive value) -> null
+       daily_memory_time_quota                        = 0 -> null
+       default_hostname                               = "s190d01-plantechcontentfulfunction.azurewebsites.net" -> null
+       enabled                                        = true -> null
+       ftp_publish_basic_authentication_enabled       = true -> null
+       functions_extension_version                    = "~4" -> null
+       https_only                                     = false -> null
+       id                                             = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Web/sites/s190d01-plantechcontentfulfunction" -> null
+       key_vault_reference_identity_id                = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.ManagedIdentity/userAssignedIdentities/s190d01-plantech-mi" -> null
+       kind                                           = "functionapp,linux" -> null
+       location                                       = "westeurope" -> null
+       name                                           = "s190d01-plantechcontentfulfunction" -> null
+       outbound_ip_address_list                       = [
+           "51.144.224.93",
+           "52.232.70.142",
+           "52.232.4.132",
+           "52.232.64.246",
+           "52.178.92.96",
+        ] -> null
+       outbound_ip_addresses                          = "51.144.224.93,52.232.70.142,52.232.4.132,52.232.64.246,52.178.92.96" -> null
+       possible_outbound_ip_address_list              = [
+           "51.144.224.93",
+           "52.232.70.142",
+           "52.232.4.132",
+           "52.232.64.246",
+           "51.145.159.13",
+           "52.136.236.15",
+           "20.8.145.207",
+           "20.8.145.210",
+           "20.31.24.96",
+           "20.31.24.120",
+           "20.31.24.253",
+           "20.31.25.72",
+           "20.31.25.170",
+           "20.31.26.102",
+           "20.31.27.42",
+           "20.31.27.207",
+           "20.31.28.244",
+           "20.31.29.149",
+           "52.178.92.96",
+        ] -> null
+       possible_outbound_ip_addresses                 = "51.144.224.93,52.232.70.142,52.232.4.132,52.232.64.246,51.145.159.13,52.136.236.15,20.8.145.207,20.8.145.210,20.31.24.96,20.31.24.120,20.31.24.253,20.31.25.72,20.31.25.170,20.31.26.102,20.31.27.42,20.31.27.207,20.31.28.244,20.31.29.149,52.178.92.96" -> null
+       public_network_access_enabled                  = true -> null
+       resource_group_name                            = "s190d01-plantech" -> null
+       service_plan_id                                = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Web/serverFarms/s190d01-plantechappserviceplan" -> null
+       site_credential                                = (sensitive value) -> null
+       storage_account_access_key                     = (sensitive value) -> null
+       storage_account_name                           = "s190d01plantechfuncstr" -> null
+       storage_uses_managed_identity                  = false -> null
+       tags                                           = {
+           "Environment"      = "Dev"
+           "Product"          = "Plan Technology for your School"
+           "Service Offering" = "Plan Technology for your School"
+        } -> null
+       webdeploy_publish_basic_authentication_enabled = true -> null
+
+       identity {
+           identity_ids = [
+               "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.ManagedIdentity/userAssignedIdentities/s190d01-plantech-mi",
+            ] -> null
+           type         = "UserAssigned" -> null
+        }
+
+       site_config {
+           always_on                               = false -> null
+           app_scale_limit                         = 200 -> null
+           application_insights_key                = (sensitive value) -> null
+           container_registry_use_managed_identity = false -> null
+           default_documents                       = [
+               "Default.htm",
+               "Default.html",
+               "Default.asp",
+               "index.htm",
+               "index.html",
+               "iisstart.htm",
+               "default.aspx",
+               "index.php",
+            ] -> null
+           detailed_error_logging_enabled          = false -> null
+           elastic_instance_minimum                = 0 -> null
+           ftps_state                              = "Disabled" -> null
+           health_check_eviction_time_in_min       = 0 -> null
+           http2_enabled                           = false -> null
+           ip_restriction_default_action           = "Allow" -> null
+           linux_fx_version                        = "DOTNET-ISOLATED|8.0" -> null
+           load_balancing_mode                     = "LeastRequests" -> null
+           managed_pipeline_mode                   = "Integrated" -> null
+           minimum_tls_version                     = "1.2" -> null
+           pre_warmed_instance_count               = 0 -> null
+           remote_debugging_enabled                = false -> null
+           runtime_scale_monitoring_enabled        = false -> null
+           scm_ip_restriction_default_action       = "Allow" -> null
+           scm_minimum_tls_version                 = "1.2" -> null
+           scm_type                                = "None" -> null
+           scm_use_main_ip_restriction             = false -> null
+           use_32_bit_worker                       = false -> null
+           vnet_route_all_enabled                  = false -> null
+           websockets_enabled                      = false -> null
+           worker_count                            = 1 -> null
+
+           application_stack {
+               dotnet_version              = "8.0" -> null
+               use_custom_runtime          = false -> null
+               use_dotnet_isolated_runtime = true -> null
+            }
+        }
+
+       sticky_settings {
+           app_setting_names       = [
+               "AZURE_SQL_AZURESQLCONNECTION_CONNECTIONSTRING",
+               "AZURE_KEYVAULT_AZUREKEYVAULTCONNECTION_RESOURCEENDPOINT",
+               "AZURE_KEYVAULT_AZUREKEYVAULTCONNECTION_CLIENTID",
+               "AZURE_KEYVAULT_AZUREKEYVAULTCONNECTION_SCOPE",
+            ] -> null
+           connection_string_names = [] -> null
+        }
+    }
+
+  # azurerm_private_dns_zone.blob_storage will be created
+  + resource "azurerm_private_dns_zone" "blob_storage" {
+      + id                                                    = (known after apply)
+      + max_number_of_record_sets                             = (known after apply)
+      + max_number_of_virtual_network_links                   = (known after apply)
+      + max_number_of_virtual_network_links_with_registration = (known after apply)
+      + name                                                  = "privatelink.blob.core.windows.net"
+      + number_of_record_sets                                 = (known after apply)
+      + resource_group_name                                   = "s190d01-plantech"
+      + tags                                                  = {
+          + "Environment"      = "Dev"
+          + "Product"          = "Plan Technology for your School"
+          + "Service Offering" = "Plan Technology for your School"
+        }
+    }
+
+  # azurerm_private_dns_zone.database will be created
+  + resource "azurerm_private_dns_zone" "database" {
+      + id                                                    = (known after apply)
+      + max_number_of_record_sets                             = (known after apply)
+      + max_number_of_virtual_network_links                   = (known after apply)
+      + max_number_of_virtual_network_links_with_registration = (known after apply)
+      + name                                                  = "privatelink.database.windows.net"
+      + number_of_record_sets                                 = (known after apply)
+      + resource_group_name                                   = "s190d01-plantech"
+      + tags                                                  = {
+          + "Environment"      = "Dev"
+          + "Product"          = "Plan Technology for your School"
+          + "Service Offering" = "Plan Technology for your School"
+        }
+    }
+
+  # azurerm_private_dns_zone.files_storage will be created
+  + resource "azurerm_private_dns_zone" "files_storage" {
+      + id                                                    = (known after apply)
+      + max_number_of_record_sets                             = (known after apply)
+      + max_number_of_virtual_network_links                   = (known after apply)
+      + max_number_of_virtual_network_links_with_registration = (known after apply)
+      + name                                                  = "privatelink.file.core.windows.net"
+      + number_of_record_sets                                 = (known after apply)
+      + resource_group_name                                   = "s190d01-plantech"
+      + tags                                                  = {
+          + "Environment"      = "Dev"
+          + "Product"          = "Plan Technology for your School"
+          + "Service Offering" = "Plan Technology for your School"
+        }
+    }
+
+  # azurerm_private_dns_zone.keyvault will be created
+  + resource "azurerm_private_dns_zone" "keyvault" {
+      + id                                                    = (known after apply)
+      + max_number_of_record_sets                             = (known after apply)
+      + max_number_of_virtual_network_links                   = (known after apply)
+      + max_number_of_virtual_network_links_with_registration = (known after apply)
+      + name                                                  = "privatelink.vaultcore.azure.net"
+      + number_of_record_sets                                 = (known after apply)
+      + resource_group_name                                   = "s190d01-plantech"
+      + tags                                                  = {
+          + "Environment"      = "Dev"
+          + "Product"          = "Plan Technology for your School"
+          + "Service Offering" = "Plan Technology for your School"
+        }
+    }
+
+  # azurerm_private_dns_zone_virtual_network_link.blob_storage will be created
+  + resource "azurerm_private_dns_zone_virtual_network_link" "blob_storage" {
+      + id                    = (known after apply)
+      + name                  = "function_vn"
+      + private_dns_zone_name = "privatelink.blob.core.windows.net"
+      + registration_enabled  = false
+      + resource_group_name   = "s190d01-plantech"
+      + virtual_network_id    = (known after apply)
+    }
+
+  # azurerm_private_dns_zone_virtual_network_link.database_default will be created
+  + resource "azurerm_private_dns_zone_virtual_network_link" "database_default" {
+      + id                    = (known after apply)
+      + name                  = "default_vnet"
+      + private_dns_zone_name = "privatelink.database.windows.net"
+      + registration_enabled  = false
+      + resource_group_name   = "s190d01-plantech"
+      + virtual_network_id    = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Network/virtualNetworks/s190d01-plantechdefault"
+    }
+
+  # azurerm_private_dns_zone_virtual_network_link.database_function will be created
+  + resource "azurerm_private_dns_zone_virtual_network_link" "database_function" {
+      + id                    = (known after apply)
+      + name                  = "function_vnet"
+      + private_dns_zone_name = "privatelink.database.windows.net"
+      + registration_enabled  = false
+      + resource_group_name   = "s190d01-plantech"
+      + virtual_network_id    = (known after apply)
+    }
+
+  # azurerm_private_dns_zone_virtual_network_link.files_storage will be created
+  + resource "azurerm_private_dns_zone_virtual_network_link" "files_storage" {
+      + id                    = (known after apply)
+      + name                  = "function_vnet"
+      + private_dns_zone_name = "privatelink.file.core.windows.net"
+      + registration_enabled  = false
+      + resource_group_name   = "s190d01-plantech"
+      + virtual_network_id    = (known after apply)
+    }
+
+  # azurerm_private_dns_zone_virtual_network_link.keyvault_to_defaultvnet will be created
+  + resource "azurerm_private_dns_zone_virtual_network_link" "keyvault_to_defaultvnet" {
+      + id                    = (known after apply)
+      + name                  = "default_vnet"
+      + private_dns_zone_name = "privatelink.vaultcore.azure.net"
+      + registration_enabled  = false
+      + resource_group_name   = "s190d01-plantech"
+      + virtual_network_id    = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Network/virtualNetworks/s190d01-plantechdefault"
+    }
+
+  # azurerm_private_dns_zone_virtual_network_link.keyvault_to_functionvnet will be created
+  + resource "azurerm_private_dns_zone_virtual_network_link" "keyvault_to_functionvnet" {
+      + id                    = (known after apply)
+      + name                  = "function_vnet"
+      + private_dns_zone_name = "privatelink.vaultcore.azure.net"
+      + registration_enabled  = false
+      + resource_group_name   = "s190d01-plantech"
+      + virtual_network_id    = (known after apply)
+    }
+
+  # azurerm_private_endpoint.blob_storage will be created
+  + resource "azurerm_private_endpoint" "blob_storage" {
+      + custom_dns_configs            = (known after apply)
+      + custom_network_interface_name = "s190d01-plantech-blob-storage-nic"
+      + id                            = (known after apply)
+      + location                      = "northeurope"
+      + name                          = "s190d01-plantech-blob-storage"
+      + network_interface             = (known after apply)
+      + private_dns_zone_configs      = (known after apply)
+      + resource_group_name           = "s190d01-plantech"
+      + subnet_id                     = (known after apply)
+      + tags                          = {
+          + "Environment"      = "Dev"
+          + "Product"          = "Plan Technology for your School"
+          + "Service Offering" = "Plan Technology for your School"
+        }
+
+      + private_dns_zone_group {
+          + id                   = (known after apply)
+          + name                 = "default"
+          + private_dns_zone_ids = (known after apply)
+        }
+
+      + private_service_connection {
+          + is_manual_connection           = false
+          + name                           = "s190d01-plantech-blob-storage"
+          + private_connection_resource_id = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Storage/storageAccounts/s190d01plantechfuncstr"
+          + private_ip_address             = (known after apply)
+          + subresource_names              = [
+              + "blob",
+            ]
+        }
+    }
+
+  # azurerm_private_endpoint.database will be created
+  + resource "azurerm_private_endpoint" "database" {
+      + custom_dns_configs            = (known after apply)
+      + custom_network_interface_name = "privatelink.database.windows.net"
+      + id                            = (known after apply)
+      + location                      = "westeurope"
+      + name                          = "s190d01-plantech-db"
+      + network_interface             = (known after apply)
+      + private_dns_zone_configs      = (known after apply)
+      + resource_group_name           = "s190d01-plantech"
+      + subnet_id                     = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Network/virtualNetworks/s190d01-plantechdefault/subnets/s190d01-plantechcontainerappsinfra"
+      + tags                          = {
+          + "Environment"      = "Dev"
+          + "Product"          = "Plan Technology for your School"
+          + "Service Offering" = "Plan Technology for your School"
+        }
+
+      + private_dns_zone_group {
+          + id                   = (known after apply)
+          + name                 = "default"
+          + private_dns_zone_ids = (known after apply)
+        }
+
+      + private_service_connection {
+          + is_manual_connection           = false
+          + name                           = "s190d01-plantech-db"
+          + private_connection_resource_id = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Sql/servers/s190d01-plantech"
+          + private_ip_address             = (known after apply)
+          + subresource_names              = [
+              + "sqlServer",
+            ]
+        }
+    }
+
+  # azurerm_private_endpoint.files_storage will be created
+  + resource "azurerm_private_endpoint" "files_storage" {
+      + custom_dns_configs            = (known after apply)
+      + custom_network_interface_name = "s190d01-plantech-files-storage-nic"
+      + id                            = (known after apply)
+      + location                      = "northeurope"
+      + name                          = "s190d01-plantech-files-storage"
+      + network_interface             = (known after apply)
+      + private_dns_zone_configs      = (known after apply)
+      + resource_group_name           = "s190d01-plantech"
+      + subnet_id                     = (known after apply)
+      + tags                          = {
+          + "Environment"      = "Dev"
+          + "Product"          = "Plan Technology for your School"
+          + "Service Offering" = "Plan Technology for your School"
+        }
+
+      + private_dns_zone_group {
+          + id                   = (known after apply)
+          + name                 = "default"
+          + private_dns_zone_ids = (known after apply)
+        }
+
+      + private_service_connection {
+          + is_manual_connection           = false
+          + name                           = "s190d01-plantech-files-storage"
+          + private_connection_resource_id = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Storage/storageAccounts/s190d01plantechfuncstr"
+          + private_ip_address             = (known after apply)
+          + subresource_names              = [
+              + "file",
+            ]
+        }
+    }
+
+  # azurerm_private_endpoint.keyvault will be created
+  + resource "azurerm_private_endpoint" "keyvault" {
+      + custom_dns_configs            = (known after apply)
+      + custom_network_interface_name = "s190d01-plantech-keyvault-nic"
+      + id                            = (known after apply)
+      + location                      = "westeurope"
+      + name                          = "s190d01-plantech-keyvault"
+      + network_interface             = (known after apply)
+      + private_dns_zone_configs      = (known after apply)
+      + resource_group_name           = "s190d01-plantech"
+      + subnet_id                     = (known after apply)
+      + tags                          = {
+          + "Environment"      = "Dev"
+          + "Product"          = "Plan Technology for your School"
+          + "Service Offering" = "Plan Technology for your School"
+        }
+
+      + private_dns_zone_group {
+          + id                   = (known after apply)
+          + name                 = "default"
+          + private_dns_zone_ids = (known after apply)
+        }
+
+      + private_service_connection {
+          + is_manual_connection           = false
+          + name                           = "s190d01-plantech-keyvault"
+          + private_connection_resource_id = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.KeyVault/vaults/s190d01-plantech-kv"
+          + private_ip_address             = (known after apply)
+          + subresource_names              = [
+              + "vault",
+            ]
+        }
+    }
+
+  # azurerm_service_plan.function_plan must be replaced
+-/+ resource "azurerm_service_plan" "function_plan" {
+      ~ id                           = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Web/serverFarms/s190d01-plantechappserviceplan" -> (known after apply)
+      ~ kind                         = "functionapp" -> (known after apply)
+      ~ location                     = "westeurope" -> "northeurope" # forces replacement
+      ~ maximum_elastic_worker_count = 1 -> (known after apply)
+        name                         = "s190d01-plantechappserviceplan"
+      ~ reserved                     = true -> (known after apply)
+      ~ sku_name                     = "Y1" -> "FC1"
+        tags                         = {
+            "Environment"      = "Dev"
+            "Product"          = "Plan Technology for your School"
+            "Service Offering" = "Plan Technology for your School"
+        }
+      ~ worker_count                 = 0 -> (known after apply)
+       zone_balancing_enabled       = false -> null
+        # (3 unchanged attributes hidden)
+    }
+
+  # azurerm_storage_account.costing_storage will be created
+  + resource "azurerm_storage_account" "costing_storage" {
+      + access_tier                        = (known after apply)
+      + account_kind                       = "StorageV2"
+      + account_replication_type           = "LRS"
+      + account_tier                       = "Standard"
+      + allow_nested_items_to_be_public    = false
+      + cross_tenant_replication_enabled   = true
+      + default_to_oauth_authentication    = false
+      + dns_endpoint_type                  = "Standard"
+      + enable_https_traffic_only          = true
+      + id                                 = (known after apply)
+      + infrastructure_encryption_enabled  = false
+      + is_hns_enabled                     = false
+      + large_file_share_enabled           = (known after apply)
+      + local_user_enabled                 = true
+      + location                           = "westeurope"
+      + min_tls_version                    = "TLS1_2"
+      + name                               = "s190d01plantechcosting"
+      + nfsv3_enabled                      = false
+      + primary_access_key                 = (sensitive value)
+      + primary_blob_connection_string     = (sensitive value)
+      + primary_blob_endpoint              = (known after apply)
+      + primary_blob_host                  = (known after apply)
+      + primary_blob_internet_endpoint     = (known after apply)
+      + primary_blob_internet_host         = (known after apply)
+      + primary_blob_microsoft_endpoint    = (known after apply)
+      + primary_blob_microsoft_host        = (known after apply)
+      + primary_connection_string          = (sensitive value)
+      + primary_dfs_endpoint               = (known after apply)
+      + primary_dfs_host                   = (known after apply)
+      + primary_dfs_internet_endpoint      = (known after apply)
+      + primary_dfs_internet_host          = (known after apply)
+      + primary_dfs_microsoft_endpoint     = (known after apply)
+      + primary_dfs_microsoft_host         = (known after apply)
+      + primary_file_endpoint              = (known after apply)
+      + primary_file_host                  = (known after apply)
+      + primary_file_internet_endpoint     = (known after apply)
+      + primary_file_internet_host         = (known after apply)
+      + primary_file_microsoft_endpoint    = (known after apply)
+      + primary_file_microsoft_host        = (known after apply)
+      + primary_location                   = (known after apply)
+      + primary_queue_endpoint             = (known after apply)
+      + primary_queue_host                 = (known after apply)
+      + primary_queue_microsoft_endpoint   = (known after apply)
+      + primary_queue_microsoft_host       = (known after apply)
+      + primary_table_endpoint             = (known after apply)
+      + primary_table_host                 = (known after apply)
+      + primary_table_microsoft_endpoint   = (known after apply)
+      + primary_table_microsoft_host       = (known after apply)
+      + primary_web_endpoint               = (known after apply)
+      + primary_web_host                   = (known after apply)
+      + primary_web_internet_endpoint      = (known after apply)
+      + primary_web_internet_host          = (known after apply)
+      + primary_web_microsoft_endpoint     = (known after apply)
+      + primary_web_microsoft_host         = (known after apply)
+      + public_network_access_enabled      = true
+      + queue_encryption_key_type          = "Service"
+      + resource_group_name                = "s190d01-plantech"
+      + secondary_access_key               = (sensitive value)
+      + secondary_blob_connection_string   = (sensitive value)
+      + secondary_blob_endpoint            = (known after apply)
+      + secondary_blob_host                = (known after apply)
+      + secondary_blob_internet_endpoint   = (known after apply)
+      + secondary_blob_internet_host       = (known after apply)
+      + secondary_blob_microsoft_endpoint  = (known after apply)
+      + secondary_blob_microsoft_host      = (known after apply)
+      + secondary_connection_string        = (sensitive value)
+      + secondary_dfs_endpoint             = (known after apply)
+      + secondary_dfs_host                 = (known after apply)
+      + secondary_dfs_internet_endpoint    = (known after apply)
+      + secondary_dfs_internet_host        = (known after apply)
+      + secondary_dfs_microsoft_endpoint   = (known after apply)
+      + secondary_dfs_microsoft_host       = (known after apply)
+      + secondary_file_endpoint            = (known after apply)
+      + secondary_file_host                = (known after apply)
+      + secondary_file_internet_endpoint   = (known after apply)
+      + secondary_file_internet_host       = (known after apply)
+      + secondary_file_microsoft_endpoint  = (known after apply)
+      + secondary_file_microsoft_host      = (known after apply)
+      + secondary_location                 = (known after apply)
+      + secondary_queue_endpoint           = (known after apply)
+      + secondary_queue_host               = (known after apply)
+      + secondary_queue_microsoft_endpoint = (known after apply)
+      + secondary_queue_microsoft_host     = (known after apply)
+      + secondary_table_endpoint           = (known after apply)
+      + secondary_table_host               = (known after apply)
+      + secondary_table_microsoft_endpoint = (known after apply)
+      + secondary_table_microsoft_host     = (known after apply)
+      + secondary_web_endpoint             = (known after apply)
+      + secondary_web_host                 = (known after apply)
+      + secondary_web_internet_endpoint    = (known after apply)
+      + secondary_web_internet_host        = (known after apply)
+      + secondary_web_microsoft_endpoint   = (known after apply)
+      + secondary_web_microsoft_host       = (known after apply)
+      + sftp_enabled                       = false
+      + shared_access_key_enabled          = true
+      + table_encryption_key_type          = "Service"
+      + tags                               = {
+          + "Environment"      = "Dev"
+          + "Product"          = "Plan Technology for your School"
+          + "Service Offering" = "Plan Technology for your School"
+        }
+
+      + blob_properties {
+          + change_feed_enabled      = false
+          + default_service_version  = (known after apply)
+          + last_access_time_enabled = false
+          + versioning_enabled       = false
+
+          + container_delete_retention_policy {
+              + days = 7
+            }
+
+          + delete_retention_policy {
+              + days                     = 7
+              + permanent_delete_enabled = false
+            }
+        }
+
+      + identity {
+          + identity_ids = [
+              + "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.ManagedIdentity/userAssignedIdentities/s190d01-plantech-mi",
+            ]
+          + principal_id = (known after apply)
+          + tenant_id    = (known after apply)
+          + type         = "UserAssigned"
+        }
+
+      + sas_policy {
+          + expiration_action = "Log"
+          + expiration_period = "00.01:00:00"
+        }
+    }
+
+  # azurerm_storage_account.function_storage will be updated in-place
+  ~ resource "azurerm_storage_account" "function_storage" {
+        id                                = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Storage/storageAccounts/s190d01plantechfuncstr"
+        name                              = "s190d01plantechfuncstr"
+        tags                              = {
+            "Environment"      = "Dev"
+            "Product"          = "Plan Technology for your School"
+            "Service Offering" = "Plan Technology for your School"
+        }
+        # (40 unchanged attributes hidden)
+
+      ~ network_rules {
+          ~ default_action             = "Allow" -> "Deny"
+            # (3 unchanged attributes hidden)
+        }
+
+      ~ sas_policy {
+          ~ expiration_period = "0.01:00:00" -> "00.01:00:00"
+            # (1 unchanged attribute hidden)
+        }
+
+        # (5 unchanged blocks hidden)
+    }
+
+  # azurerm_storage_container.blobforcost will be created
+  + resource "azurerm_storage_container" "blobforcost" {
+      + container_access_type             = "private"
+      + default_encryption_scope          = (known after apply)
+      + encryption_scope_override_enabled = true
+      + has_immutability_policy           = (known after apply)
+      + has_legal_hold                    = (known after apply)
+      + id                                = (known after apply)
+      + metadata                          = (known after apply)
+      + name                              = "blobforcost"
+      + resource_manager_id               = (known after apply)
+      + storage_account_name              = "s190d01plantechcosting"
+    }
+
+  # azurerm_subnet.function_infra_subnet will be created
+  + resource "azurerm_subnet" "function_infra_subnet" {
+      + address_prefixes                               = [
+          + "10.0.0.0/24",
+        ]
+      + default_outbound_access_enabled                = true
+      + enforce_private_link_endpoint_network_policies = (known after apply)
+      + enforce_private_link_service_network_policies  = (known after apply)
+      + id                                             = (known after apply)
+      + name                                           = "s190d01-plantech-functioninfra"
+      + private_endpoint_network_policies              = (known after apply)
+      + private_endpoint_network_policies_enabled      = (known after apply)
+      + private_link_service_network_policies_enabled  = (known after apply)
+      + resource_group_name                            = "s190d01-plantech"
+      + service_endpoints                              = [
+          + "Microsoft.KeyVault",
+          + "Microsoft.Storage",
+        ]
+      + virtual_network_name                           = "s190d01-plantech-function-vn"
+
+      + delegation {
+          + name = "AFADelegationService"
+
+          + service_delegation {
+              + actions = [
+                  + "Microsoft.Network/virtualNetworks/subnets/join/action",
+                ]
+              + name    = "Microsoft.App/environments"
+            }
+        }
+    }
+
+  # azurerm_subnet.function_storage will be created
+  + resource "azurerm_subnet" "function_storage" {
+      + address_prefixes                               = [
+          + "10.0.1.0/24",
+        ]
+      + default_outbound_access_enabled                = true
+      + enforce_private_link_endpoint_network_policies = (known after apply)
+      + enforce_private_link_service_network_policies  = (known after apply)
+      + id                                             = (known after apply)
+      + name                                           = "s190d01-plantech-function-storage"
+      + private_endpoint_network_policies              = (known after apply)
+      + private_endpoint_network_policies_enabled      = (known after apply)
+      + private_link_service_network_policies_enabled  = (known after apply)
+      + resource_group_name                            = "s190d01-plantech"
+      + virtual_network_name                           = "s190d01-plantech-function-vn"
+    }
+
+  # azurerm_subnet.keyvault will be created
+  + resource "azurerm_subnet" "keyvault" {
+      + address_prefixes                               = [
+          + "172.16.7.0/24",
+        ]
+      + default_outbound_access_enabled                = true
+      + enforce_private_link_endpoint_network_policies = (known after apply)
+      + enforce_private_link_service_network_policies  = (known after apply)
+      + id                                             = (known after apply)
+      + name                                           = "s190d01-plantech-keyvault-endpoint"
+      + private_endpoint_network_policies              = (known after apply)
+      + private_endpoint_network_policies_enabled      = (known after apply)
+      + private_link_service_network_policies_enabled  = (known after apply)
+      + resource_group_name                            = "s190d01-plantech"
+      + virtual_network_name                           = "s190d01-plantechdefault"
+    }
+
+  # azurerm_subnet_route_table_association.keyvault will be created
+  + resource "azurerm_subnet_route_table_association" "keyvault" {
+      + id             = (known after apply)
+      + route_table_id = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Network/routeTables/s190d01-plantechdefault"
+      + subnet_id      = (known after apply)
+    }
+
+  # azurerm_virtual_network.function_vnet will be created
+  + resource "azurerm_virtual_network" "function_vnet" {
+      + address_space       = [
+          + "10.0.0.0/14",
+        ]
+      + dns_servers         = (known after apply)
+      + guid                = (known after apply)
+      + id                  = (known after apply)
+      + location            = "northeurope"
+      + name                = "s190d01-plantech-function-vn"
+      + resource_group_name = "s190d01-plantech"
+      + subnet              = (known after apply)
+      + tags                = {
+          + "Environment"      = "Dev"
+          + "Product"          = "Plan Technology for your School"
+          + "Service Offering" = "Plan Technology for your School"
+        }
+    }
+
+  # azurerm_virtual_network_peering.function_to_main will be created
+  + resource "azurerm_virtual_network_peering" "function_to_main" {
+      + allow_forwarded_traffic                = true
+      + allow_gateway_transit                  = false
+      + allow_virtual_network_access           = true
+      + id                                     = (known after apply)
+      + name                                   = "s190d01-plantech-defaultvn-peer"
+      + peer_complete_virtual_networks_enabled = true
+      + remote_virtual_network_id              = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Network/virtualNetworks/s190d01-plantechdefault"
+      + resource_group_name                    = "s190d01-plantech"
+      + use_remote_gateways                    = false
+      + virtual_network_name                   = "s190d01-plantech-function-vn"
+    }
+
+  # azurerm_virtual_network_peering.main_to_function will be created
+  + resource "azurerm_virtual_network_peering" "main_to_function" {
+      + allow_forwarded_traffic                = true
+      + allow_gateway_transit                  = false
+      + allow_virtual_network_access           = true
+      + id                                     = (known after apply)
+      + name                                   = "s190d01-plantech-functionvn-peer"
+      + peer_complete_virtual_networks_enabled = true
+      + remote_virtual_network_id              = (known after apply)
+      + resource_group_name                    = "s190d01-plantech"
+      + use_remote_gateways                    = false
+      + virtual_network_name                   = "s190d01-plantechdefault"
+    }
+
+  # module.main_hosting.azapi_update_resource.mssql_security_storage_key_rotation_reminder[0] will be created
+  + resource "azapi_update_resource" "mssql_security_storage_key_rotation_reminder" {
+      + body                    = jsonencode(
+            {
+              + properties = {
+                  + keyPolicy = {
+                      + keyExpirationPeriodInDays = 90
+                    }
+                }
+            }
+        )
+      + id                      = (known after apply)
+      + ignore_casing           = false
+      + ignore_missing_property = true
+      + name                    = (known after apply)
+      + output                  = (known after apply)
+      + parent_id               = (known after apply)
+      + resource_id             = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Storage/storageAccounts/s190d01plantechmssqlsec"
+      + type                    = "Microsoft.Storage/storageAccounts@2023-01-01"
+    }
+
+  # module.main_hosting.azurerm_monitor_diagnostic_setting.mssql_security_storage[0] will be updated in-place
+  ~ resource "azurerm_monitor_diagnostic_setting" "mssql_security_storage" {
+        id                         = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Storage/storageAccounts/s190d01plantechmssqlsec/blobServices/default|s190d01-plantech-mssql-blob-diag"
+        name                       = "s190d01-plantech-mssql-blob-diag"
+        # (2 unchanged attributes hidden)
+
+       metric {
+           category = "Capacity" -> null
+           enabled  = false -> null
+
+           retention_policy {
+               days    = 0 -> null
+               enabled = false -> null
+            }
+        }
+       metric {
+           category = "Transaction" -> null
+           enabled  = false -> null
+
+           retention_policy {
+               days    = 0 -> null
+               enabled = false -> null
+            }
+        }
+      + metric {
+          + category = "AllMetrics"
+          + enabled  = false
+        }
+
+        # (3 unchanged blocks hidden)
+    }
+
+  # module.main_hosting.azurerm_private_dns_a_record.mssql_private_endpoint[0] will be updated in-place
+  ~ resource "azurerm_private_dns_a_record" "mssql_private_endpoint" {
+        id                  = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Network/privateDnsZones/s190d01-plantech.database.windows.net/A/@"
+        name                = "@"
+      ~ tags                = {
+            "Environment"      = "Dev"
+            "Product"          = "Plan Technology for your School"
+          + "Service Offering" = "Plan Technology for your School"
+        }
+        # (5 unchanged attributes hidden)
+    }
+
+  # module.main_hosting.azurerm_private_dns_zone.mssql_private_link[0] will be updated in-place
+  ~ resource "azurerm_private_dns_zone" "mssql_private_link" {
+        id                                                    = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Network/privateDnsZones/s190d01-plantech.database.windows.net"
+        name                                                  = "s190d01-plantech.database.windows.net"
+      ~ tags                                                  = {
+            "Environment"      = "Dev"
+            "Product"          = "Plan Technology for your School"
+          + "Service Offering" = "Plan Technology for your School"
+        }
+        # (5 unchanged attributes hidden)
+
+        # (1 unchanged block hidden)
+    }
+
+  # module.main_hosting.azurerm_private_dns_zone_virtual_network_link.mssql_private_link[0] will be updated in-place
+  ~ resource "azurerm_private_dns_zone_virtual_network_link" "mssql_private_link" {
+        id                    = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Network/privateDnsZones/s190d01-plantech.database.windows.net/virtualNetworkLinks/s190d01-plantechmssqlprivatelink"
+        name                  = "s190d01-plantechmssqlprivatelink"
+      ~ tags                  = {
+            "Environment"      = "Dev"
+            "Product"          = "Plan Technology for your School"
+          + "Service Offering" = "Plan Technology for your School"
+        }
+        # (4 unchanged attributes hidden)
+    }
+
+  # module.main_hosting.azurerm_storage_account.mssql_security_storage[0] will be updated in-place
+  ~ resource "azurerm_storage_account" "mssql_security_storage" {
+      ~ cross_tenant_replication_enabled  = true -> false
+        id                                = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Storage/storageAccounts/s190d01plantechmssqlsec"
+        name                              = "s190d01plantechmssqlsec"
+        tags                              = {
+            "Environment"      = "Dev"
+            "Product"          = "Plan Technology for your School"
+            "Service Offering" = "Plan Technology for your School"
+        }
+        # (39 unchanged attributes hidden)
+
+        # (4 unchanged blocks hidden)
+    }
+
+  # module.main_hosting.azurerm_storage_management_policy.mssql_security_storage[0] will be created
+  + resource "azurerm_storage_management_policy" "mssql_security_storage" {
+      + id                 = (known after apply)
+      + storage_account_id = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Storage/storageAccounts/s190d01plantechmssqlsec"
+
+      + rule {
+          + enabled = true
+          + name    = "object-lifecycle-policy"
+
+          + actions {
+              + base_blob {
+                  + delete_after_days_since_creation_greater_than                  = 30
+                  + delete_after_days_since_last_access_time_greater_than          = -1
+                  + delete_after_days_since_modification_greater_than              = -1
+                  + tier_to_archive_after_days_since_creation_greater_than         = 7
+                  + tier_to_archive_after_days_since_last_access_time_greater_than = -1
+                  + tier_to_archive_after_days_since_last_tier_change_greater_than = -1
+                  + tier_to_archive_after_days_since_modification_greater_than     = -1
+                  + tier_to_cold_after_days_since_creation_greater_than            = -1
+                  + tier_to_cold_after_days_since_last_access_time_greater_than    = -1
+                  + tier_to_cold_after_days_since_modification_greater_than        = -1
+                  + tier_to_cool_after_days_since_creation_greater_than            = 3
+                  + tier_to_cool_after_days_since_last_access_time_greater_than    = -1
+                  + tier_to_cool_after_days_since_modification_greater_than        = -1
+                }
+            }
+
+          + filters {
+              + blob_types   = [
+                  + "blockBlob",
+                ]
+              + prefix_match = [
+                  + "s190d01-plantech-mssqlsec/*",
+                  + "sqldbauditlogs/*",
+                  + "sqldbtdlogs/*",
+                ]
+            }
+        }
+    }
+
+  # module.main_hosting.azurerm_subnet.container_apps_infra_subnet[0] will be updated in-place
+  ~ resource "azurerm_subnet" "container_apps_infra_subnet" {
+        id                                             = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Network/virtualNetworks/s190d01-plantechdefault/subnets/s190d01-plantechcontainerappsinfra"
+        name                                           = "s190d01-plantechcontainerappsinfra"
+      ~ service_endpoints                              = [
+          + "Microsoft.Storage",
+            # (1 unchanged element hidden)
+        ]
+        # (10 unchanged attributes hidden)
+    }
+
+  # module.waf.data.azurerm_client_config.current will be read during apply
+  # (depends on a resource or a module with changes pending)
+ <= data "azurerm_client_config" "current" {
+      + client_id       = (known after apply)
+      + id              = (known after apply)
+      + object_id       = (known after apply)
+      + subscription_id = (known after apply)
+      + tenant_id       = (known after apply)
+    }
+
+  # module.waf.data.azurerm_resource_group.existing_resource_group[0] will be read during apply
+  # (depends on a resource or a module with changes pending)
+ <= data "azurerm_resource_group" "existing_resource_group" {
+      + id         = (known after apply)
+      + location   = (known after apply)
+      + managed_by = (known after apply)
+      + name       = "s190d01-plantech"
+      + tags       = (known after apply)
+    }
+
+  # module.waf.azurerm_log_analytics_workspace.waf must be replaced
+-/+ resource "azurerm_log_analytics_workspace" "waf" {
+       cmk_for_query_forced                    = false -> null
+      ~ id                                      = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.OperationalInsights/workspaces/s190d01-plantechwaf" -> (known after apply)
+       immediate_data_purge_on_30_days_enabled = false -> null
+      ~ location                                = "westeurope" # forces replacement -> (known after apply) # forces replacement
+        name                                    = "s190d01-plantechwaf"
+      ~ primary_shared_key                      = (sensitive value)
+      ~ secondary_shared_key                    = (sensitive value)
+        tags                                    = {
+            "Environment"      = "Dev"
+            "Product"          = "Plan Technology for your School"
+            "Service Offering" = "Plan Technology for your School"
+        }
+      ~ workspace_id                            = "ad83d73f-e297-40a3-b069-70130bb1f789" -> (known after apply)
+        # (8 unchanged attributes hidden)
+    }
+
+  # module.waf.azurerm_monitor_diagnostic_setting.waf will be updated in-place
+  ~ resource "azurerm_monitor_diagnostic_setting" "waf" {
+        id                             = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.Cdn/profiles/s190d01-plantech-cdnwaf|s190d01-plantechwaf"
+      + log_analytics_destination_type = "AzureDiagnostics"
+      ~ log_analytics_workspace_id     = "/subscriptions/01ca3b42-9780-4628-806b-79279e3c7e89/resourceGroups/s190d01-plantech/providers/Microsoft.OperationalInsights/workspaces/s190d01-plantechwaf" -> (known after apply)
+        name                           = "s190d01-plantechwaf"
+        # (1 unchanged attribute hidden)
+
+        # (6 unchanged blocks hidden)
+    }
+
+Plan: 28 to add, 9 to change, 5 to destroy.
+╷
+│ Warning: Deprecated Resource
+│ 
+│   with data.azurerm_sql_server.database,
+│   on database.tf line 1, in data "azurerm_sql_server" "database":
+│    1: data "azurerm_sql_server" "database" [4m{
+│ 
+│ The `azurerm_sql_server` data source is deprecated and will be removed in version 4.0 of the AzureRM provider. Please use the `azurerm_mssql_server` data source instead.
+│ 
+│ (and one more similar warning elsewhere)
+╵
+╷
+│ Warning: Argument is deprecated
+│ 
+│   with module.main_hosting.azurerm_route_table.default,
+│   on .terraform/modules/main_hosting/virtual-network.tf line 19, in resource "azurerm_route_table" "default":
+│   19:   disable_bgp_route_propagation = [4mfalse
+│ 
+│ The property `disable_bgp_route_propagation` has been superseded by the property `bgp_route_propagation_enabled` and will be removed in v4.0 of the AzureRM Provider.
+│ 
+│ (and 10 more similar warnings elsewhere)
+╵
+
+─────────────────────────────────────────────────────────────────────────────
+
+Note: You didn't use the -out option to save this plan, so Terraform can't
+guarantee to take exactly these actions if you run "terraform apply" now.

--- a/terraform/container-app/20240819_test_revert_plan.txt
+++ b/terraform/container-app/20240819_test_revert_plan.txt
@@ -1,0 +1,893 @@
+[0m[1mmodule.main_hosting.azapi_update_resource.mssql_security_storage_key_rotation_reminder[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Storage/storageAccounts/s190t01plantechmssqlsec][0m
+[0m[1mazapi_update_resource.example: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Web/sites/s190t01-plantechcontentfulfunction][0m
+[0m[1mazapi_resource.contentful_function: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Web/sites/s190t01-plantechcontentfulfunction][0m
+[0m[1mdata.azurerm_subscription.subscription: Reading...[0m[0m
+[0m[1mazurerm_subnet.function_storage: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/virtualNetworks/s190t01-plantech-function-vn/subnets/s190t01-plantech-function-storage][0m
+[0m[1mmodule.main_hosting.data.azurerm_subscription.current: Reading...[0m[0m
+[0m[1mazurerm_virtual_network.function_vnet: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/virtualNetworks/s190t01-plantech-function-vn][0m
+[0m[1mazurerm_private_endpoint.files_storage: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateEndpoints/s190t01-plantech-files-storage][0m
+[0m[1mazurerm_subnet.function_infra_subnet: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/virtualNetworks/s190t01-plantech-function-vn/subnets/s190t01-plantech-functioninfra][0m
+[0m[1mazurerm_private_endpoint.blob_storage: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateEndpoints/s190t01-plantech-blob-storage][0m
+[0m[1mazurerm_private_dns_zone.files_storage: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateDnsZones/privatelink.file.core.windows.net][0m
+[0m[1mazurerm_private_dns_zone.blob_storage: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateDnsZones/privatelink.blob.core.windows.net][0m
+[0m[1mmodule.main_hosting.azurerm_storage_management_policy.mssql_security_storage[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Storage/storageAccounts/s190t01plantechmssqlsec/managementPolicies/default][0m
+[0m[1mdata.azurerm_subscription.subscription: Read complete after 1s [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89][0m
+[0m[1mmodule.main_hosting.azurerm_resource_group.default[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech][0m
+[0m[1mmodule.main_hosting.data.azurerm_subscription.current: Read complete after 1s [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89][0m
+[0m[1mdata.azurerm_client_config.current: Reading...[0m[0m
+[0m[1mdata.azurerm_client_config.current: Read complete after 0s [id=Y2xpZW50Q29uZmlncy9jbGllbnRJZD03YzJjZDQ1Yi1lNmUwLTQ0MTEtODc4YS1lZWUyYWUyMzllODA7b2JqZWN0SWQ9NjI2YTYwZjgtNTU3Ni00ZmI4LThhYjQtMDZkNmYyNzY3ZWQ3O3N1YnNjcmlwdGlvbklkPTc4YzNlODJmLTI1NmYtNDZjMC1hOGNhLTI5YWQzYTQ5OWI4OTt0ZW5hbnRJZD05YzdkOWRkMy04NDBjLTRiM2YtODE4ZS01NTI4NjUwODJlMTY=][0m
+[0m[1mmodule.main_hosting.azurerm_log_analytics_query_pack.container_app: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.OperationalInsights/queryPacks/s190t01-plantechcontainerapp][0m
+[0m[1mmodule.main_hosting.azurerm_log_analytics_workspace.container_app: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.OperationalInsights/workspaces/s190t01-plantechcontainerapp][0m
+[0m[1mmodule.main_hosting.azurerm_private_dns_zone.mssql_private_link[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateDnsZones/s190t01-plantech.database.windows.net][0m
+[0m[1mazurerm_service_plan.function_plan: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Web/serverFarms/s190t01-plantechappserviceplan][0m
+[0m[1mmodule.main_hosting.azurerm_virtual_network.default[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/virtualNetworks/s190t01-plantechdefault][0m
+[0m[1mmodule.main_hosting.azurerm_storage_account.mssql_security_storage[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Storage/storageAccounts/s190t01plantechmssqlsec][0m
+[0m[1mmodule.main_hosting.azurerm_network_security_group.container_apps_infra[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/networkSecurityGroups/s190t01-plantechcontainerappsinfransg][0m
+[0m[1mmodule.main_hosting.azurerm_route_table.default[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/routeTables/s190t01-plantechdefault][0m
+[0m[1mmodule.main_hosting.azurerm_log_analytics_workspace.app_insights[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.OperationalInsights/workspaces/s190t01-plantech-insights][0m
+[0m[1mazurerm_user_assigned_identity.user_assigned_identity: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.ManagedIdentity/userAssignedIdentities/s190t01-plantech-mi][0m
+[0m[1mmodule.main_hosting.azurerm_user_assigned_identity.mssql[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.ManagedIdentity/userAssignedIdentities/s190t01-plantech-uami-mssql][0m
+[0m[1mazurerm_application_insights.functional_insights: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Insights/components/s190t01-plantech-function-insights][0m
+[0m[1mmodule.main_hosting.azurerm_subnet.container_apps_infra_subnet[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/virtualNetworks/s190t01-plantechdefault/subnets/s190t01-plantechcontainerappsinfra][0m
+[0m[1mmodule.main_hosting.azurerm_subnet.container_instances_subnet[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/virtualNetworks/s190t01-plantechdefault/subnets/s190t01-plantechcontainerinstances][0m
+[0m[1mmodule.main_hosting.azurerm_subnet.mssql_private_endpoint_subnet[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/virtualNetworks/s190t01-plantechdefault/subnets/s190t01-plantechmssqlprivateendpoint][0m
+[0m[1mmodule.main_hosting.azurerm_private_dns_zone_virtual_network_link.mssql_private_link[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateDnsZones/s190t01-plantech.database.windows.net/virtualNetworkLinks/s190t01-plantechmssqlprivatelink][0m
+[0m[1mazurerm_servicebus_namespace.service_bus: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.ServiceBus/namespaces/s190t01-plantechservicebus][0m
+[0m[1mmodule.main_hosting.azurerm_mssql_server.default[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Sql/servers/s190t01-plantech][0m
+[0m[1mazurerm_storage_account.function_storage: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Storage/storageAccounts/s190t01plantechfuncstr][0m
+[0m[1mmodule.main_hosting.azurerm_subnet_route_table_association.containerinstances_subnet[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/virtualNetworks/s190t01-plantechdefault/subnets/s190t01-plantechcontainerinstances][0m
+[0m[1mmodule.main_hosting.azurerm_container_app_environment.container_app_env: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.App/managedEnvironments/s190t01-plantechcontainerapp][0m
+[0m[1mmodule.main_hosting.azurerm_subnet_route_table_association.container_apps_infra_subnet[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/virtualNetworks/s190t01-plantechdefault/subnets/s190t01-plantechcontainerappsinfra][0m
+[0m[1mmodule.main_hosting.azurerm_subnet_network_security_group_association.container_apps_infra[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/virtualNetworks/s190t01-plantechdefault/subnets/s190t01-plantechcontainerappsinfra][0m
+[0m[1mmodule.main_hosting.azurerm_container_registry.acr[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.ContainerRegistry/registries/s190t01plantech][0m
+[0m[1mmodule.main_hosting.azurerm_subnet_route_table_association.mssql_private_endpoint_subnet[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/virtualNetworks/s190t01-plantechdefault/subnets/s190t01-plantechmssqlprivateendpoint][0m
+[0m[1mazurerm_key_vault.vault: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.KeyVault/vaults/s190t01-plantech-kv][0m
+[0m[1mmodule.main_hosting.azurerm_application_insights.main[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Insights/components/s190t01-plantech-insights][0m
+[0m[1mmodule.main_hosting.azurerm_monitor_diagnostic_setting.container_app_env: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.App/managedEnvironments/s190t01-plantechcontainerapp|s190t01-plantech-containerapp-diag][0m
+[0m[1mmodule.main_hosting.azurerm_network_security_rule.container_apps_infra_allow_frontdoor_inbound_only[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/networkSecurityGroups/s190t01-plantechcontainerappsinfransg/securityRules/AllowFrontdoor][0m
+[0m[1mmodule.main_hosting.azapi_update_resource.mssql_vulnerability_assessment[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Sql/servers/s190t01-plantech/sqlVulnerabilityAssessments/s190t01-plantech][0m
+[0m[1mmodule.main_hosting.azapi_update_resource.mssql_threat_protection[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Sql/servers/s190t01-plantech/advancedThreatProtectionSettings/s190t01-plantech][0m
+[0m[1mmodule.main_hosting.azurerm_mssql_database.default[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Sql/servers/s190t01-plantech/databases/s190t01-plantech-sqldb][0m
+[0m[1mmodule.main_hosting.azurerm_private_endpoint.default["mssql"]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateEndpoints/s190t01-plantechmssql][0m
+[0m[1mazurerm_key_vault_secret.vault_secret_contentful_spaceid: Refreshing state... [id=https://s190t01-plantech-kv.vault.azure.net/secrets/contentful--spaceid/96304b12924f40f9a736b7d54670d0b0][0m
+[0m[1mazurerm_key_vault_secret.vault_secret_contentful_environment: Refreshing state... [id=https://s190t01-plantech-kv.vault.azure.net/secrets/contentful--environment/61e1a854e9924223b4e58319d61ffd6a][0m
+[0m[1mazurerm_key_vault_secret.csp_default_src: Refreshing state... [id=https://s190t01-plantech-kv.vault.azure.net/secrets/CSP--DefaultSrc/f94151fc987d4de08467c3ed63e17e4e][0m
+[0m[1mazurerm_key_vault_secret.vault_secret_contentful_previewapikey: Refreshing state... [id=https://s190t01-plantech-kv.vault.azure.net/secrets/contentful--previewapikey/75f55b92027d4c50b559b25a41ae32c5][0m
+[0m[1mazurerm_key_vault_access_policy.vault_access_policy_tf: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.KeyVault/vaults/s190t01-plantech-kv/objectId/626a60f8-5576-4fb8-8ab4-06d6f2767ed7][0m
+[0m[1mazurerm_key_vault_secret.vault_secret_contentful_deliveryapikey: Refreshing state... [id=https://s190t01-plantech-kv.vault.azure.net/secrets/contentful--deliveryapikey/1ced12df40fa4028935a9814a54d7427][0m
+[0m[1mazurerm_key_vault_access_policy.vault_access_policy_mi: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.KeyVault/vaults/s190t01-plantech-kv/objectId/2f156b0a-108b-4edb-a5b9-e1cc3e9ddec7][0m
+[0m[1mazurerm_key_vault_secret.vault_secret_database_connectionstring: Refreshing state... [id=https://s190t01-plantech-kv.vault.azure.net/secrets/connectionstrings--database/e5a766f5144d454eb497afc59364cfe7][0m
+[0m[1mazurerm_key_vault_secret.csp_frame_src: Refreshing state... [id=https://s190t01-plantech-kv.vault.azure.net/secrets/CSP--FrameSrc/d3ee006c5a4d4575b587306621ab0fda][0m
+[0m[1mazurerm_key_vault_secret.csp_connect_src: Refreshing state... [id=https://s190t01-plantech-kv.vault.azure.net/secrets/CSP--ConnectSrc/702e2f9ec09a4d7e8fdfe3167cd32135][0m
+[0m[1mazurerm_key_vault_secret.csp_img_src: Refreshing state... [id=https://s190t01-plantech-kv.vault.azure.net/secrets/CSP--ImgSrc/75d8dcd10c2044b2b0698b396bcbb68f][0m
+[0m[1mazurerm_key_vault_key.data_protection_key: Refreshing state... [id=https://s190t01-plantech-kv.vault.azure.net/keys/dataprotection/a64451e9bc2a44bc92e2613e1bdcbede][0m
+[0m[1mazurerm_servicebus_queue.contentful_queue: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.ServiceBus/namespaces/s190t01-plantechservicebus/queues/contentful][0m
+[0m[1mmodule.main_hosting.azurerm_storage_container.mssql_security_storage[0]: Refreshing state... [id=https://s190t01plantechmssqlsec.blob.core.windows.net/s190t01-plantech-mssqlsec][0m
+[0m[1mmodule.main_hosting.azurerm_storage_account_network_rules.mssql_security_storage[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Storage/storageAccounts/s190t01plantechmssqlsec][0m
+[0m[1mmodule.main_hosting.azurerm_mssql_server_extended_auditing_policy.default[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Sql/servers/s190t01-plantech/extendedAuditingSettings/Default][0m
+[0m[1mmodule.main_hosting.azurerm_monitor_diagnostic_setting.mssql_security_storage[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Storage/storageAccounts/s190t01plantechmssqlsec/blobServices/default|s190t01-plantech-mssql-blob-diag][0m
+[0m[1mmodule.main_hosting.azurerm_container_app.container_apps["main"]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.App/containerApps/s190t01-plantech-plan-tech-app][0m
+[0m[1mazurerm_servicebus_queue_authorization_rule.azurefunction: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.ServiceBus/namespaces/s190t01-plantechservicebus/queues/contentful/authorizationRules/azurefunction][0m
+[0m[1mmodule.main_hosting.azurerm_private_dns_a_record.mssql_private_endpoint[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateDnsZones/s190t01-plantech.database.windows.net/A/@][0m
+[0m[1mmodule.main_hosting.azurerm_mssql_database_extended_auditing_policy.default[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Sql/servers/s190t01-plantech/databases/s190t01-plantech-sqldb/extendedAuditingSettings/Default][0m
+[0m[1mmodule.waf.azurerm_cdn_frontdoor_profile.waf[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Cdn/profiles/s190t01-plantech-cdnwaf][0m
+[0m[1mmodule.waf.azurerm_monitor_action_group.main: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Insights/actionGroups/s190t01-plantech-actiongroup][0m
+[0m[1mmodule.waf.azurerm_log_analytics_workspace.waf: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.OperationalInsights/workspaces/s190t01-plantechwaf][0m
+[0m[1mmodule.waf.azurerm_cdn_frontdoor_rule_set.origin_headers["container-app-url"]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Cdn/profiles/s190t01-plantech-cdnwaf/ruleSets/containerappurlheaders][0m
+[0m[1mmodule.waf.azurerm_cdn_frontdoor_rule_set.global_headers[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Cdn/profiles/s190t01-plantech-cdnwaf/ruleSets/s190t01plantechheaders][0m
+[0m[1mmodule.waf.azurerm_cdn_frontdoor_endpoint.waf["container-app-url"]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Cdn/profiles/s190t01-plantech-cdnwaf/afdEndpoints/s190t01-plantech-container-app-url][0m
+[0m[1mmodule.waf.azurerm_cdn_frontdoor_origin_group.waf["container-app-url"]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Cdn/profiles/s190t01-plantech-cdnwaf/originGroups/s190t01-plantech-container-app-url][0m
+[0m[1mmodule.waf.azurerm_cdn_frontdoor_firewall_policy.waf[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/frontDoorWebApplicationFirewallPolicies/s190t01plantechwaf][0m
+[0m[1mmodule.waf.azurerm_monitor_diagnostic_setting.waf: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Cdn/profiles/s190t01-plantech-cdnwaf|s190t01-plantechwaf][0m
+[0m[1mmodule.waf.azurerm_cdn_frontdoor_origin.waf["container-app-url"]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Cdn/profiles/s190t01-plantech-cdnwaf/originGroups/s190t01-plantech-container-app-url/origins/s190t01-plantechorigin-container-app-url][0m
+[0m[1mmodule.waf.azurerm_cdn_frontdoor_route.waf["container-app-url"]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Cdn/profiles/s190t01-plantech-cdnwaf/afdEndpoints/s190t01-plantech-container-app-url/routes/s190t01-plantech-container-app-url][0m
+[0m[1mmodule.waf.azurerm_cdn_frontdoor_rule.add_response_headers["2"]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Cdn/profiles/s190t01-plantech-cdnwaf/ruleSets/s190t01plantechheaders/rules/addresponseheaders2][0m
+[0m[1mmodule.waf.azurerm_cdn_frontdoor_rule.add_response_headers["1"]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Cdn/profiles/s190t01-plantech-cdnwaf/ruleSets/s190t01plantechheaders/rules/addresponseheaders1][0m
+[0m[1mmodule.waf.azurerm_cdn_frontdoor_rule.add_response_headers["0"]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Cdn/profiles/s190t01-plantech-cdnwaf/ruleSets/s190t01plantechheaders/rules/addresponseheaders0][0m
+[0m[1mmodule.waf.azurerm_cdn_frontdoor_security_policy.waf[0]: Refreshing state... [id=/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Cdn/profiles/s190t01-plantech-cdnwaf/securityPolicies/s190t01plantechwafsecuritypolicy][0m
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  [32m+[0m create[0m
+  [33m~[0m update in-place[0m
+  [31m-[0m destroy[0m
+[31m-[0m/[32m+[0m destroy and then create replacement[0m
+ [36m<=[0m read (data resources)[0m
+
+Terraform will perform the following actions:
+
+[1m  # azapi_resource.contentful_function[0m will be [1m[31mdestroyed[0m
+  # (because azapi_resource.contentful_function is not in configuration)
+[0m  [31m-[0m[0m resource "azapi_resource" "contentful_function" {
+      [31m-[0m[0m body                      = (sensitive value) [90m-> null[0m[0m
+      [31m-[0m[0m id                        = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Web/sites/s190t01-plantechcontentfulfunction" [90m-> null[0m[0m
+      [31m-[0m[0m ignore_casing             = false [90m-> null[0m[0m
+      [31m-[0m[0m ignore_missing_property   = true [90m-> null[0m[0m
+      [31m-[0m[0m location                  = "northeurope" [90m-> null[0m[0m
+      [31m-[0m[0m name                      = "s190t01-plantechcontentfulfunction" [90m-> null[0m[0m
+      [31m-[0m[0m output                    = jsonencode({})
+      [31m-[0m[0m parent_id                 = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech" [90m-> null[0m[0m
+      [31m-[0m[0m removing_special_chars    = false [90m-> null[0m[0m
+      [31m-[0m[0m schema_validation_enabled = false [90m-> null[0m[0m
+      [31m-[0m[0m tags                      = {
+          [31m-[0m[0m "Environment"                                    = "Test"
+          [31m-[0m[0m "Product"                                        = "Plan Technology for your School"
+          [31m-[0m[0m "Service Offering"                               = "Plan Technology for your School"
+          [31m-[0m[0m "hidden-link: /app-insights-conn-string"         = "InstrumentationKey=a5c4bea1-42c3-4568-b801-6abd66e00cb4;IngestionEndpoint=https://westeurope-2.in.applicationinsights.azure.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.com/;ApplicationId=840af685-c6c4-4e61-ac53-c7a9c54cb0fd"
+          [31m-[0m[0m "hidden-link: /app-insights-instrumentation-key" = "a5c4bea1-42c3-4568-b801-6abd66e00cb4"
+          [31m-[0m[0m "hidden-link: /app-insights-resource-id"         = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/microsoft.insights/components/s190t01-plantech-function-insights"
+        } [90m-> null[0m[0m
+      [31m-[0m[0m type                      = "Microsoft.Web/sites@2023-12-01" [90m-> null[0m[0m
+
+      [31m-[0m[0m identity {
+          [31m-[0m[0m identity_ids = [
+              [31m-[0m[0m "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.ManagedIdentity/userAssignedIdentities/s190t01-plantech-mi",
+            ] [90m-> null[0m[0m
+          [31m-[0m[0m type         = "UserAssigned" [90m-> null[0m[0m
+        }
+    }
+
+[1m  # azapi_update_resource.example[0m will be [1m[31mdestroyed[0m
+  # (because azapi_update_resource.example is not in configuration)
+[0m  [31m-[0m[0m resource "azapi_update_resource" "example" {
+      [31m-[0m[0m body                    = {
+          [31m-[0m[0m properties = {
+              [31m-[0m[0m keyVaultReferenceIdentity = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourcegroups/s190t01-plantech/providers/Microsoft.ManagedIdentity/userAssignedIdentities/s190t01-plantech-mi"
+            }
+        } [90m-> null[0m[0m
+      [31m-[0m[0m id                      = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Web/sites/s190t01-plantechcontentfulfunction" [90m-> null[0m[0m
+      [31m-[0m[0m ignore_casing           = false [90m-> null[0m[0m
+      [31m-[0m[0m ignore_missing_property = true [90m-> null[0m[0m
+      [31m-[0m[0m name                    = "s190t01-plantechcontentfulfunction" [90m-> null[0m[0m
+      [31m-[0m[0m output                  = {} [90m-> null[0m[0m
+      [31m-[0m[0m parent_id               = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech" [90m-> null[0m[0m
+      [31m-[0m[0m resource_id             = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Web/sites/s190t01-plantechcontentfulfunction" [90m-> null[0m[0m
+      [31m-[0m[0m type                    = "Microsoft.Web/sites@2023-12-01" [90m-> null[0m[0m
+    }
+
+[1m  # azurerm_app_service_connection.azurekeyvaultconnector[0m will be created
+[0m  [32m+[0m[0m resource "azurerm_app_service_connection" "azurekeyvaultconnector" {
+      [32m+[0m[0m app_service_id     = (known after apply)
+      [32m+[0m[0m client_type        = "dotnet"
+      [32m+[0m[0m id                 = (known after apply)
+      [32m+[0m[0m name               = "azurekeyvaultconnection"
+      [32m+[0m[0m target_resource_id = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.KeyVault/vaults/s190t01-plantech-kv"
+
+      [32m+[0m[0m authentication {
+          [32m+[0m[0m client_id       = "988101f8-5c0b-4fb9-b9ad-d37d49eba44e"
+          [32m+[0m[0m subscription_id = "78c3e82f-256f-46c0-a8ca-29ad3a499b89"
+          [32m+[0m[0m type            = "userAssignedIdentity"
+        }
+    }
+
+[1m  # azurerm_app_service_connection.azuresqlconnector[0m will be created
+[0m  [32m+[0m[0m resource "azurerm_app_service_connection" "azuresqlconnector" {
+      [32m+[0m[0m app_service_id     = (known after apply)
+      [32m+[0m[0m client_type        = "dotnet"
+      [32m+[0m[0m id                 = (known after apply)
+      [32m+[0m[0m name               = "azuresqlconnection"
+      [32m+[0m[0m target_resource_id = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Sql/servers/s190t01-plantech/databases/s190t01-plantech-sqldb"
+
+      [32m+[0m[0m authentication {
+          [32m+[0m[0m client_id       = "988101f8-5c0b-4fb9-b9ad-d37d49eba44e"
+          [32m+[0m[0m subscription_id = "78c3e82f-256f-46c0-a8ca-29ad3a499b89"
+          [32m+[0m[0m type            = "userAssignedIdentity"
+        }
+    }
+
+[1m  # azurerm_key_vault.vault[0m will be updated in-place
+[0m  [33m~[0m[0m resource "azurerm_key_vault" "vault" {
+        id                              = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.KeyVault/vaults/s190t01-plantech-kv"
+        name                            = "s190t01-plantech-kv"
+        tags                            = {
+            "Environment"      = "Test"
+            "Product"          = "Plan Technology for your School"
+            "Service Offering" = "Plan Technology for your School"
+        }
+        [90m# (13 unchanged attributes hidden)[0m[0m
+
+      [33m~[0m[0m network_acls {
+          [33m~[0m[0m virtual_network_subnet_ids = [
+              [31m-[0m[0m "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/virtualNetworks/s190t01-plantech-function-vn/subnets/s190t01-plantech-keyvault",
+                [90m# (1 unchanged element hidden)[0m[0m
+            ]
+            [90m# (3 unchanged attributes hidden)[0m[0m
+        }
+    }
+
+[1m  # azurerm_linux_function_app.contentful_function[0m will be created
+[0m  [32m+[0m[0m resource "azurerm_linux_function_app" "contentful_function" {
+      [32m+[0m[0m app_settings                                   = {
+          [32m+[0m[0m "AZURE_CLIENT_ID"                 = "988101f8-5c0b-4fb9-b9ad-d37d49eba44e"
+          [32m+[0m[0m "AZURE_KEYVAULT_CLIENTID"         = "988101f8-5c0b-4fb9-b9ad-d37d49eba44e"
+          [32m+[0m[0m "AZURE_KEYVAULT_RESOURCEENDPOINT" = "https://s190t01-plantech-kv.vault.azure.net/"
+          [32m+[0m[0m "AZURE_KEYVAULT_SCOPE"            = "https://vault.azure.net/.default"
+          [32m+[0m[0m "AZURE_SQL_CONNECTIONSTRING"      = "@Microsoft.KeyVault(VaultName=s190t01-plantech-kv;SecretName=connectionstrings--database)"
+          [32m+[0m[0m "AzureWebJobsServiceBus"          = (sensitive value)
+          [32m+[0m[0m "KeyVaultReferenceIdentity"       = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.ManagedIdentity/userAssignedIdentities/s190t01-plantech-mi"
+          [32m+[0m[0m "WEBSITE_ENABLE_SYNC_UPDATE_SITE" = "true"
+          [32m+[0m[0m "WEBSITE_MOUNT_ENABLED"           = "1"
+          [32m+[0m[0m "WEBSITE_RUN_FROM_PACKAGE"        = ""
+        }
+      [32m+[0m[0m builtin_logging_enabled                        = true
+      [32m+[0m[0m client_certificate_enabled                     = false
+      [32m+[0m[0m client_certificate_mode                        = "Optional"
+      [32m+[0m[0m content_share_force_disabled                   = false
+      [32m+[0m[0m custom_domain_verification_id                  = (sensitive value)
+      [32m+[0m[0m daily_memory_time_quota                        = 0
+      [32m+[0m[0m default_hostname                               = (known after apply)
+      [32m+[0m[0m enabled                                        = true
+      [32m+[0m[0m ftp_publish_basic_authentication_enabled       = true
+      [32m+[0m[0m functions_extension_version                    = "~4"
+      [32m+[0m[0m hosting_environment_id                         = (known after apply)
+      [32m+[0m[0m https_only                                     = false
+      [32m+[0m[0m id                                             = (known after apply)
+      [32m+[0m[0m key_vault_reference_identity_id                = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.ManagedIdentity/userAssignedIdentities/s190t01-plantech-mi"
+      [32m+[0m[0m kind                                           = (known after apply)
+      [32m+[0m[0m location                                       = "westeurope"
+      [32m+[0m[0m name                                           = "s190t01-plantechcontentfulfunction"
+      [32m+[0m[0m outbound_ip_address_list                       = (known after apply)
+      [32m+[0m[0m outbound_ip_addresses                          = (known after apply)
+      [32m+[0m[0m possible_outbound_ip_address_list              = (known after apply)
+      [32m+[0m[0m possible_outbound_ip_addresses                 = (known after apply)
+      [32m+[0m[0m public_network_access_enabled                  = true
+      [32m+[0m[0m resource_group_name                            = "s190t01-plantech"
+      [32m+[0m[0m service_plan_id                                = (known after apply)
+      [32m+[0m[0m site_credential                                = (sensitive value)
+      [32m+[0m[0m storage_account_access_key                     = (sensitive value)
+      [32m+[0m[0m storage_account_name                           = "s190t01plantechfuncstr"
+      [32m+[0m[0m storage_uses_managed_identity                  = false
+      [32m+[0m[0m tags                                           = {
+          [32m+[0m[0m "Environment"      = "Test"
+          [32m+[0m[0m "Product"          = "Plan Technology for your School"
+          [32m+[0m[0m "Service Offering" = "Plan Technology for your School"
+        }
+      [32m+[0m[0m webdeploy_publish_basic_authentication_enabled = true
+      [32m+[0m[0m zip_deploy_file                                = (known after apply)
+
+      [32m+[0m[0m identity {
+          [32m+[0m[0m identity_ids = [
+              [32m+[0m[0m "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.ManagedIdentity/userAssignedIdentities/s190t01-plantech-mi",
+            ]
+          [32m+[0m[0m principal_id = (known after apply)
+          [32m+[0m[0m tenant_id    = (known after apply)
+          [32m+[0m[0m type         = "UserAssigned"
+        }
+
+      [32m+[0m[0m site_config {
+          [32m+[0m[0m always_on                               = (known after apply)
+          [32m+[0m[0m app_scale_limit                         = (known after apply)
+          [32m+[0m[0m application_insights_key                = (sensitive value)
+          [32m+[0m[0m container_registry_use_managed_identity = false
+          [32m+[0m[0m default_documents                       = (known after apply)
+          [32m+[0m[0m detailed_error_logging_enabled          = (known after apply)
+          [32m+[0m[0m elastic_instance_minimum                = (known after apply)
+          [32m+[0m[0m ftps_state                              = "Disabled"
+          [32m+[0m[0m health_check_eviction_time_in_min       = (known after apply)
+          [32m+[0m[0m http2_enabled                           = false
+          [32m+[0m[0m ip_restriction_default_action           = "Allow"
+          [32m+[0m[0m linux_fx_version                        = (known after apply)
+          [32m+[0m[0m load_balancing_mode                     = "LeastRequests"
+          [32m+[0m[0m managed_pipeline_mode                   = "Integrated"
+          [32m+[0m[0m minimum_tls_version                     = "1.2"
+          [32m+[0m[0m pre_warmed_instance_count               = (known after apply)
+          [32m+[0m[0m remote_debugging_enabled                = false
+          [32m+[0m[0m remote_debugging_version                = (known after apply)
+          [32m+[0m[0m scm_ip_restriction_default_action       = "Allow"
+          [32m+[0m[0m scm_minimum_tls_version                 = "1.2"
+          [32m+[0m[0m scm_type                                = (known after apply)
+          [32m+[0m[0m scm_use_main_ip_restriction             = false
+          [32m+[0m[0m use_32_bit_worker                       = false
+          [32m+[0m[0m vnet_route_all_enabled                  = false
+          [32m+[0m[0m websockets_enabled                      = false
+          [32m+[0m[0m worker_count                            = (known after apply)
+
+          [32m+[0m[0m application_stack {
+              [32m+[0m[0m dotnet_version              = "8.0"
+              [32m+[0m[0m use_dotnet_isolated_runtime = true
+            }
+        }
+    }
+
+[1m  # azurerm_private_dns_zone.blob_storage[0m will be [1m[31mdestroyed[0m
+  # (because azurerm_private_dns_zone.blob_storage is not in configuration)
+[0m  [31m-[0m[0m resource "azurerm_private_dns_zone" "blob_storage" {
+      [31m-[0m[0m id                                                    = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateDnsZones/privatelink.blob.core.windows.net" [90m-> null[0m[0m
+      [31m-[0m[0m max_number_of_record_sets                             = 25000 [90m-> null[0m[0m
+      [31m-[0m[0m max_number_of_virtual_network_links                   = 1000 [90m-> null[0m[0m
+      [31m-[0m[0m max_number_of_virtual_network_links_with_registration = 100 [90m-> null[0m[0m
+      [31m-[0m[0m name                                                  = "privatelink.blob.core.windows.net" [90m-> null[0m[0m
+      [31m-[0m[0m number_of_record_sets                                 = 2 [90m-> null[0m[0m
+      [31m-[0m[0m resource_group_name                                   = "s190t01-plantech" [90m-> null[0m[0m
+      [31m-[0m[0m tags                                                  = {
+          [31m-[0m[0m "Environment" = "Test"
+          [31m-[0m[0m "Product"     = "Plan Technology for your School"
+        } [90m-> null[0m[0m
+
+      [31m-[0m[0m soa_record {
+          [31m-[0m[0m email         = "azureprivatedns-host.microsoft.com" [90m-> null[0m[0m
+          [31m-[0m[0m expire_time   = 2419200 [90m-> null[0m[0m
+          [31m-[0m[0m fqdn          = "privatelink.blob.core.windows.net." [90m-> null[0m[0m
+          [31m-[0m[0m host_name     = "azureprivatedns.net" [90m-> null[0m[0m
+          [31m-[0m[0m minimum_ttl   = 10 [90m-> null[0m[0m
+          [31m-[0m[0m refresh_time  = 3600 [90m-> null[0m[0m
+          [31m-[0m[0m retry_time    = 300 [90m-> null[0m[0m
+          [31m-[0m[0m serial_number = 1 [90m-> null[0m[0m
+          [31m-[0m[0m tags          = {} [90m-> null[0m[0m
+          [31m-[0m[0m ttl           = 3600 [90m-> null[0m[0m
+        }
+    }
+
+[1m  # azurerm_private_dns_zone.files_storage[0m will be [1m[31mdestroyed[0m
+  # (because azurerm_private_dns_zone.files_storage is not in configuration)
+[0m  [31m-[0m[0m resource "azurerm_private_dns_zone" "files_storage" {
+      [31m-[0m[0m id                                                    = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateDnsZones/privatelink.file.core.windows.net" [90m-> null[0m[0m
+      [31m-[0m[0m max_number_of_record_sets                             = 25000 [90m-> null[0m[0m
+      [31m-[0m[0m max_number_of_virtual_network_links                   = 1000 [90m-> null[0m[0m
+      [31m-[0m[0m max_number_of_virtual_network_links_with_registration = 100 [90m-> null[0m[0m
+      [31m-[0m[0m name                                                  = "privatelink.file.core.windows.net" [90m-> null[0m[0m
+      [31m-[0m[0m number_of_record_sets                                 = 2 [90m-> null[0m[0m
+      [31m-[0m[0m resource_group_name                                   = "s190t01-plantech" [90m-> null[0m[0m
+      [31m-[0m[0m tags                                                  = {
+          [31m-[0m[0m "Environment" = "Test"
+          [31m-[0m[0m "Product"     = "Plan Technology for your School"
+        } [90m-> null[0m[0m
+
+      [31m-[0m[0m soa_record {
+          [31m-[0m[0m email         = "azureprivatedns-host.microsoft.com" [90m-> null[0m[0m
+          [31m-[0m[0m expire_time   = 2419200 [90m-> null[0m[0m
+          [31m-[0m[0m fqdn          = "privatelink.file.core.windows.net." [90m-> null[0m[0m
+          [31m-[0m[0m host_name     = "azureprivatedns.net" [90m-> null[0m[0m
+          [31m-[0m[0m minimum_ttl   = 10 [90m-> null[0m[0m
+          [31m-[0m[0m refresh_time  = 3600 [90m-> null[0m[0m
+          [31m-[0m[0m retry_time    = 300 [90m-> null[0m[0m
+          [31m-[0m[0m serial_number = 1 [90m-> null[0m[0m
+          [31m-[0m[0m tags          = {} [90m-> null[0m[0m
+          [31m-[0m[0m ttl           = 3600 [90m-> null[0m[0m
+        }
+    }
+
+[1m  # azurerm_private_endpoint.blob_storage[0m will be [1m[31mdestroyed[0m
+  # (because azurerm_private_endpoint.blob_storage is not in configuration)
+[0m  [31m-[0m[0m resource "azurerm_private_endpoint" "blob_storage" {
+      [31m-[0m[0m custom_dns_configs            = [] [90m-> null[0m[0m
+      [31m-[0m[0m custom_network_interface_name = "s190t01-plantech-blob-storage-nic" [90m-> null[0m[0m
+      [31m-[0m[0m id                            = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateEndpoints/s190t01-plantech-blob-storage" [90m-> null[0m[0m
+      [31m-[0m[0m location                      = "northeurope" [90m-> null[0m[0m
+      [31m-[0m[0m name                          = "s190t01-plantech-blob-storage" [90m-> null[0m[0m
+      [31m-[0m[0m network_interface             = [
+          [31m-[0m[0m {
+              [31m-[0m[0m id   = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/networkInterfaces/s190t01-plantech-blob-storage-nic"
+              [31m-[0m[0m name = "s190t01-plantech-blob-storage-nic"
+            },
+        ] [90m-> null[0m[0m
+      [31m-[0m[0m private_dns_zone_configs      = [
+          [31m-[0m[0m {
+              [31m-[0m[0m id                  = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateEndpoints/s190t01-plantech-blob-storage/privateDnsZoneGroups/default/privateDnsZoneConfigs/privatelink.blob.core.windows.net"
+              [31m-[0m[0m name                = "privatelink.blob.core.windows.net"
+              [31m-[0m[0m private_dns_zone_id = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateDnsZones/privatelink.blob.core.windows.net"
+              [31m-[0m[0m record_sets         = [
+                  [31m-[0m[0m {
+                      [31m-[0m[0m fqdn         = "s190t01plantechfuncstr.privatelink.blob.core.windows.net"
+                      [31m-[0m[0m ip_addresses = [
+                          [31m-[0m[0m "10.0.1.5",
+                        ]
+                      [31m-[0m[0m name         = "s190t01plantechfuncstr"
+                      [31m-[0m[0m ttl          = 10
+                      [31m-[0m[0m type         = "A"
+                    },
+                ]
+            },
+        ] [90m-> null[0m[0m
+      [31m-[0m[0m resource_group_name           = "s190t01-plantech" [90m-> null[0m[0m
+      [31m-[0m[0m subnet_id                     = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/virtualNetworks/s190t01-plantech-function-vn/subnets/s190t01-plantech-function-storage" [90m-> null[0m[0m
+      [31m-[0m[0m tags                          = {
+          [31m-[0m[0m "Environment"      = "Test"
+          [31m-[0m[0m "Product"          = "Plan Technology for your School"
+          [31m-[0m[0m "Service Offering" = "Plan Technology for your School"
+        } [90m-> null[0m[0m
+
+      [31m-[0m[0m private_dns_zone_group {
+          [31m-[0m[0m id                   = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateEndpoints/s190t01-plantech-blob-storage/privateDnsZoneGroups/default" [90m-> null[0m[0m
+          [31m-[0m[0m name                 = "default" [90m-> null[0m[0m
+          [31m-[0m[0m private_dns_zone_ids = [
+              [31m-[0m[0m "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateDnsZones/privatelink.blob.core.windows.net",
+            ] [90m-> null[0m[0m
+        }
+
+      [31m-[0m[0m private_service_connection {
+          [31m-[0m[0m is_manual_connection           = false [90m-> null[0m[0m
+          [31m-[0m[0m name                           = "s190t01-plantech-blob-storage" [90m-> null[0m[0m
+          [31m-[0m[0m private_connection_resource_id = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Storage/storageAccounts/s190t01plantechfuncstr" [90m-> null[0m[0m
+          [31m-[0m[0m private_ip_address             = "10.0.1.5" [90m-> null[0m[0m
+          [31m-[0m[0m subresource_names              = [
+              [31m-[0m[0m "blob",
+            ] [90m-> null[0m[0m
+        }
+    }
+
+[1m  # azurerm_private_endpoint.files_storage[0m will be [1m[31mdestroyed[0m
+  # (because azurerm_private_endpoint.files_storage is not in configuration)
+[0m  [31m-[0m[0m resource "azurerm_private_endpoint" "files_storage" {
+      [31m-[0m[0m custom_dns_configs            = [] [90m-> null[0m[0m
+      [31m-[0m[0m custom_network_interface_name = "s190t01-plantech-files-storage-nic" [90m-> null[0m[0m
+      [31m-[0m[0m id                            = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateEndpoints/s190t01-plantech-files-storage" [90m-> null[0m[0m
+      [31m-[0m[0m location                      = "northeurope" [90m-> null[0m[0m
+      [31m-[0m[0m name                          = "s190t01-plantech-files-storage" [90m-> null[0m[0m
+      [31m-[0m[0m network_interface             = [
+          [31m-[0m[0m {
+              [31m-[0m[0m id   = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/networkInterfaces/s190t01-plantech-files-storage-nic"
+              [31m-[0m[0m name = "s190t01-plantech-files-storage-nic"
+            },
+        ] [90m-> null[0m[0m
+      [31m-[0m[0m private_dns_zone_configs      = [
+          [31m-[0m[0m {
+              [31m-[0m[0m id                  = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateEndpoints/s190t01-plantech-files-storage/privateDnsZoneGroups/default/privateDnsZoneConfigs/privatelink.file.core.windows.net"
+              [31m-[0m[0m name                = "privatelink.file.core.windows.net"
+              [31m-[0m[0m private_dns_zone_id = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateDnsZones/privatelink.file.core.windows.net"
+              [31m-[0m[0m record_sets         = [
+                  [31m-[0m[0m {
+                      [31m-[0m[0m fqdn         = "s190t01plantechfuncstr.privatelink.file.core.windows.net"
+                      [31m-[0m[0m ip_addresses = [
+                          [31m-[0m[0m "10.0.1.4",
+                        ]
+                      [31m-[0m[0m name         = "s190t01plantechfuncstr"
+                      [31m-[0m[0m ttl          = 10
+                      [31m-[0m[0m type         = "A"
+                    },
+                ]
+            },
+        ] [90m-> null[0m[0m
+      [31m-[0m[0m resource_group_name           = "s190t01-plantech" [90m-> null[0m[0m
+      [31m-[0m[0m subnet_id                     = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/virtualNetworks/s190t01-plantech-function-vn/subnets/s190t01-plantech-function-storage" [90m-> null[0m[0m
+      [31m-[0m[0m tags                          = {
+          [31m-[0m[0m "Environment"      = "Test"
+          [31m-[0m[0m "Product"          = "Plan Technology for your School"
+          [31m-[0m[0m "Service Offering" = "Plan Technology for your School"
+        } [90m-> null[0m[0m
+
+      [31m-[0m[0m private_dns_zone_group {
+          [31m-[0m[0m id                   = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateEndpoints/s190t01-plantech-files-storage/privateDnsZoneGroups/default" [90m-> null[0m[0m
+          [31m-[0m[0m name                 = "default" [90m-> null[0m[0m
+          [31m-[0m[0m private_dns_zone_ids = [
+              [31m-[0m[0m "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateDnsZones/privatelink.file.core.windows.net",
+            ] [90m-> null[0m[0m
+        }
+
+      [31m-[0m[0m private_service_connection {
+          [31m-[0m[0m is_manual_connection           = false [90m-> null[0m[0m
+          [31m-[0m[0m name                           = "s190t01-plantech-files-storage" [90m-> null[0m[0m
+          [31m-[0m[0m private_connection_resource_id = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Storage/storageAccounts/s190t01plantechfuncstr" [90m-> null[0m[0m
+          [31m-[0m[0m private_ip_address             = "10.0.1.4" [90m-> null[0m[0m
+          [31m-[0m[0m subresource_names              = [
+              [31m-[0m[0m "file",
+            ] [90m-> null[0m[0m
+        }
+    }
+
+[1m  # azurerm_service_plan.function_plan[0m must be [1m[31mreplaced[0m
+[0m[31m-[0m/[32m+[0m[0m resource "azurerm_service_plan" "function_plan" {
+      [33m~[0m[0m id                           = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Web/serverFarms/s190t01-plantechappserviceplan" -> (known after apply)
+      [33m~[0m[0m kind                         = "functionapp" -> (known after apply)
+      [33m~[0m[0m location                     = "northeurope" [33m->[0m[0m "westeurope" [31m# forces replacement[0m[0m
+      [33m~[0m[0m maximum_elastic_worker_count = 1 -> (known after apply)
+        name                         = "s190t01-plantechappserviceplan"
+      [33m~[0m[0m reserved                     = true -> (known after apply)
+      [33m~[0m[0m sku_name                     = "FC1" [33m->[0m[0m "Y1"
+        tags                         = {
+            "Environment"      = "Test"
+            "Product"          = "Plan Technology for your School"
+            "Service Offering" = "Plan Technology for your School"
+        }
+      [33m~[0m[0m worker_count                 = 0 -> (known after apply)
+      [31m-[0m[0m zone_balancing_enabled       = false [90m-> null[0m[0m
+        [90m# (3 unchanged attributes hidden)[0m[0m
+    }
+
+[1m  # azurerm_storage_account.function_storage[0m will be updated in-place
+[0m  [33m~[0m[0m resource "azurerm_storage_account" "function_storage" {
+        id                                = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Storage/storageAccounts/s190t01plantechfuncstr"
+        name                              = "s190t01plantechfuncstr"
+        tags                              = {
+            "Environment"      = "Test"
+            "Product"          = "Plan Technology for your School"
+            "Service Offering" = "Plan Technology for your School"
+        }
+        [90m# (40 unchanged attributes hidden)[0m[0m
+
+      [31m-[0m[0m sas_policy {
+          [31m-[0m[0m expiration_action = "Log" [90m-> null[0m[0m
+          [31m-[0m[0m expiration_period = "00.01:00:00" [90m-> null[0m[0m
+        }
+
+        [90m# (5 unchanged blocks hidden)[0m[0m
+    }
+
+[1m  # azurerm_subnet.function_infra_subnet[0m will be [1m[31mdestroyed[0m
+  # (because azurerm_subnet.function_infra_subnet is not in configuration)
+[0m  [31m-[0m[0m resource "azurerm_subnet" "function_infra_subnet" {
+      [31m-[0m[0m address_prefixes                               = [
+          [31m-[0m[0m "10.0.0.0/24",
+        ] [90m-> null[0m[0m
+      [31m-[0m[0m default_outbound_access_enabled                = true [90m-> null[0m[0m
+      [31m-[0m[0m enforce_private_link_endpoint_network_policies = false [90m-> null[0m[0m
+      [31m-[0m[0m enforce_private_link_service_network_policies  = false [90m-> null[0m[0m
+      [31m-[0m[0m id                                             = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/virtualNetworks/s190t01-plantech-function-vn/subnets/s190t01-plantech-functioninfra" [90m-> null[0m[0m
+      [31m-[0m[0m name                                           = "s190t01-plantech-functioninfra" [90m-> null[0m[0m
+      [31m-[0m[0m private_endpoint_network_policies              = "RouteTableEnabled" [90m-> null[0m[0m
+      [31m-[0m[0m private_endpoint_network_policies_enabled      = false [90m-> null[0m[0m
+      [31m-[0m[0m private_link_service_network_policies_enabled  = true [90m-> null[0m[0m
+      [31m-[0m[0m resource_group_name                            = "s190t01-plantech" [90m-> null[0m[0m
+      [31m-[0m[0m service_endpoint_policy_ids                    = [] [90m-> null[0m[0m
+      [31m-[0m[0m service_endpoints                              = [
+          [31m-[0m[0m "Microsoft.KeyVault",
+        ] [90m-> null[0m[0m
+      [31m-[0m[0m virtual_network_name                           = "s190t01-plantech-function-vn" [90m-> null[0m[0m
+
+      [31m-[0m[0m delegation {
+          [31m-[0m[0m name = "Microsoft.App.environments" [90m-> null[0m[0m
+
+          [31m-[0m[0m service_delegation {
+              [31m-[0m[0m actions = [
+                  [31m-[0m[0m "Microsoft.Network/virtualNetworks/subnets/join/action",
+                ] [90m-> null[0m[0m
+              [31m-[0m[0m name    = "Microsoft.App/environments" [90m-> null[0m[0m
+            }
+        }
+    }
+
+[1m  # azurerm_subnet.function_storage[0m will be [1m[31mdestroyed[0m
+  # (because azurerm_subnet.function_storage is not in configuration)
+[0m  [31m-[0m[0m resource "azurerm_subnet" "function_storage" {
+      [31m-[0m[0m address_prefixes                               = [
+          [31m-[0m[0m "10.0.1.0/24",
+        ] [90m-> null[0m[0m
+      [31m-[0m[0m default_outbound_access_enabled                = true [90m-> null[0m[0m
+      [31m-[0m[0m enforce_private_link_endpoint_network_policies = true [90m-> null[0m[0m
+      [31m-[0m[0m enforce_private_link_service_network_policies  = false [90m-> null[0m[0m
+      [31m-[0m[0m id                                             = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/virtualNetworks/s190t01-plantech-function-vn/subnets/s190t01-plantech-function-storage" [90m-> null[0m[0m
+      [31m-[0m[0m name                                           = "s190t01-plantech-function-storage" [90m-> null[0m[0m
+      [31m-[0m[0m private_endpoint_network_policies              = "Disabled" [90m-> null[0m[0m
+      [31m-[0m[0m private_endpoint_network_policies_enabled      = false [90m-> null[0m[0m
+      [31m-[0m[0m private_link_service_network_policies_enabled  = true [90m-> null[0m[0m
+      [31m-[0m[0m resource_group_name                            = "s190t01-plantech" [90m-> null[0m[0m
+      [31m-[0m[0m service_endpoint_policy_ids                    = [] [90m-> null[0m[0m
+      [31m-[0m[0m service_endpoints                              = [
+          [31m-[0m[0m "Microsoft.KeyVault",
+        ] [90m-> null[0m[0m
+      [31m-[0m[0m virtual_network_name                           = "s190t01-plantech-function-vn" [90m-> null[0m[0m
+    }
+
+[1m  # azurerm_virtual_network.function_vnet[0m will be [1m[31mdestroyed[0m
+  # (because azurerm_virtual_network.function_vnet is not in configuration)
+[0m  [31m-[0m[0m resource "azurerm_virtual_network" "function_vnet" {
+      [31m-[0m[0m address_space           = [
+          [31m-[0m[0m "10.0.0.0/14",
+        ] [90m-> null[0m[0m
+      [31m-[0m[0m dns_servers             = [] [90m-> null[0m[0m
+      [31m-[0m[0m flow_timeout_in_minutes = 0 [90m-> null[0m[0m
+      [31m-[0m[0m guid                    = "5821af56-645d-46b5-b35b-269798c4e0a8" [90m-> null[0m[0m
+      [31m-[0m[0m id                      = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/virtualNetworks/s190t01-plantech-function-vn" [90m-> null[0m[0m
+      [31m-[0m[0m location                = "northeurope" [90m-> null[0m[0m
+      [31m-[0m[0m name                    = "s190t01-plantech-function-vn" [90m-> null[0m[0m
+      [31m-[0m[0m resource_group_name     = "s190t01-plantech" [90m-> null[0m[0m
+      [31m-[0m[0m subnet                  = [
+          [31m-[0m[0m {
+              [31m-[0m[0m address_prefix = "10.0.0.0/24"
+              [31m-[0m[0m id             = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/virtualNetworks/s190t01-plantech-function-vn/subnets/s190t01-plantech-functioninfra"
+              [31m-[0m[0m name           = "s190t01-plantech-functioninfra"
+              [31m-[0m[0m security_group = ""
+            },
+          [31m-[0m[0m {
+              [31m-[0m[0m address_prefix = "10.0.1.0/24"
+              [31m-[0m[0m id             = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/virtualNetworks/s190t01-plantech-function-vn/subnets/s190t01-plantech-function-storage"
+              [31m-[0m[0m name           = "s190t01-plantech-function-storage"
+              [31m-[0m[0m security_group = ""
+            },
+          [31m-[0m[0m {
+              [31m-[0m[0m address_prefix = "10.0.2.0/24"
+              [31m-[0m[0m id             = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/virtualNetworks/s190t01-plantech-function-vn/subnets/s190t01-plantech-keyvault"
+              [31m-[0m[0m name           = "s190t01-plantech-keyvault"
+              [31m-[0m[0m security_group = ""
+            },
+          [31m-[0m[0m {
+              [31m-[0m[0m address_prefix = "10.0.3.0/24"
+              [31m-[0m[0m id             = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/virtualNetworks/s190t01-plantech-function-vn/subnets/s190t01-plantech-function"
+              [31m-[0m[0m name           = "s190t01-plantech-function"
+              [31m-[0m[0m security_group = ""
+            },
+          [31m-[0m[0m {
+              [31m-[0m[0m address_prefix = "10.0.4.0/24"
+              [31m-[0m[0m id             = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/virtualNetworks/s190t01-plantech-function-vn/subnets/s190t01-plantech-functest"
+              [31m-[0m[0m name           = "s190t01-plantech-functest"
+              [31m-[0m[0m security_group = ""
+            },
+        ] [90m-> null[0m[0m
+      [31m-[0m[0m tags                    = {
+          [31m-[0m[0m "Environment"      = "Test"
+          [31m-[0m[0m "Product"          = "Plan Technology for your School"
+          [31m-[0m[0m "Service Offering" = "Plan Technology for your School"
+        } [90m-> null[0m[0m
+    }
+
+[1m  # module.main_hosting.azapi_update_resource.mssql_security_storage_key_rotation_reminder[0][0m will be [1m[31mdestroyed[0m
+  # (because azapi_update_resource.mssql_security_storage_key_rotation_reminder is not in configuration)
+[0m  [31m-[0m[0m resource "azapi_update_resource" "mssql_security_storage_key_rotation_reminder" {
+      [31m-[0m[0m body                    = jsonencode(
+            {
+              [31m-[0m[0m properties = {
+                  [31m-[0m[0m keyPolicy = {
+                      [31m-[0m[0m keyExpirationPeriodInDays = 90
+                    }
+                }
+            }
+        ) [90m-> null[0m[0m
+      [31m-[0m[0m id                      = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Storage/storageAccounts/s190t01plantechmssqlsec" [90m-> null[0m[0m
+      [31m-[0m[0m ignore_casing           = false [90m-> null[0m[0m
+      [31m-[0m[0m ignore_missing_property = true [90m-> null[0m[0m
+      [31m-[0m[0m name                    = "s190t01plantechmssqlsec" [90m-> null[0m[0m
+      [31m-[0m[0m output                  = jsonencode({})
+      [31m-[0m[0m parent_id               = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech" [90m-> null[0m[0m
+      [31m-[0m[0m resource_id             = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Storage/storageAccounts/s190t01plantechmssqlsec" [90m-> null[0m[0m
+      [31m-[0m[0m type                    = "Microsoft.Storage/storageAccounts@2023-01-01" [90m-> null[0m[0m
+    }
+
+[1m  # module.main_hosting.azurerm_container_app.container_apps["main"][0m will be updated in-place
+[0m  [33m~[0m[0m resource "azurerm_container_app" "container_apps" {
+        id                            = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.App/containerApps/s190t01-plantech-plan-tech-app"
+        name                          = "s190t01-plantech-plan-tech-app"
+        tags                          = {
+            "Environment"      = "Test"
+            "Product"          = "Plan Technology for your School"
+            "Service Offering" = "Plan Technology for your School"
+        }
+        [90m# (8 unchanged attributes hidden)[0m[0m
+
+      [33m~[0m[0m template {
+            [90m# (2 unchanged attributes hidden)[0m[0m
+
+          [33m~[0m[0m container {
+              [33m~[0m[0m image             = "s190t01plantech.azurecr.io/plan-tech-app:development-784d22fa6925808e20b7d8bf2a8d658cca814681-Tst" [33m->[0m[0m "s190t01plantech.azurecr.io/plan-tech-app:development-b0757c8068c03780f926e148b9716ff63a3a8f81-Tst"
+                name              = "main"
+                [90m# (5 unchanged attributes hidden)[0m[0m
+
+                [90m# (7 unchanged blocks hidden)[0m[0m
+            }
+
+            [90m# (1 unchanged block hidden)[0m[0m
+        }
+
+        [90m# (8 unchanged blocks hidden)[0m[0m
+    }
+
+[1m  # module.main_hosting.azurerm_monitor_diagnostic_setting.mssql_security_storage[0][0m will be updated in-place
+[0m  [33m~[0m[0m resource "azurerm_monitor_diagnostic_setting" "mssql_security_storage" {
+        id                         = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Storage/storageAccounts/s190t01plantechmssqlsec/blobServices/default|s190t01-plantech-mssql-blob-diag"
+        name                       = "s190t01-plantech-mssql-blob-diag"
+        [90m# (2 unchanged attributes hidden)[0m[0m
+
+      [31m-[0m[0m metric {
+          [31m-[0m[0m category = "Capacity" [90m-> null[0m[0m
+          [31m-[0m[0m enabled  = false [90m-> null[0m[0m
+
+          [31m-[0m[0m retention_policy {
+              [31m-[0m[0m days    = 0 [90m-> null[0m[0m
+              [31m-[0m[0m enabled = false [90m-> null[0m[0m
+            }
+        }
+      [31m-[0m[0m metric {
+          [31m-[0m[0m category = "Transaction" [90m-> null[0m[0m
+          [31m-[0m[0m enabled  = false [90m-> null[0m[0m
+
+          [31m-[0m[0m retention_policy {
+              [31m-[0m[0m days    = 0 [90m-> null[0m[0m
+              [31m-[0m[0m enabled = false [90m-> null[0m[0m
+            }
+        }
+      [32m+[0m[0m metric {
+          [32m+[0m[0m category = "AllMetrics"
+          [32m+[0m[0m enabled  = false
+        }
+
+        [90m# (3 unchanged blocks hidden)[0m[0m
+    }
+
+[1m  # module.main_hosting.azurerm_private_dns_a_record.mssql_private_endpoint[0][0m will be updated in-place
+[0m  [33m~[0m[0m resource "azurerm_private_dns_a_record" "mssql_private_endpoint" {
+        id                  = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateDnsZones/s190t01-plantech.database.windows.net/A/@"
+        name                = "@"
+      [33m~[0m[0m tags                = {
+            "Environment"      = "Test"
+            "Product"          = "Plan Technology for your School"
+          [32m+[0m[0m "Service Offering" = "Plan Technology for your School"
+        }
+        [90m# (5 unchanged attributes hidden)[0m[0m
+    }
+
+[1m  # module.main_hosting.azurerm_private_dns_zone.mssql_private_link[0][0m will be updated in-place
+[0m  [33m~[0m[0m resource "azurerm_private_dns_zone" "mssql_private_link" {
+        id                                                    = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateDnsZones/s190t01-plantech.database.windows.net"
+        name                                                  = "s190t01-plantech.database.windows.net"
+      [33m~[0m[0m tags                                                  = {
+            "Environment"      = "Test"
+            "Product"          = "Plan Technology for your School"
+          [32m+[0m[0m "Service Offering" = "Plan Technology for your School"
+        }
+        [90m# (5 unchanged attributes hidden)[0m[0m
+
+        [90m# (1 unchanged block hidden)[0m[0m
+    }
+
+[1m  # module.main_hosting.azurerm_private_dns_zone_virtual_network_link.mssql_private_link[0][0m will be updated in-place
+[0m  [33m~[0m[0m resource "azurerm_private_dns_zone_virtual_network_link" "mssql_private_link" {
+        id                    = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateDnsZones/s190t01-plantech.database.windows.net/virtualNetworkLinks/s190t01-plantechmssqlprivatelink"
+        name                  = "s190t01-plantechmssqlprivatelink"
+      [33m~[0m[0m tags                  = {
+            "Environment"      = "Test"
+            "Product"          = "Plan Technology for your School"
+          [32m+[0m[0m "Service Offering" = "Plan Technology for your School"
+        }
+        [90m# (4 unchanged attributes hidden)[0m[0m
+    }
+
+[1m  # module.main_hosting.azurerm_private_endpoint.default["mssql"][0m will be updated in-place
+[0m  [33m~[0m[0m resource "azurerm_private_endpoint" "default" {
+        id                       = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateEndpoints/s190t01-plantechmssql"
+        name                     = "s190t01-plantechmssql"
+        tags                     = {
+            "Environment"      = "Test"
+            "Product"          = "Plan Technology for your School"
+            "Service Offering" = "Plan Technology for your School"
+        }
+        [90m# (6 unchanged attributes hidden)[0m[0m
+
+      [31m-[0m[0m private_dns_zone_group {
+          [31m-[0m[0m id                   = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateEndpoints/s190t01-plantechmssql/privateDnsZoneGroups/default" [90m-> null[0m[0m
+          [31m-[0m[0m name                 = "default" [90m-> null[0m[0m
+          [31m-[0m[0m private_dns_zone_ids = [
+              [31m-[0m[0m "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/privateDnsZones/privatelink.database.windows.net",
+            ] [90m-> null[0m[0m
+        }
+
+        [90m# (1 unchanged block hidden)[0m[0m
+    }
+
+[1m  # module.main_hosting.azurerm_storage_account.mssql_security_storage[0][0m will be updated in-place
+[0m  [33m~[0m[0m resource "azurerm_storage_account" "mssql_security_storage" {
+      [33m~[0m[0m cross_tenant_replication_enabled  = false [33m->[0m[0m true
+        id                                = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Storage/storageAccounts/s190t01plantechmssqlsec"
+        name                              = "s190t01plantechmssqlsec"
+        tags                              = {
+            "Environment"      = "Test"
+            "Product"          = "Plan Technology for your School"
+            "Service Offering" = "Plan Technology for your School"
+        }
+        [90m# (39 unchanged attributes hidden)[0m[0m
+
+      [31m-[0m[0m sas_policy {
+          [31m-[0m[0m expiration_action = "Log" [90m-> null[0m[0m
+          [31m-[0m[0m expiration_period = "02.00:00:00" [90m-> null[0m[0m
+        }
+
+        [90m# (4 unchanged blocks hidden)[0m[0m
+    }
+
+[1m  # module.main_hosting.azurerm_storage_management_policy.mssql_security_storage[0][0m will be [1m[31mdestroyed[0m
+  # (because azurerm_storage_management_policy.mssql_security_storage is not in configuration)
+[0m  [31m-[0m[0m resource "azurerm_storage_management_policy" "mssql_security_storage" {
+      [31m-[0m[0m id                 = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Storage/storageAccounts/s190t01plantechmssqlsec/managementPolicies/default" [90m-> null[0m[0m
+      [31m-[0m[0m storage_account_id = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Storage/storageAccounts/s190t01plantechmssqlsec" [90m-> null[0m[0m
+
+      [31m-[0m[0m rule {
+          [31m-[0m[0m enabled = true [90m-> null[0m[0m
+          [31m-[0m[0m name    = "object-lifecycle-policy" [90m-> null[0m[0m
+
+          [31m-[0m[0m actions {
+              [31m-[0m[0m base_blob {
+                  [31m-[0m[0m auto_tier_to_hot_from_cool_enabled                             = false [90m-> null[0m[0m
+                  [31m-[0m[0m delete_after_days_since_creation_greater_than                  = 30 [90m-> null[0m[0m
+                  [31m-[0m[0m delete_after_days_since_last_access_time_greater_than          = -1 [90m-> null[0m[0m
+                  [31m-[0m[0m delete_after_days_since_modification_greater_than              = -1 [90m-> null[0m[0m
+                  [31m-[0m[0m tier_to_archive_after_days_since_creation_greater_than         = 7 [90m-> null[0m[0m
+                  [31m-[0m[0m tier_to_archive_after_days_since_last_access_time_greater_than = -1 [90m-> null[0m[0m
+                  [31m-[0m[0m tier_to_archive_after_days_since_last_tier_change_greater_than = -1 [90m-> null[0m[0m
+                  [31m-[0m[0m tier_to_archive_after_days_since_modification_greater_than     = -1 [90m-> null[0m[0m
+                  [31m-[0m[0m tier_to_cold_after_days_since_creation_greater_than            = -1 [90m-> null[0m[0m
+                  [31m-[0m[0m tier_to_cold_after_days_since_last_access_time_greater_than    = -1 [90m-> null[0m[0m
+                  [31m-[0m[0m tier_to_cold_after_days_since_modification_greater_than        = -1 [90m-> null[0m[0m
+                  [31m-[0m[0m tier_to_cool_after_days_since_creation_greater_than            = 3 [90m-> null[0m[0m
+                  [31m-[0m[0m tier_to_cool_after_days_since_last_access_time_greater_than    = -1 [90m-> null[0m[0m
+                  [31m-[0m[0m tier_to_cool_after_days_since_modification_greater_than        = -1 [90m-> null[0m[0m
+                }
+            }
+
+          [31m-[0m[0m filters {
+              [31m-[0m[0m blob_types   = [
+                  [31m-[0m[0m "blockBlob",
+                ] [90m-> null[0m[0m
+              [31m-[0m[0m prefix_match = [
+                  [31m-[0m[0m "s190t01-plantech-mssqlsec/*",
+                  [31m-[0m[0m "sqldbauditlogs/*",
+                  [31m-[0m[0m "sqldbtdlogs/*",
+                ] [90m-> null[0m[0m
+            }
+        }
+    }
+
+[1m  # module.main_hosting.azurerm_subnet.container_apps_infra_subnet[0][0m will be updated in-place
+[0m  [33m~[0m[0m resource "azurerm_subnet" "container_apps_infra_subnet" {
+        id                                             = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Network/virtualNetworks/s190t01-plantechdefault/subnets/s190t01-plantechcontainerappsinfra"
+        name                                           = "s190t01-plantechcontainerappsinfra"
+      [33m~[0m[0m service_endpoints                              = [
+          [31m-[0m[0m "Microsoft.Storage",
+            [90m# (1 unchanged element hidden)[0m[0m
+        ]
+        [90m# (10 unchanged attributes hidden)[0m[0m
+    }
+
+[1m  # module.waf.data.azurerm_client_config.current[0m will be read during apply
+  # (depends on a resource or a module with changes pending)
+[0m [36m<=[0m[0m data "azurerm_client_config" "current" {
+      [32m+[0m[0m client_id       = (known after apply)
+      [32m+[0m[0m id              = (known after apply)
+      [32m+[0m[0m object_id       = (known after apply)
+      [32m+[0m[0m subscription_id = (known after apply)
+      [32m+[0m[0m tenant_id       = (known after apply)
+    }
+
+[1m  # module.waf.data.azurerm_resource_group.existing_resource_group[0][0m will be read during apply
+  # (depends on a resource or a module with changes pending)
+[0m [36m<=[0m[0m data "azurerm_resource_group" "existing_resource_group" {
+      [32m+[0m[0m id         = (known after apply)
+      [32m+[0m[0m location   = (known after apply)
+      [32m+[0m[0m managed_by = (known after apply)
+      [32m+[0m[0m name       = "s190t01-plantech"
+      [32m+[0m[0m tags       = (known after apply)
+    }
+
+[1m  # module.waf.azurerm_log_analytics_workspace.waf[0m must be [1m[31mreplaced[0m
+[0m[31m-[0m/[32m+[0m[0m resource "azurerm_log_analytics_workspace" "waf" {
+      [31m-[0m[0m cmk_for_query_forced                    = false [90m-> null[0m[0m
+      [33m~[0m[0m id                                      = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.OperationalInsights/workspaces/s190t01-plantechwaf" -> (known after apply)
+      [31m-[0m[0m immediate_data_purge_on_30_days_enabled = false [90m-> null[0m[0m
+      [33m~[0m[0m location                                = "westeurope" [31m# forces replacement[0m[0m -> (known after apply) [31m# forces replacement[0m[0m
+        name                                    = "s190t01-plantechwaf"
+      [33m~[0m[0m primary_shared_key                      = (sensitive value)
+      [33m~[0m[0m secondary_shared_key                    = (sensitive value)
+        tags                                    = {
+            "Environment"      = "Test"
+            "Product"          = "Plan Technology for your School"
+            "Service Offering" = "Plan Technology for your School"
+        }
+      [33m~[0m[0m workspace_id                            = "65a059b5-6b0d-49d5-af62-bed13f41fc4d" -> (known after apply)
+        [90m# (8 unchanged attributes hidden)[0m[0m
+    }
+
+[1m  # module.waf.azurerm_monitor_diagnostic_setting.waf[0m will be updated in-place
+[0m  [33m~[0m[0m resource "azurerm_monitor_diagnostic_setting" "waf" {
+        id                             = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.Cdn/profiles/s190t01-plantech-cdnwaf|s190t01-plantechwaf"
+      [32m+[0m[0m log_analytics_destination_type = "AzureDiagnostics"
+      [33m~[0m[0m log_analytics_workspace_id     = "/subscriptions/78c3e82f-256f-46c0-a8ca-29ad3a499b89/resourceGroups/s190t01-plantech/providers/Microsoft.OperationalInsights/workspaces/s190t01-plantechwaf" -> (known after apply)
+        name                           = "s190t01-plantechwaf"
+        [90m# (1 unchanged attribute hidden)[0m[0m
+
+        [90m# (6 unchanged blocks hidden)[0m[0m
+    }
+
+[1mPlan:[0m 5 to add, 11 to change, 13 to destroy.
+[0m[33m╷[0m[0m
+[33m│[0m [0m[1m[33mWarning: [0m[0m[1mArgument is deprecated[0m
+[33m│[0m [0m
+[33m│[0m [0m[0m  with module.main_hosting.azurerm_subnet.container_instances_subnet,
+[33m│[0m [0m  on .terraform/modules/main_hosting/virtual-network.tf line 52, in resource "azurerm_subnet" "container_instances_subnet":
+[33m│[0m [0m  52:   private_endpoint_network_policies_enabled = [4mtrue[0m[0m
+[33m│[0m [0m
+[33m│[0m [0m`private_endpoint_network_policies_enabled` will be removed in favour of the property `private_endpoint_network_policies` in version 4.0 of the AzureRM Provider
+[33m│[0m [0m
+[33m│[0m [0m(and 7 more similar warnings elsewhere)
+[33m╵[0m[0m
+[90m
+─────────────────────────────────────────────────────────────────────────────[0m
+
+Note: You didn't use the -out option to save this plan, so Terraform can't
+guarantee to take exactly these actions if you run "terraform apply" now.

--- a/terraform/container-app/database.networking.tf
+++ b/terraform/container-app/database.networking.tf
@@ -1,0 +1,40 @@
+resource "azurerm_private_dns_zone" "database" {
+  name                = local.az_sql_vnet.dns_zone_name
+  resource_group_name = local.resource_group_name
+  tags                = local.tags
+}
+
+resource "azurerm_private_endpoint" "database" {
+  custom_network_interface_name = local.az_sql_vnet.dns_zone_name
+  location                      = local.azure_location
+  name                          = local.az_sql_vnet.endpoint_name
+  resource_group_name           = local.resource_group_name
+  subnet_id                     = module.main_hosting.networking.subnet_id
+  tags                          = local.tags
+
+  private_dns_zone_group {
+    name                 = "default"
+    private_dns_zone_ids = [azurerm_private_dns_zone.database.id]
+  }
+
+  private_service_connection {
+    is_manual_connection           = false
+    name                           = local.az_sql_vnet.endpoint_name
+    private_connection_resource_id = data.azurerm_sql_server.database.id
+    subresource_names              = ["sqlServer"]
+  }
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "database_default" {
+  name                  = "default_vnet"
+  resource_group_name   = local.resource_group_name
+  private_dns_zone_name = azurerm_private_dns_zone.database.name
+  virtual_network_id    = module.main_hosting.networking.vnet_id
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "database_function" {
+  name                  = "function_vnet"
+  resource_group_name   = local.resource_group_name
+  private_dns_zone_name = azurerm_private_dns_zone.database.name
+  virtual_network_id    = azurerm_virtual_network.function_vnet.id
+}

--- a/terraform/container-app/database.tf
+++ b/terraform/container-app/database.tf
@@ -1,0 +1,4 @@
+data "azurerm_sql_server" "database" {
+  name                = local.resource_prefix
+  resource_group_name = local.resource_group_name
+}

--- a/terraform/container-app/functions.networking.tf
+++ b/terraform/container-app/functions.networking.tf
@@ -1,0 +1,89 @@
+resource "azurerm_virtual_network" "function_vnet" {
+  name                = local.function.vnet.name
+  address_space       = [local.function.vnet.address_space]
+  location            = local.function.location
+  resource_group_name = local.resource_group_name
+  tags                = local.tags
+}
+
+resource "azurerm_subnet" "function_infra_subnet" {
+  name                 = local.function.vnet.subnets.infra.name
+  virtual_network_name = local.function.vnet.name
+  resource_group_name  = local.resource_group_name
+  address_prefixes     = local.function.vnet.subnets.infra.address_prefixes
+
+  service_endpoints = ["Microsoft.KeyVault", "Microsoft.Storage"]
+
+  delegation {
+    name = "AFADelegationService"
+
+    service_delegation {
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action"
+      ]
+      name = "Microsoft.App/environments"
+    }
+  }
+}
+
+resource "azurerm_subnet" "function_storage" {
+  name                 = local.function.vnet.subnets.storage.name
+  virtual_network_name = azurerm_virtual_network.function_vnet.name
+  resource_group_name  = local.resource_group_name
+  address_prefixes     = local.function.vnet.subnets.storage.address_prefixes
+
+}
+
+resource "azurerm_private_dns_zone" "blob_storage" {
+  name                = local.function.vnet.dns.blob.name
+  resource_group_name = local.resource_group_name
+  tags                = local.tags
+}
+
+resource "azurerm_private_dns_zone" "files_storage" {
+  name                = local.function.vnet.dns.files.name
+  resource_group_name = local.resource_group_name
+  tags                = local.tags
+}
+
+resource "azurerm_private_endpoint" "blob_storage" {
+  custom_network_interface_name = local.function.vnet.endpoints.blob.nic_name
+  location                      = local.function.location
+  name                          = local.function.vnet.endpoints.blob.name
+  resource_group_name           = local.resource_group_name
+  subnet_id                     = azurerm_subnet.function_storage.id
+  tags                          = local.tags
+
+  private_dns_zone_group {
+    name                 = "default"
+    private_dns_zone_ids = [azurerm_private_dns_zone.blob_storage.id]
+  }
+
+  private_service_connection {
+    is_manual_connection           = false
+    name                           = local.function.vnet.endpoints.blob.name
+    private_connection_resource_id = azurerm_storage_account.function_storage.id
+    subresource_names              = ["blob"]
+  }
+}
+
+resource "azurerm_private_endpoint" "files_storage" {
+  custom_network_interface_name = local.function.vnet.endpoints.files.nic_name
+  location                      = local.function.location
+  name                          = local.function.vnet.endpoints.files.name
+  resource_group_name           = local.resource_group_name
+  subnet_id                     = azurerm_subnet.function_storage.id
+  tags                          = local.tags
+
+  private_dns_zone_group {
+    name                 = "default"
+    private_dns_zone_ids = [azurerm_private_dns_zone.files_storage.id]
+  }
+
+  private_service_connection {
+    is_manual_connection           = false
+    name                           = local.function.vnet.endpoints.files.name
+    private_connection_resource_id = azurerm_storage_account.function_storage.id
+    subresource_names              = ["file"]
+  }
+}

--- a/terraform/container-app/functions.networking.tf
+++ b/terraform/container-app/functions.networking.tf
@@ -22,6 +22,8 @@ resource "azurerm_subnet" "function_infra_subnet" {
       name = "Microsoft.App/environments"
     }
   }
+
+  service_endpoints = ["Microsoft.Storage", "Microsoft.KeyVault"]
 }
 
 resource "azurerm_subnet" "function_storage" {

--- a/terraform/container-app/functions.networking.tf
+++ b/terraform/container-app/functions.networking.tf
@@ -12,8 +12,6 @@ resource "azurerm_subnet" "function_infra_subnet" {
   resource_group_name  = local.resource_group_name
   address_prefixes     = local.function.vnet.subnets.infra.address_prefixes
 
-  service_endpoints = ["Microsoft.KeyVault", "Microsoft.Storage"]
-
   delegation {
     name = "AFADelegationService"
 
@@ -31,23 +29,29 @@ resource "azurerm_subnet" "function_storage" {
   virtual_network_name = azurerm_virtual_network.function_vnet.name
   resource_group_name  = local.resource_group_name
   address_prefixes     = local.function.vnet.subnets.storage.address_prefixes
+}
 
+
+resource "azurerm_virtual_network_peering" "function_to_main" {
+  name                      = "${local.resource_prefix}-defaultvn-peer"
+  resource_group_name       = local.resource_group_name
+  virtual_network_name      = azurerm_virtual_network.function_vnet.name
+  remote_virtual_network_id = module.main_hosting.networking.vnet_id
+
+  allow_forwarded_traffic = true
+}
+
+resource "azurerm_virtual_network_peering" "main_to_function" {
+  name                      = "${local.resource_prefix}-functionvn-peer"
+  resource_group_name       = local.resource_group_name
+  virtual_network_name      = "${local.resource_prefix}default"
+  remote_virtual_network_id = azurerm_virtual_network.function_vnet.id
+
+  allow_forwarded_traffic = true
 }
 
 resource "azurerm_private_dns_zone" "blob_storage" {
   name                = local.function.vnet.dns.blob.name
-  resource_group_name = local.resource_group_name
-  tags                = local.tags
-}
-
-resource "azurerm_private_dns_zone" "files_storage" {
-  name                = local.function.vnet.dns.files.name
-  resource_group_name = local.resource_group_name
-  tags                = local.tags
-}
-
-resource "azurerm_private_dns_zone" "keyvault" {
-  name                = local.function.vnet.dns.keyvault.name
   resource_group_name = local.resource_group_name
   tags                = local.tags
 }
@@ -80,6 +84,12 @@ resource "azurerm_private_dns_zone_virtual_network_link" "blob_storage" {
   virtual_network_id    = azurerm_virtual_network.function_vnet.id
 }
 
+resource "azurerm_private_dns_zone" "files_storage" {
+  name                = local.function.vnet.dns.files.name
+  resource_group_name = local.resource_group_name
+  tags                = local.tags
+}
+
 resource "azurerm_private_endpoint" "files_storage" {
   custom_network_interface_name = local.function.vnet.endpoints.files.nic_name
   location                      = local.function.location
@@ -102,61 +112,8 @@ resource "azurerm_private_endpoint" "files_storage" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "files_storage" {
-  name                  = "function_vn"
+  name                  = "function_vnet"
   resource_group_name   = local.resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.files_storage.name
   virtual_network_id    = azurerm_virtual_network.function_vnet.id
-}
-
-resource "azurerm_private_endpoint" "keyvault" {
-  custom_network_interface_name = local.function.vnet.endpoints.keyvault.nic_name
-  location                      = local.function.location
-  name                          = local.function.vnet.endpoints.keyvault.name
-  resource_group_name           = local.resource_group_name
-  subnet_id                     = azurerm_subnet.function_storage.id
-  tags                          = local.tags
-
-  private_dns_zone_group {
-    name                 = "default"
-    private_dns_zone_ids = [azurerm_private_dns_zone.keyvault.id]
-  }
-
-  private_service_connection {
-    is_manual_connection           = false
-    name                           = local.function.vnet.endpoints.vault.name
-    private_connection_resource_id = azurerm_key_vault.vault.id
-    subresource_names              = ["vault"]
-  }
-}
-
-resource "azurerm_private_dns_zone_virtual_network_link" "keyvault_to_functionvnet" {
-  name                  = "function_vn"
-  resource_group_name   = local.resource_group_name
-  private_dns_zone_name = azurerm_private_dns_zone.keyvault.name
-  virtual_network_id    = azurerm_virtual_network.function_vnet.id
-}
-
-resource "azurerm_private_dns_zone_virtual_network_link" "keyvault_to_defaultvnet" {
-  name                  = "default_vn"
-  resource_group_name   = local.resource_group_name
-  private_dns_zone_name = azurerm_private_dns_zone.keyvault.name
-  virtual_network_id    = module.main_hosting.networking.vnet_id
-}
-
-resource "azurerm_virtual_network_peering" "function_to_main" {
-  name                      = "${local.resource_prefix}-defaultvn-peer"
-  resource_group_name       = local.resource_group_name
-  virtual_network_name      = azurerm_virtual_network.function_vnet.name
-  remote_virtual_network_id = module.main_hosting.networking.vnet_id
-
-  allow_forwarded_traffic = true
-}
-
-resource "azurerm_virtual_network_peering" "main_to_function" {
-  name                      = "${local.resource_prefix}-functionvn-peer"
-  resource_group_name       = local.resource_group_name
-  virtual_network_name      = "${local.resource_prefix}default"
-  remote_virtual_network_id = azurerm_virtual_network.function_vnet.id
-
-  allow_forwarded_traffic = true
 }

--- a/terraform/container-app/functions.networking.tf
+++ b/terraform/container-app/functions.networking.tf
@@ -52,7 +52,6 @@ resource "azurerm_private_dns_zone" "keyvault" {
   tags                = local.tags
 }
 
-
 resource "azurerm_private_endpoint" "blob_storage" {
   custom_network_interface_name = local.function.vnet.endpoints.blob.nic_name
   location                      = local.function.location
@@ -124,9 +123,9 @@ resource "azurerm_private_endpoint" "keyvault" {
 
   private_service_connection {
     is_manual_connection           = false
-    name                           = local.function.vnet.endpoints.blob.name
-    private_connection_resource_id = azurerm_storage_account.function_storage.id
-    subresource_names              = ["blob"]
+    name                           = local.function.vnet.endpoints.vault.name
+    private_connection_resource_id = azurerm_key_vault.vault.id
+    subresource_names              = ["vault"]
   }
 }
 

--- a/terraform/container-app/functions.tf
+++ b/terraform/container-app/functions.tf
@@ -36,34 +36,6 @@ resource "azurerm_storage_account" "function_storage" {
   }
 }
 
-resource "azurerm_virtual_network" "function_vnet" {
-  name                = local.function.vnet.name
-  address_space       = [local.function.vnet.address_space]
-  location            = local.function.location
-  resource_group_name = local.resource_group_name
-  tags                = local.tags
-}
-
-resource "azurerm_subnet" "function_infra_subnet" {
-  name                 = local.function.vnet.subnet.name
-  virtual_network_name = local.function.vnet.name
-  resource_group_name  = local.resource_group_name
-  address_prefixes     = local.function.vnet.subnet.address_prefixes
-
-  service_endpoints = ["Microsoft.KeyVault", "Microsoft.Storage"]
-
-  delegation {
-    name = "AFADelegationService"
-
-    service_delegation {
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action"
-      ]
-      name = "Microsoft.App/environments"
-    }
-  }
-}
-
 resource "azurerm_service_plan" "function_plan" {
   name                = "${local.resource_prefix}appserviceplan"
   resource_group_name = local.resource_group_name

--- a/terraform/container-app/functions.tf
+++ b/terraform/container-app/functions.tf
@@ -115,6 +115,10 @@ resource "azapi_resource" "contentful_function" {
             name  = "AzureWebJobsStorage__accountName",
             value = azurerm_storage_account.function_storage.name
           },
+          {
+            name  = "Key_Vault_Name",
+            value = azurerm_key_vault.vault.name
+          },
         ],
         http20enabled = true
         minTlsVersion = "1.3"

--- a/terraform/container-app/functions.tf
+++ b/terraform/container-app/functions.tf
@@ -115,10 +115,15 @@ resource "azapi_resource" "contentful_function" {
             name  = "AzureWebJobsStorage__accountName",
             value = azurerm_storage_account.function_storage.name
           },
+          /* Key Vault */
           {
             name  = "Azure_KeyVault_Name",
             value = azurerm_key_vault.vault.name
           },
+          {
+            name  = "AZURE_CLIENT_ID",
+            value = azurerm_user_assigned_identity.user_assigned_identity.client_id
+          }
         ],
         http20enabled = true
         minTlsVersion = "1.3"

--- a/terraform/container-app/functions.tf
+++ b/terraform/container-app/functions.tf
@@ -30,9 +30,8 @@ resource "azurerm_storage_account" "function_storage" {
   }
 
   network_rules {
-    bypass                     = ["Logging", "Metrics"]
-    default_action             = "Deny"
-    virtual_network_subnet_ids = [azurerm_subnet.function_infra_subnet.id]
+    bypass         = ["Logging", "Metrics"]
+    default_action = "Deny"
   }
 }
 

--- a/terraform/container-app/functions.tf
+++ b/terraform/container-app/functions.tf
@@ -116,7 +116,7 @@ resource "azapi_resource" "contentful_function" {
             value = azurerm_storage_account.function_storage.name
           },
           {
-            name  = "Key_Vault_Name",
+            name  = "Azure_KeyVault_Name",
             value = azurerm_key_vault.vault.name
           },
         ],

--- a/terraform/container-app/functions.tf
+++ b/terraform/container-app/functions.tf
@@ -69,9 +69,13 @@ resource "azapi_resource" "contentful_function" {
     properties = {
       serverFarmId = azurerm_service_plan.function_plan.id,
 
-      httpsOnly              = true,
-      virtualNetworkSubnetId = azurerm_subnet.function_infra_subnet.id,
-      vnetImagePullEnabled   = true,
+      keyVaultReferenceIdentity = azurerm_user_assigned_identity.user_assigned_identity.id,
+
+      virtualNetworkSubnetId  = azurerm_subnet.function_infra_subnet.id,
+      vnetContentShareEnabled = true,
+      vnetImagePullEnabled    = true,
+      vnetRouteAllEnabled     = true,
+
       functionAppConfig = {
         deployment = {
           storage = {

--- a/terraform/container-app/key-vault.networking.tf
+++ b/terraform/container-app/key-vault.networking.tf
@@ -1,0 +1,57 @@
+data "azurerm_route_table" "default" {
+  name                = "${local.resource_prefix}default"
+  resource_group_name = local.resource_group_name
+}
+
+resource "azurerm_subnet" "keyvault" {
+  name                 = local.kv_networking.subnet.name
+  virtual_network_name = "${local.resource_prefix}default"
+  resource_group_name  = local.resource_group_name
+  address_prefixes     = local.kv_networking.subnet.address_prefixes
+}
+
+resource "azurerm_subnet_route_table_association" "keyvault" {
+  subnet_id      = azurerm_subnet.keyvault.id
+  route_table_id = data.azurerm_route_table.default.id
+}
+
+resource "azurerm_private_dns_zone" "keyvault" {
+  name                = local.kv_networking.private_dns_zone.name
+  resource_group_name = local.resource_group_name
+  tags                = local.tags
+}
+
+resource "azurerm_private_endpoint" "keyvault" {
+  custom_network_interface_name = local.kv_networking.endpoint.nic_name
+  location                      = local.azure_location
+  name                          = local.kv_networking.endpoint.name
+  resource_group_name           = local.resource_group_name
+  subnet_id                     = module.main_hosting.networking.subnet_id
+  tags                          = local.tags
+
+  private_dns_zone_group {
+    name                 = "default"
+    private_dns_zone_ids = [azurerm_private_dns_zone.keyvault.id]
+  }
+
+  private_service_connection {
+    is_manual_connection           = false
+    name                           = local.kv_networking.endpoint.name
+    private_connection_resource_id = azurerm_key_vault.vault.id
+    subresource_names              = ["vault"]
+  }
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "keyvault_to_functionvnet" {
+  name                  = "function_vnet"
+  resource_group_name   = local.resource_group_name
+  private_dns_zone_name = azurerm_private_dns_zone.keyvault.name
+  virtual_network_id    = azurerm_virtual_network.function_vnet.id
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "keyvault_to_defaultvnet" {
+  name                  = "default_vnet"
+  resource_group_name   = local.resource_group_name
+  private_dns_zone_name = azurerm_private_dns_zone.keyvault.name
+  virtual_network_id    = module.main_hosting.networking.vnet_id
+}

--- a/terraform/container-app/key-vault.networking.tf
+++ b/terraform/container-app/key-vault.networking.tf
@@ -26,7 +26,7 @@ resource "azurerm_private_endpoint" "keyvault" {
   location                      = local.azure_location
   name                          = local.kv_networking.endpoint.name
   resource_group_name           = local.resource_group_name
-  subnet_id                     = module.main_hosting.networking.subnet_id
+  subnet_id                     = azurerm_subnet.keyvault.id
   tags                          = local.tags
 
   private_dns_zone_group {

--- a/terraform/container-app/locals.tf
+++ b/terraform/container-app/locals.tf
@@ -138,6 +138,10 @@ locals {
         files = {
           name = "privatelink.file.core.windows.net"
         }
+
+        keyvault = {
+          name = "privatelink.vaultcore.azure.net"
+        }
       }
 
       endpoints = {
@@ -149,6 +153,11 @@ locals {
         files = {
           nic_name = "${local.resource_prefix}-files-storage-nic"
           name     = "${local.resource_prefix}-files-storage"
+        }
+
+        keyvault = {
+          nic_name = "${local.resource_prefix}-keyvault-nic"
+          name     = "${local.resource_prefix}-keyvault"
         }
       }
     }

--- a/terraform/container-app/locals.tf
+++ b/terraform/container-app/locals.tf
@@ -138,10 +138,6 @@ locals {
         files = {
           name = "privatelink.file.core.windows.net"
         }
-
-        keyvault = {
-          name = "privatelink.vaultcore.azure.net"
-        }
       }
 
       endpoints = {
@@ -153,11 +149,6 @@ locals {
         files = {
           nic_name = "${local.resource_prefix}-files-storage-nic"
           name     = "${local.resource_prefix}-files-storage"
-        }
-
-        keyvault = {
-          nic_name = "${local.resource_prefix}-keyvault-nic"
-          name     = "${local.resource_prefix}-keyvault"
         }
       }
     }

--- a/terraform/container-app/locals.tf
+++ b/terraform/container-app/locals.tf
@@ -133,6 +133,10 @@ locals {
         files = {
           name = "privatelink.file.core.windows.net"
         }
+
+        keyvault = {
+          name = "privatelink.vaultcore.azure.net"
+        }
       }
 
       endpoints = {
@@ -144,6 +148,11 @@ locals {
         files = {
           nic_name = "${local.resource_prefix}-files-storage-nic"
           name     = "${local.resource_prefix}-files-storage"
+        }
+
+        keyvault = {
+          nic_name = "${local.resource_prefix}-keyvault-nic"
+          name     = "${local.resource_prefix}-keyvault"
         }
       }
     }

--- a/terraform/container-app/locals.tf
+++ b/terraform/container-app/locals.tf
@@ -55,6 +55,20 @@ locals {
   kv_secrets_csp_framesrc   = "${local.csp_google_tag_manager_domain} ${local.csp_clarity_domains}"
   kv_secrets_csp_imgsrc     = "${local.csp_google_tag_manager_domain} ${local.csp_clarity_domains}"
 
+  kv_networking = {
+    subnet = {
+      name             = "${local.resource_prefix}-keyvault-endpoint"
+      address_prefixes = ["172.16.7.0/24"]
+    }
+    private_dns_zone = {
+      name = "privatelink.vaultcore.azure.net"
+    }
+    endpoint = {
+      nic_name = "${local.resource_prefix}-keyvault-nic"
+      name     = "${local.resource_prefix}-keyvault"
+    }
+  }
+
   ##################
   # CDN/Front Door #
   ##################
@@ -100,15 +114,6 @@ locals {
     runtime = var.function_runtime,
     scaling = var.function_scaling,
 
-    app_settings = {
-      sql_connection_string = local.function_appsetting_sql_connection_string
-      cacheclear = {
-        apikey_name  = local.function_appsetting_cacheclear_apikey_name,
-        apikey_value = local.function_appsetting_cacheclear_apikey_value,
-        endpoint     = local.function_appsetting_cacheclear_endpoint
-      }
-    }
-
     vnet = {
       name          = "${local.resource_prefix}-function-vn"
       address_space = "10.0.0.0/14"
@@ -133,10 +138,6 @@ locals {
         files = {
           name = "privatelink.file.core.windows.net"
         }
-
-        keyvault = {
-          name = "privatelink.vaultcore.azure.net"
-        }
       }
 
       endpoints = {
@@ -149,18 +150,7 @@ locals {
           nic_name = "${local.resource_prefix}-files-storage-nic"
           name     = "${local.resource_prefix}-files-storage"
         }
-
-        keyvault = {
-          nic_name = "${local.resource_prefix}-keyvault-nic"
-          name     = "${local.resource_prefix}-keyvault"
-        }
       }
     }
   }
-
-  # Settings
-  function_appsetting_sql_connection_string   = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.vault.name};SecretName=${azurerm_key_vault_secret.vault_secret_database_connectionstring.name})"
-  function_appsetting_cacheclear_apikey_name  = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.vault.name};SecretName=CacheClear--ApiKeyName)"
-  function_appsetting_cacheclear_apikey_value = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.vault.name};SecretName=CacheClear--ApiKeyValue)"
-  function_appsetting_cacheclear_endpoint     = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.vault.name};SecretName=CacheClear--Endpoint)"
 }

--- a/terraform/container-app/locals.tf
+++ b/terraform/container-app/locals.tf
@@ -113,9 +113,38 @@ locals {
       name          = "${local.resource_prefix}-function-vn"
       address_space = "10.0.0.0/14"
 
-      subnet = {
-        name             = "${local.resource_prefix}-functioninfra"
-        address_prefixes = ["10.0.0.0/24"]
+      subnets = {
+        infra = {
+          name             = "${local.resource_prefix}-functioninfra"
+          address_prefixes = ["10.0.0.0/24"]
+        }
+
+        storage = {
+          name             = "${local.resource_prefix}-function-storage"
+          address_prefixes = ["10.0.1.0/24"]
+        }
+      }
+
+      dns = {
+        blob = {
+          name = "privatelink.blob.core.windows.net"
+        }
+
+        files = {
+          name = "privatelink.file.core.windows.net"
+        }
+      }
+
+      endpoints = {
+        blob = {
+          nic_name = "${local.resource_prefix}-blob-storage-nic"
+          name     = "${local.resource_prefix}-blob-storage"
+        }
+
+        files = {
+          nic_name = "${local.resource_prefix}-files-storage-nic"
+          name     = "${local.resource_prefix}-files-storage"
+        }
       }
     }
   }

--- a/terraform/container-app/locals.tf
+++ b/terraform/container-app/locals.tf
@@ -45,6 +45,12 @@ locals {
   az_sql_sku                    = var.az_sql_sku
   az_sql_max_pool_size          = var.az_sql_max_pool_size
 
+  az_sql_vnet = {
+    dns_zone_name = "privatelink.database.windows.net"
+    nic_name      = "${local.resource_prefix}-db-nic"
+    endpoint_name = "${local.resource_prefix}-db"
+  }
+
   ##################
   # Azure KeyVault #
   ##################

--- a/terraform/container-app/main-hosting.tf
+++ b/terraform/container-app/main-hosting.tf
@@ -59,4 +59,9 @@ module "main_hosting" {
   registry_username = local.registry_username
   registry_password = local.registry_password
   image_tag         = local.image_tag
+
+  ###########
+  # Storage #
+  ###########
+  storage_account_sas_expiration_period = "00.01:00:00"
 }

--- a/terraform/container-app/main-hosting.tf
+++ b/terraform/container-app/main-hosting.tf
@@ -63,5 +63,5 @@ module "main_hosting" {
   ###########
   # Storage #
   ###########
-  storage_account_sas_expiration_period = "00.01:00:00"
+  storage_account_sas_expiration_period = local.storage_account_expiration_period
 }

--- a/terraform/container-app/terraform-configuration.md
+++ b/terraform/container-app/terraform-configuration.md
@@ -38,7 +38,7 @@ We use two external modules to create the majority of the resources required:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azapi"></a> [azapi](#provider\_azapi) | 1.14.0 |
+| <a name="provider_azapi"></a> [azapi](#provider\_azapi) | 1.15.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.113.0 |
 
 ## Modules
@@ -68,13 +68,17 @@ We use two external modules to create the majority of the resources required:
 | [azurerm_key_vault_secret.vault_secret_contentful_spaceid](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.vault_secret_database_connectionstring](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_private_dns_zone.blob_storage](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/private_dns_zone) | resource |
+| [azurerm_private_dns_zone.database](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone.files_storage](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone.keyvault](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/private_dns_zone) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.blob_storage](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
+| [azurerm_private_dns_zone_virtual_network_link.database_default](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
+| [azurerm_private_dns_zone_virtual_network_link.database_function](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.files_storage](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.keyvault_to_defaultvnet](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.keyvault_to_functionvnet](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_private_endpoint.blob_storage](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/private_endpoint) | resource |
+| [azurerm_private_endpoint.database](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/private_endpoint) | resource |
 | [azurerm_private_endpoint.files_storage](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/private_endpoint) | resource |
 | [azurerm_private_endpoint.keyvault](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/private_endpoint) | resource |
 | [azurerm_service_plan.function_plan](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/service_plan) | resource |
@@ -95,6 +99,7 @@ We use two external modules to create the majority of the resources required:
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/data-sources/resource_group) | data source |
 | [azurerm_route_table.default](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/data-sources/route_table) | data source |
+| [azurerm_sql_server.database](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/data-sources/sql_server) | data source |
 
 ## Inputs
 

--- a/terraform/container-app/terraform-configuration.md
+++ b/terraform/container-app/terraform-configuration.md
@@ -40,7 +40,6 @@ We use two external modules to create the majority of the resources required:
 |------|---------|
 | <a name="provider_azapi"></a> [azapi](#provider\_azapi) | 1.14.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.113.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
 
 ## Modules
 
@@ -68,6 +67,16 @@ We use two external modules to create the majority of the resources required:
 | [azurerm_key_vault_secret.vault_secret_contentful_previewapikey](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.vault_secret_contentful_spaceid](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.vault_secret_database_connectionstring](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/key_vault_secret) | resource |
+| [azurerm_private_dns_zone.blob_storage](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/private_dns_zone) | resource |
+| [azurerm_private_dns_zone.files_storage](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/private_dns_zone) | resource |
+| [azurerm_private_dns_zone.keyvault](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/private_dns_zone) | resource |
+| [azurerm_private_dns_zone_virtual_network_link.blob_storage](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
+| [azurerm_private_dns_zone_virtual_network_link.files_storage](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
+| [azurerm_private_dns_zone_virtual_network_link.keyvault_to_defaultvnet](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
+| [azurerm_private_dns_zone_virtual_network_link.keyvault_to_functionvnet](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
+| [azurerm_private_endpoint.blob_storage](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/private_endpoint) | resource |
+| [azurerm_private_endpoint.files_storage](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/private_endpoint) | resource |
+| [azurerm_private_endpoint.keyvault](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/private_endpoint) | resource |
 | [azurerm_service_plan.function_plan](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/service_plan) | resource |
 | [azurerm_servicebus_namespace.service_bus](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/servicebus_namespace) | resource |
 | [azurerm_servicebus_queue.contentful_queue](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/servicebus_queue) | resource |
@@ -76,11 +85,16 @@ We use two external modules to create the majority of the resources required:
 | [azurerm_storage_account.function_storage](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/storage_account) | resource |
 | [azurerm_storage_container.blobforcost](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/storage_container) | resource |
 | [azurerm_subnet.function_infra_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/subnet) | resource |
+| [azurerm_subnet.function_storage](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/subnet) | resource |
+| [azurerm_subnet.keyvault](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/subnet) | resource |
+| [azurerm_subnet_route_table_association.keyvault](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/subnet_route_table_association) | resource |
 | [azurerm_user_assigned_identity.user_assigned_identity](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/user_assigned_identity) | resource |
 | [azurerm_virtual_network.function_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/virtual_network) | resource |
-| [null_resource.function_set_keyVaultReferenceIdentity](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [azurerm_virtual_network_peering.function_to_main](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/virtual_network_peering) | resource |
+| [azurerm_virtual_network_peering.main_to_function](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/resources/virtual_network_peering) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/data-sources/resource_group) | data source |
+| [azurerm_route_table.default](https://registry.terraform.io/providers/hashicorp/azurerm/3.113.0/docs/data-sources/route_table) | data source |
 
 ## Inputs
 

--- a/terraform/container-app/upgrade-scripts/README.md
+++ b/terraform/container-app/upgrade-scripts/README.md
@@ -1,0 +1,1 @@
+Collection of scripts for manual changes required for various releases.

--- a/terraform/container-app/upgrade-scripts/README.md
+++ b/terraform/container-app/upgrade-scripts/README.md
@@ -1,1 +1,20 @@
-Collection of scripts for manual changes required for various releases.
+## Overview
+
+When applying new Terraform changes, sometimes there are manual changes that are required, for things such as importing existing Key Vault secrets into state, or tearing down resources in a specific order that TF fails to do.
+
+This folder contains various scripts designed to be ran before a specific sprint/release, to ensure that the required changes are executed correctly, and consistently across every environment.
+
+## Scripts
+
+### Sprints
+
+| Sprint # | Script readme                      |
+| -------- | ---------------------------------- |
+| 33       | [Sprint 33](./sprint_33/README.md) |
+
+
+### Other
+
+| Name                                                        | Description                                                                            |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| [Key Vault State Import](./shared/keyvault/state_import.sh) | Retrieves a Key Vault secret's ID from Azure using the CLI, then imports into TF state |

--- a/terraform/container-app/upgrade-scripts/shared/keyvault/state_import.sh
+++ b/terraform/container-app/upgrade-scripts/shared/keyvault/state_import.sh
@@ -1,3 +1,14 @@
+#!/usr/bin/env bash
+
+## Retrieves the ID for a Key Vault secret, then imports it into TF state for a specified resource
+
+## Usage:
+## Requires exporting the following environment variables:
+## SECRET_NAME: The name of the Key Vault secret (as shown on the Azure Portal)
+## KEYVAULT_NAME: The name of the Key Vault
+## TFVAR_PATH: The location of the Terraform variables file, relative to the dir that the _Terminal_ is running this script (or the calling script of this script) from
+## TF_ID_NAME: The name of the resource in Terraform to import to. E.g. azurerm_key_vault_secret.example
+
 if [[ -z "$SECRET_NAME" || -z "$KEYVAULT_NAME" ]]; then
   echo "Variable(s) not set. \$SECRET_NAME and \$KEYVAULT_NAME are required"
   exit 1

--- a/terraform/container-app/upgrade-scripts/shared/keyvault/state_import.sh
+++ b/terraform/container-app/upgrade-scripts/shared/keyvault/state_import.sh
@@ -1,0 +1,17 @@
+if [[ -z "$SECRET_NAME" || -z "$KEYVAULT_NAME" ]]; then
+  echo "Variable(s) not set. \$SECRET_NAME and \$KEYVAULT_NAME are required"
+  exit 1
+fi
+
+echo "Fetching ID for $SECRET_NAME for Key Vault $KEYVAULT_NAME"
+
+# Fetch secret value using CLI -> extract ID using JQ -> remove quotation marks
+SECRET_ID=$(az keyvault secret show --vault-name $KEYVAULT_NAME --name $SECRET_NAME | jq .id | sed -e 's/"//g')
+
+if [[ -z "$SECRET_ID" ]]; then
+  echo "Could not retrieve ID for secret $SECRET_NAME"
+  exit 1
+fi
+
+echo "Running command: terraform import -var-file=${TFVAR_PATH} $TF_ID_NAME $SECRET_ID"
+terraform import -var-file=../$TF_VARS $TF_NAME $secret_id

--- a/terraform/container-app/upgrade-scripts/sprint_33/README.md
+++ b/terraform/container-app/upgrade-scripts/sprint_33/README.md
@@ -1,0 +1,21 @@
+## [Sprint 33](./sprint_33/main.sh)
+
+### Usage
+
+The script for sprint 33 can be ran using the following bash command:
+
+```bash
+bash upgrade-scripts/sprint_33/main.sh -g RESOURCE_GROUP_NAME -t PATH_TO_TERRAFORM_VARIABLES
+```
+
+Note: This assumes you are running the script from the [`container-app`](../) folder.
+
+- **RESOURCE_GROUP_NAME**: The name of the resource group to apply changes to (e.g. "ENV-plantech")
+- **PATH_TO_TERRAFORM_VARIABLES**: The relative path (from where you are executing the script) to your TF variables file for the specific environment. E.g.`terraform-test.tfvars`, or `../dev.tfvars` etc.
+
+### Changes performed
+
+This script performs the following changes:
+
+1. Imports the following Key Vault secrets into the existing TF state:
+   1. `csp--connectsrc`, `csp--imgsrc`, `csp--defaultsrc`, `csp--framesrc`

--- a/terraform/container-app/upgrade-scripts/sprint_33/import_keyvault_secrets.sh
+++ b/terraform/container-app/upgrade-scripts/sprint_33/import_keyvault_secrets.sh
@@ -1,0 +1,23 @@
+set -e
+set -o pipefail
+
+echo $RESOURCE_GROUP_NAME
+echo $TFVAR_PATH
+
+exit 0
+
+keyvault_name="${RESOURCE_GROUP_NAME}-kv"
+declare -a secret_names=("connect" "img" "frame" "default")
+
+for secret in "${secret_names[@]}";
+do
+  secret_name="csp--${secret}src"
+  tf_name="azurerm_key_vault_secret.csp_${secret}_src"
+  
+  echo "Fetching ID for $secret_name"
+  # Fetch secret value using CLI -> extract ID using JQ -> remove quotation marks
+  secret_id=$(az keyvault secret show --vault-name ${keyvault_name} --name $secret_name | jq .id | sed -e 's/"//g')
+
+  echo "Running command: terraform import -var-file=${TFVAR_PATH} $tf_name $secret_id"
+  terraform import -var-file=../terraform-${terraform_environment}.tfvars $tf_name $secret_id
+done

--- a/terraform/container-app/upgrade-scripts/sprint_33/import_keyvault_secrets.sh
+++ b/terraform/container-app/upgrade-scripts/sprint_33/import_keyvault_secrets.sh
@@ -1,23 +1,16 @@
-set -e
-set -o pipefail
+declare -a SECRET_NAMES=("connect" "img" "frame" "default")
 
-echo $RESOURCE_GROUP_NAME
-echo $TFVAR_PATH
+KEYVAULT_NAME="${RESOURCE_GROUP_NAME}-kv"
 
-exit 0
+export KEYVAULT_NAME
+export TFVAR
 
-keyvault_name="${RESOURCE_GROUP_NAME}-kv"
-declare -a secret_names=("connect" "img" "frame" "default")
-
-for secret in "${secret_names[@]}";
+for secret in "${SECRET_NAMES[@]}";
 do
-  secret_name="csp--${secret}src"
-  tf_name="azurerm_key_vault_secret.csp_${secret}_src"
+  SECRET_NAME="csp--${secret}src"
+  TF_ID_NAME="azurerm_key_vault_secret.csp_${secret}_src"
   
-  echo "Fetching ID for $secret_name"
-  # Fetch secret value using CLI -> extract ID using JQ -> remove quotation marks
-  secret_id=$(az keyvault secret show --vault-name ${keyvault_name} --name $secret_name | jq .id | sed -e 's/"//g')
-
-  echo "Running command: terraform import -var-file=${TFVAR_PATH} $tf_name $secret_id"
-  terraform import -var-file=../terraform-${terraform_environment}.tfvars $tf_name $secret_id
+  export SECRET_NAME
+  export TF_ID_NAME
+  bash "$PARENT_DIR/shared/keyvault/state_import.sh"
 done

--- a/terraform/container-app/upgrade-scripts/sprint_33/main.sh
+++ b/terraform/container-app/upgrade-scripts/sprint_33/main.sh
@@ -52,4 +52,3 @@ export TFVAR_PATH
 export PARENT_DIR
 
 bash "$(dirname "$0")/import_keyvault_secrets.sh"
-

--- a/terraform/container-app/upgrade-scripts/sprint_33/main.sh
+++ b/terraform/container-app/upgrade-scripts/sprint_33/main.sh
@@ -38,7 +38,7 @@ while getopts "g:t:h" opt; do
   esac
 done
 
-# Validate calues exist
+# Validate required arguments exist
 if [[
   -z "$RESOURCE_GROUP_NAME" ||
   -z "$TFVAR_PATH"
@@ -46,4 +46,10 @@ if [[
   usage
 fi
 
-bash $(dirname "$0")/import_keyvault_secrets.sh
+export PARENT_DIR=$( cd $(dirname $0)"/../"; pwd -P )
+
+export RESOURCE_GROUP_NAME
+export TFVAR_PATH
+export PARENT_DIR
+
+bash "$(dirname "$0")/import_keyvault_secrets.sh"

--- a/terraform/container-app/upgrade-scripts/sprint_33/main.sh
+++ b/terraform/container-app/upgrade-scripts/sprint_33/main.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+
+usage() {
+  echo "Usage: $(basename "$0") [OPTIONS]" 1>&2
+  echo "  -h               - help"
+  echo "  -g               - Resource group name"
+  echo "  -t               - Terraform variables file path"
+
+  exit 1
+}
+
+##########################
+# Command line arguments #
+##########################
+
+# Validate that commandline arguments exist
+if [ $# -lt 1 ];
+then
+ usage
+fi
+
+# Get commandline arguments
+while getopts "g:t:h" opt; do
+  case $opt in
+    g)
+      RESOURCE_GROUP_NAME=$OPTARG
+      ;;
+    t)
+      TFVAR_PATH=$OPTARG
+      ;;
+    h)
+      usage
+      exit;;
+    *)
+      usage
+      exit;;
+  esac
+done
+
+# Validate calues exist
+if [[
+  -z "$RESOURCE_GROUP_NAME" ||
+  -z "$TFVAR_PATH"
+]]; then
+  usage
+fi
+
+bash $(dirname "$0")/import_keyvault_secrets.sh

--- a/terraform/container-app/upgrade-scripts/sprint_33/main.sh
+++ b/terraform/container-app/upgrade-scripts/sprint_33/main.sh
@@ -52,3 +52,4 @@ export TFVAR_PATH
 export PARENT_DIR
 
 bash "$(dirname "$0")/import_keyvault_secrets.sh"
+

--- a/terraform/container-app/upgrade-scripts/sprint_33/main.sh
+++ b/terraform/container-app/upgrade-scripts/sprint_33/main.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-
 usage() {
   echo "Usage: $(basename "$0") [OPTIONS]" 1>&2
   echo "  -h               - help"
@@ -53,3 +52,4 @@ export TFVAR_PATH
 export PARENT_DIR
 
 bash "$(dirname "$0")/import_keyvault_secrets.sh"
+


### PR DESCRIPTION
** To be expanded**

Changes:

- Adds private DNS zones + endpoints for the Storage Account that the Function uses
- Adds peering for the two vnets
- Removes Key Vault settings from the Function App, as these are now handled by the Function directly/progamatically
- Adds Key Vault networking
- Adds a mini script to auto-import several secrets from the Key Vault into TF state, to make the applying process easier
- Amends the deploy Azure Function workflow to change the public network access for deployment
- Separates Functions networking into own file due to size

**To do in another PR**:

- Update architecture documentation + diagrams