### PR TITLE
fix(function): Clear entity tracking

### DIFF
--- a/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Functions/QueueReceiver.cs
@@ -59,6 +59,8 @@ public class QueueReceiver(
     {
         try
         {
+            db.ChangeTracker.Clear();
+
             CmsEvent cmsEvent = GetCmsEvent(message.Subject);
             MappedEntity mapped = await MapMessageToEntity(message, cmsEvent, cancellationToken);
 

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Functions/QueueReceiverTests.cs
@@ -11,7 +11,11 @@ using Dfe.PlanTech.Domain.Questionnaire.Models;
 using Dfe.PlanTech.Infrastructure.Data;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using MockQueryable.NSubstitute;
 using NSubstitute;
@@ -51,6 +55,7 @@ public class QueueReceiverTests
         _messageRetryHandlerMock = Substitute.For<IMessageRetryHandler>();
         _cacheHandler = Substitute.For<ICacheHandler>();
 
+
         _loggerFactoryMock.CreateLogger<Arg.AnyType>().Returns((callinfo) =>
         {
             return _loggerMock;
@@ -59,8 +64,9 @@ public class QueueReceiverTests
         _cmsDbContextMock = Substitute.For<CmsDbContext>();
         _entityRetrieverMock = Substitute.For<EntityRetriever>(_cmsDbContextMock);
 
-        _cmsDbContextMock.SaveChangesAsync().Returns(1);
+        MockEntityChangeTracking();
 
+        _cmsDbContextMock.SaveChangesAsync().Returns(1);
         var mockQuestionSet = _questions.AsQueryable().BuildMockDbSet();
         _cmsDbContextMock.Questions = mockQuestionSet;
         _cmsDbContextMock.Set<QuestionDbEntity>().Returns(mockQuestionSet);
@@ -103,6 +109,20 @@ public class QueueReceiverTests
         DbSet<ContentComponentDbEntity> contentComponentsMock = MockContentComponents();
         _cmsDbContextMock.ContentComponents = contentComponentsMock;
 
+    }
+
+    private void MockEntityChangeTracking()
+    {
+        var dbContextOptionsBuilder = new DbContextOptionsBuilder<CmsDbContext>();
+        dbContextOptionsBuilder.UseSqlServer("NotARealSqlServer");
+
+        var services = new ServiceCollection();
+
+        services.AddSingleton(new ContentfulOptions());
+        dbContextOptionsBuilder.UseApplicationServiceProvider(services.BuildServiceProvider());
+        var actualDbContext = new CmsDbContext(dbContextOptionsBuilder.Options);
+        var changeTrackerMock = Substitute.For<ChangeTracker>(actualDbContext, Substitute.For<IStateManager>(), Substitute.For<IChangeDetector>(), Substitute.For<IRuntimeModel>(), Substitute.For<IEntityEntryGraphIterator>());
+        _cmsDbContextMock.ChangeTracker.Returns(changeTrackerMock);
     }
 
     private DbSet<ContentComponentDbEntity> MockContentComponents()


### PR DESCRIPTION
## Overview

Addresses the cause of ticket #222371, but does not fix existing data.

Fixes an issue where join tables could be updated with null references, if messages were processed in same run.

This was only identified in `RecommendationChunkContent` joins, but likely existed in other join tables.

## Changes

### Minor Changes

- Clear tracked entities in the CmsDbContext before processing any Contentful webhook payload

## How to review the PR

### Replicating the original bug

1. Turn off the `QueueReceiver` function in dev
2. Modify a recommendation chunk and publish the changes.
3. Modify one of the contents for that recommendation chunk, and publish the changes
4. Run the Azure Function locally from the development or main branc

The function should run, and:

1. Update the recommendation chunk (from step 2)
2. For step 3, it should update the content, _and clear the ContentComponentId column in the RecommendationChunkContents table for that content component_

You can verify this by checking the SQL database afterwards, e.g. `SELECT * FROM Contentful.RecommendationChunkContents WHERE RecommendationChunkId = 'ID FROM STEP 2'`

You should see one row per content in the recommendation chunk entity, but one of them will be null. The null one should be the content component from step 3, which you can verify by comparing the remaining content component IDs vs the recommendation chunk content in Contentful.

### Testing the fix

Repeat the exact same steps as above, but run this branch for step 4. If you check the SQL database afterwards, there should be no null values in the ContentComponentId column, and all contents from the recommendation chunk should be there.

## Release requirements

None.

## Additional notes

### Cause

The cause seems to be that, when messages are processed in the same run, the entity tracking in EF Core remains from the previous message.

So, in the case of the recommendation chunk contents identified, the rough process is:

1. Two (or more) messages are processed in the same run. In this instance, a recommendation chunk change and _then_ the change for one of its contents
2. Recommendation chunk update message run happens. The function updates the recommendation chunk entity object. It's updated/inserted/whatever into the database correctly.
   - As a result of this, the DbContext stores all information about the recommendation chunk in its `ChangeTracker`
3. The update happens for the _content_ of the recommendation chunk. The content is updated correctly; all fields that have changed are updated etc.
4. _However_, since the DbContext still has a tracking of the `RecommendationChunkContent` row for this content, but _we didn't retrieve it from the database for the content_, then when it's upserted that row gets nulled as EF Core now assumes that the content no longer has any recommendation chunks attached to it.

Hope that makes sense.

### Other
- We should clear the null rows from staging and production when possible, and then verify existing data.

- I will also add E2E tests later (either in this PR or in a separate one) tomorrow.

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch