### PR TITLE
feat(recommendations): Add preview ability

### DIFF
--- a/src/Dfe.PlanTech.Application/Content/Queries/GetSubTopicRecommendationQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetSubTopicRecommendationQuery.cs
@@ -10,8 +10,6 @@ public class GetSubTopicRecommendationQuery([FromKeyedServices(GetSubtopicRecomm
                                             [FromKeyedServices(GetSubTopicRecommendationFromDbQuery.ServiceKey)] IGetSubTopicRecommendationQuery getFromDbQuery,
                                             ILogger<GetSubTopicRecommendationQuery> logger) : IGetSubTopicRecommendationQuery
 {
-    public const string ServiceKey = "Parent";
-
     private readonly IGetSubTopicRecommendationQuery _getFromContentfulQuery = getFromContentfulQuery;
     private readonly IGetSubTopicRecommendationQuery _getFromDbQuery = getFromDbQuery;
     private readonly ILogger<GetSubTopicRecommendationQuery> _logger = logger;

--- a/src/Dfe.PlanTech.Web/Controllers/RecommendationsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/RecommendationsController.cs
@@ -30,9 +30,8 @@ public class RecommendationsController(ILogger<RecommendationsController> logger
           cancellationToken);
     }
 
-    [HttpGet("{sectionSlug}/recommendation/{recommendationSlug}/preview/{maturity?}", Name = "GetRecommendationPreview")]
+    [HttpGet("{sectionSlug}/recommendation/preview/{maturity?}", Name = "GetRecommendationPreview")]
     public async Task<IActionResult> GetRecommendationPreview(string sectionSlug,
-                                                              string recommendationSlug,
                                                               string? maturity,
                                                               [FromServices] ContentfulOptions contentfulOptions,
                                                               [FromServices] IGetRecommendationRouter getRecommendationRouter,
@@ -40,19 +39,13 @@ public class RecommendationsController(ILogger<RecommendationsController> logger
     {
         if (!contentfulOptions.UsePreview)
         {
-            return new RedirectToActionResult("GetRecommendation", "Recommendations", new
-            {
-                sectionSlug,
-                recommendationSlug
-            });
+            return new RedirectResult("/self-assessment");
         }
 
         if (string.IsNullOrEmpty(sectionSlug))
             throw new ArgumentNullException(nameof(sectionSlug));
-        if (string.IsNullOrEmpty(recommendationSlug))
-            throw new ArgumentNullException(nameof(recommendationSlug));
 
-        return await getRecommendationRouter.GetRecommendationPreview(sectionSlug, recommendationSlug, maturity, this, cancellationToken);
+        return await getRecommendationRouter.GetRecommendationPreview(sectionSlug, maturity, this, cancellationToken);
     }
 
     [HttpGet("{sectionSlug}/recommendation/{recommendationSlug}/print", Name = "GetRecommendationChecklist")]

--- a/src/Dfe.PlanTech.Web/Controllers/RecommendationsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/RecommendationsController.cs
@@ -1,4 +1,8 @@
+using Dfe.PlanTech.Domain.Content.Queries;
+using Dfe.PlanTech.Domain.Persistence.Models;
+using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 using Dfe.PlanTech.Web.Helpers;
+using Dfe.PlanTech.Web.Models;
 using Dfe.PlanTech.Web.Routing;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -27,6 +31,53 @@ public class RecommendationsController(ILogger<RecommendationsController> logger
           false,
           this,
           cancellationToken);
+    }
+
+    [HttpGet("{sectionSlug}/recommendation/{recommendationSlug}/preview/{maturity?}", Name = "GetRecommendationPreview")]
+    public async Task<IActionResult> GetRecommendationPreview(string sectionSlug,
+                                                       string recommendationSlug,
+                                                       string? maturity,
+                                                       [FromServices] ContentfulOptions contentfulOptions,
+                                                       [FromServices] IGetSubTopicRecommendationQuery getSubTopicRecommendationQuery,
+                                                       [FromServices] IGetSectionQuery getSectionQuery,
+                                                       CancellationToken cancellationToken)
+    {
+        if (!contentfulOptions.UsePreview)
+        {
+            return new RedirectToActionResult("GetRecommendation", "Recommendations", new { sectionSlug, recommendationSlug });
+        }
+
+        if (string.IsNullOrEmpty(sectionSlug))
+            throw new ArgumentNullException(nameof(sectionSlug));
+        if (string.IsNullOrEmpty(recommendationSlug))
+            throw new ArgumentNullException(nameof(recommendationSlug));
+
+        var subtopic = await getSectionQuery.GetSectionBySlug(sectionSlug, cancellationToken);
+
+        if (subtopic == null)
+        {
+            return new NotFoundResult();
+        }
+
+        var recommendation = await getSubTopicRecommendationQuery.GetSubTopicRecommendation(subtopic.Sys.Id, cancellationToken);
+
+        if (recommendation == null)
+        {
+            logger.LogError("Couldn't find recommendation for section slug {SectionSlug}", sectionSlug);
+            return new NotFoundResult();
+        }
+
+        var intro = recommendation.Intros.FirstOrDefault(intro => intro.Maturity == maturity) ?? recommendation.Intros.First();
+
+        var viewModel = new RecommendationsViewModel()
+        {
+            SectionName = subtopic.Name,
+            Intro = intro,
+            Chunks = recommendation.Section.Chunks,
+            Slug = recommendationSlug,
+        };
+
+        return View("~/Views/Recommendations/Recommendations.cshtml", viewModel);
     }
 
     [HttpGet("{sectionSlug}/recommendation/{recommendationSlug}/print", Name = "GetRecommendationChecklist")]

--- a/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
@@ -51,7 +51,7 @@ public class GetRecommendationRouter(ISubmissionStatusProcessor router,
     {
         await _router.GetJourneyStatusForSectionRecommendation(sectionSlug, cancellationToken);
         var recommendation = await _getSubTopicRecommendationQuery.GetSubTopicRecommendation(_router.Section.Sys.Id, cancellationToken) ?? throw new ContentfulDataUnavailableException($"Could not find subtopic recommendation for:  {_router.Section.Name}");
-        var intro = recommendation.Intros.FirstOrDefault(intro => intro.Maturity == maturity) ?? recommendation.Intros.First();
+        var intro = recommendation.Intros.FirstOrDefault(intro => string.Equals(intro.Maturity, maturity, StringComparison.InvariantCultureIgnoreCase)) ?? recommendation.Intros.First();
 
         var viewModel = new RecommendationsViewModel()
         {

--- a/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
@@ -44,7 +44,6 @@ public class GetRecommendationRouter(ISubmissionStatusProcessor router,
     }
 
     public async Task<IActionResult> GetRecommendationPreview(string sectionSlug,
-                                                              string recommendationSlug,
                                                               string? maturity,
                                                               RecommendationsController controller,
                                                               CancellationToken cancellationToken)
@@ -58,7 +57,7 @@ public class GetRecommendationRouter(ISubmissionStatusProcessor router,
             SectionName = _router.Section.Name,
             Intro = intro,
             Chunks = recommendation.Section.Chunks,
-            Slug = recommendationSlug,
+            Slug = "preview",
         };
 
         return controller.View("~/Views/Recommendations/Recommendations.cshtml", viewModel);

--- a/src/Dfe.PlanTech.Web/Routing/IGetRecommendationRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/IGetRecommendationRouter.cs
@@ -23,4 +23,20 @@ public interface IGetRecommendationRouter
                                              bool checklist,
                                              RecommendationsController controller,
                                              CancellationToken cancellationToken);
+
+
+    /// <summary>
+    /// Gets a preview of a recommendation. Includes all recommendation chunks; no filtering off user's journey
+    /// </summary>
+    /// <param name="sectionSlug"></param>
+    /// <param name="recommendationSlug"></param>
+    /// <param name="maturity">What intro to return for the user. If null, returns first found.</param>
+    /// <param name="controller"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public Task<IActionResult> GetRecommendationPreview(string sectionSlug,
+                                                        string recommendationSlug,
+                                                        string? maturity,
+                                                        RecommendationsController controller,
+                                                        CancellationToken cancellationToken);
 }

--- a/src/Dfe.PlanTech.Web/Routing/IGetRecommendationRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/IGetRecommendationRouter.cs
@@ -29,13 +29,11 @@ public interface IGetRecommendationRouter
     /// Gets a preview of a recommendation. Includes all recommendation chunks; no filtering off user's journey
     /// </summary>
     /// <param name="sectionSlug"></param>
-    /// <param name="recommendationSlug"></param>
     /// <param name="maturity">What intro to return for the user. If null, returns first found.</param>
     /// <param name="controller"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     public Task<IActionResult> GetRecommendationPreview(string sectionSlug,
-                                                        string recommendationSlug,
                                                         string? maturity,
                                                         RecommendationsController controller,
                                                         CancellationToken cancellationToken);

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/RecommendationsControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/RecommendationsControllerTests.cs
@@ -1,5 +1,7 @@
+using Dfe.PlanTech.Domain.Persistence.Models;
 using Dfe.PlanTech.Web.Controllers;
 using Dfe.PlanTech.Web.Routing;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
@@ -46,6 +48,44 @@ public class RecommendationsControllerTests
         await _recommendationsController.GetRecommendation(sectionSlug, recommendationSlug, _recommendationsRouter, default);
 
         await _recommendationsRouter.Received().ValidateRoute(sectionSlug, recommendationSlug, false, _recommendationsController, Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("low")]
+    [InlineData("medium")]
+    [InlineData(null)]
+    public async Task RecommendationsPage_Preview_Should_Call_RecommendationsRouter_When_Args_Valid(string? maturity)
+    {
+        string sectionSlug = "section-slug";
+        string recommendationSlug = "recommendation-slug";
+
+        await _recommendationsController.GetRecommendationPreview(sectionSlug, recommendationSlug, maturity, new ContentfulOptions(true), _recommendationsRouter, default);
+
+        await _recommendationsRouter.Received().GetRecommendationPreview(sectionSlug, recommendationSlug, maturity, _recommendationsController, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RecommendationsPage_Preview_Should_Return_Redirect_When_UsePreview_Is_False()
+    {
+        string sectionSlug = "section-slug";
+        string recommendationSlug = "recommendation-slug";
+
+        var result = await _recommendationsController.GetRecommendationPreview(sectionSlug, recommendationSlug, null, new ContentfulOptions(false), _recommendationsRouter, default);
+
+        var redirectResult = result as RedirectToActionResult;
+        Assert.NotNull(redirectResult);
+        Assert.Equal(nameof(_recommendationsController.GetRecommendation), redirectResult.ActionName);
+        Assert.Equal("Recommendations", redirectResult.ControllerName);
+    }
+
+    [Theory]
+    [InlineData("section valid", null)]
+    [InlineData("section valid", "")]
+    [InlineData("", "recommendation valid")]
+    [InlineData(null, "recommendation valid")]
+    public async Task RecommendationsPage_Preview_Should_ThrowException_When_Args_Invalid(string? sectionSlug, string? recommendationSlug)
+    {
+        await Assert.ThrowsAnyAsync<ArgumentNullException>(() => _recommendationsController.GetRecommendationPreview(sectionSlug!, recommendationSlug!, null, new ContentfulOptions(true), _recommendationsRouter, default));
     }
 
     [Fact]

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/RecommendationsControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/RecommendationsControllerTests.cs
@@ -57,35 +57,30 @@ public class RecommendationsControllerTests
     public async Task RecommendationsPage_Preview_Should_Call_RecommendationsRouter_When_Args_Valid(string? maturity)
     {
         string sectionSlug = "section-slug";
-        string recommendationSlug = "recommendation-slug";
 
-        await _recommendationsController.GetRecommendationPreview(sectionSlug, recommendationSlug, maturity, new ContentfulOptions(true), _recommendationsRouter, default);
+        await _recommendationsController.GetRecommendationPreview(sectionSlug, maturity, new ContentfulOptions(true), _recommendationsRouter, default);
 
-        await _recommendationsRouter.Received().GetRecommendationPreview(sectionSlug, recommendationSlug, maturity, _recommendationsController, Arg.Any<CancellationToken>());
+        await _recommendationsRouter.Received().GetRecommendationPreview(sectionSlug, maturity, _recommendationsController, Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task RecommendationsPage_Preview_Should_Return_Redirect_When_UsePreview_Is_False()
     {
         string sectionSlug = "section-slug";
-        string recommendationSlug = "recommendation-slug";
 
-        var result = await _recommendationsController.GetRecommendationPreview(sectionSlug, recommendationSlug, null, new ContentfulOptions(false), _recommendationsRouter, default);
+        var result = await _recommendationsController.GetRecommendationPreview(sectionSlug, null, new ContentfulOptions(false), _recommendationsRouter, default);
 
-        var redirectResult = result as RedirectToActionResult;
+        var redirectResult = result as RedirectResult;
         Assert.NotNull(redirectResult);
-        Assert.Equal(nameof(_recommendationsController.GetRecommendation), redirectResult.ActionName);
-        Assert.Equal("Recommendations", redirectResult.ControllerName);
+        Assert.Equal("/self-assessment", redirectResult.Url);
     }
 
     [Theory]
-    [InlineData("section valid", null)]
-    [InlineData("section valid", "")]
-    [InlineData("", "recommendation valid")]
-    [InlineData(null, "recommendation valid")]
-    public async Task RecommendationsPage_Preview_Should_ThrowException_When_Args_Invalid(string? sectionSlug, string? recommendationSlug)
+    [InlineData("")]
+    [InlineData(null)]
+    public async Task RecommendationsPage_Preview_Should_ThrowException_When_Args_Invalid(string? sectionSlug)
     {
-        await Assert.ThrowsAnyAsync<ArgumentNullException>(() => _recommendationsController.GetRecommendationPreview(sectionSlug!, recommendationSlug!, null, new ContentfulOptions(true), _recommendationsRouter, default));
+        await Assert.ThrowsAnyAsync<ArgumentNullException>(() => _recommendationsController.GetRecommendationPreview(sectionSlug!, null, new ContentfulOptions(true), _recommendationsRouter, default));
     }
 
     [Fact]

--- a/tests/Dfe.PlanTech.Web.UnitTests/Routing/GetRecommendationRouterTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Routing/GetRecommendationRouterTests.cs
@@ -527,7 +527,7 @@ public class GetRecommendationRouterTests
     {
         Setup_Valid_Recommendation();
 
-        var result = await _router.GetRecommendationPreview(_section.InterstitialPage.Slug, "recommendation-slug", null, _controller, default);
+        var result = await _router.GetRecommendationPreview(_section.InterstitialPage.Slug, null, _controller, default);
         var viewResult = result as ViewResult;
 
         Assert.NotNull(viewResult);
@@ -548,7 +548,7 @@ public class GetRecommendationRouterTests
     {
         Setup_Valid_Recommendation();
 
-        var result = await _router.GetRecommendationPreview(_section.InterstitialPage.Slug, "recommendation-slug", maturity, _controller, default);
+        var result = await _router.GetRecommendationPreview(_section.InterstitialPage.Slug, maturity, _controller, default);
         var viewResult = result as ViewResult;
 
         Assert.NotNull(viewResult);
@@ -570,7 +570,7 @@ public class GetRecommendationRouterTests
     {
         Setup_Valid_Recommendation();
 
-        var result = await _router.GetRecommendationPreview(_section.InterstitialPage.Slug, "recommendation-slug", maturity, _controller, default);
+        var result = await _router.GetRecommendationPreview(_section.InterstitialPage.Slug, maturity, _controller, default);
         var viewResult = result as ViewResult;
 
         Assert.NotNull(viewResult);


### PR DESCRIPTION
## Overview

Adds ability to preview recommendation pages.

### Detail

- Adds a route `{sectionSlug}/recommendation/{recommendationSlug}/preview/{maturity?}`
- The route is only accessible if `UsePreview` is set to true.
    - If false, it'll redirect the user back to the normal recommendation route (i.e. `{sectionSlug}/recommendation/{recommendationSlug}`)
- It'll retrieve and return the recommendation page with:
    - _All_ recommendation chunks for that recommendation
    - Either the intro matching the `maturity` slug, or the first intro it finds in the returned recommendation section

## Changes

### Major

- Adds route to preview a recommendation page in its entirity

## How to review the PR

### Preview enabled

1. Set `Contentful:UsePreview` to true
2. Visit one of your existing recommendation pages
3. Append `/preview` to the URL. You should now see _all_ recommendation chunks.
4. Append `/Low`, `/Medium` or `/High` to the end of the preview URL from step 3. You should be returned the correct intro.

### Preview disabled

1. Set `Contentful:UsePreview` to false
2. Visit any of your existing recommendation pages
3. Append `/preview` to the URL
4. You should be redirected to the URL from step 2.

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [x] Unit tests have been added/updated