### PR TITLE
Fix: test and deploy on cs update

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,6 +8,8 @@ on:
       - "src/**"
       - "tests/Dfe.PlanTech.Web.E2ETests/**"
       - ".github/workflows/e2e-tests.yml"
+      - "contentandsupport/**"
+      - ".gitmodules"
 
 concurrency:
   group: "${{ github.workflow }}"

--- a/.github/workflows/matrix-deploy.yml
+++ b/.github/workflows/matrix-deploy.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - "src/**"
       - ".github/workflows/matrix-deploy.yml"
+      - "contentandsupport/**"
+      - ".gitmodules"
 
 jobs:
   set-env:


### PR DESCRIPTION
## Overview

Updates workflows to run e2e tests and deployments when the C&S Submodule is updated 

## Context

The recent commit to swap the C&S submodule to point at main broke the landing page locally. We didn't see this until now because git submodules don't automatically update, and as we hadn't done an update in a while, we hadn't pulled in the breaking change.

We should be running the e2e tests whenever we update the submodule to make sure we don't have conflicts and breaking changes.

Deployments should also be triggered by a C&S submodule update so an isolated C&S change is permitted

## Checklist

Delete any rows that do not apply to the PR.

- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch
- [ ] GitHub workflows/actions have been added/updated