### PR TITLE
fix(tf): Differences for prod + staging environments

### DIFF
--- a/terraform/container-app/database.networking.tf
+++ b/terraform/container-app/database.networking.tf
@@ -30,6 +30,8 @@ resource "azurerm_private_dns_zone_virtual_network_link" "database_default" {
   resource_group_name   = local.resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.database.name
   virtual_network_id    = module.main_hosting.networking.vnet_id
+
+  tags = local.tags
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "database_function" {
@@ -37,4 +39,6 @@ resource "azurerm_private_dns_zone_virtual_network_link" "database_function" {
   resource_group_name   = local.resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.database.name
   virtual_network_id    = azurerm_virtual_network.function_vnet.id
+
+  tags = local.tags
 }

--- a/terraform/container-app/functions.networking.tf
+++ b/terraform/container-app/functions.networking.tf
@@ -84,6 +84,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "blob_storage" {
   resource_group_name   = local.resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.blob_storage.name
   virtual_network_id    = azurerm_virtual_network.function_vnet.id
+  tags                  = local.tags
 }
 
 resource "azurerm_private_dns_zone" "files_storage" {
@@ -118,4 +119,5 @@ resource "azurerm_private_dns_zone_virtual_network_link" "files_storage" {
   resource_group_name   = local.resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.files_storage.name
   virtual_network_id    = azurerm_virtual_network.function_vnet.id
+  tags                  = local.tags
 }

--- a/terraform/container-app/key-vault.networking.tf
+++ b/terraform/container-app/key-vault.networking.tf
@@ -47,6 +47,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "keyvault_to_functionvn
   resource_group_name   = local.resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.keyvault.name
   virtual_network_id    = azurerm_virtual_network.function_vnet.id
+  tags                  = local.tags
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "keyvault_to_defaultvnet" {
@@ -54,4 +55,5 @@ resource "azurerm_private_dns_zone_virtual_network_link" "keyvault_to_defaultvne
   resource_group_name   = local.resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.keyvault.name
   virtual_network_id    = module.main_hosting.networking.vnet_id
+  tags                  = local.tags
 }

--- a/terraform/container-app/locals.tf
+++ b/terraform/container-app/locals.tf
@@ -44,6 +44,7 @@ locals {
   az_use_azure_ad_auth_only     = var.az_tag_environment != "Dev"
   az_sql_sku                    = var.az_sql_sku
   az_sql_max_pool_size          = var.az_sql_max_pool_size
+  az_sql_max_size_gb            = local.az_sql_sku == "Basic" ? null : 512
 
   az_sql_vnet = {
     dns_zone_name = "privatelink.database.windows.net"

--- a/terraform/container-app/main-hosting.tf
+++ b/terraform/container-app/main-hosting.tf
@@ -46,6 +46,7 @@ module "main_hosting" {
   mssql_azuread_auth_only            = local.az_use_azure_ad_auth_only
   mssql_managed_identity_assign_role = false
   mssql_sku_name                     = local.az_sql_sku
+  mssql_max_size_gb                  = local.az_sql_max_size_gb
 
   ##############
   # Networking #

--- a/terraform/container-app/upgrade-scripts/README.md
+++ b/terraform/container-app/upgrade-scripts/README.md
@@ -18,3 +18,11 @@ This folder contains various scripts designed to be ran before a specific sprint
 | Name                                                        | Description                                                                            |
 | ----------------------------------------------------------- | -------------------------------------------------------------------------------------- |
 | [Key Vault State Import](./shared/keyvault/state_import.sh) | Retrieves a Key Vault secret's ID from Azure using the CLI, then imports into TF state |
+
+### Helpful functions
+
+#### Saving plan to file and removing formatting
+
+You can use `grep -v -P '\[\d{1,2}m~?'` to cleanup a plan by remove all formatting lines/colours from it.
+
+You can do this all in one line with `terraform plan -var-file=./var-file.tfvars | grep -v -P '\[\d{1,2}m~?' > 20240820-environment_plan.txt`

--- a/terraform/container-app/upgrade-scripts/create-import-statements.js
+++ b/terraform/container-app/upgrade-scripts/create-import-statements.js
@@ -1,0 +1,38 @@
+/**
+ * Extracts existing TF resource errors from the TF apply string, and creates import statements for each one 
+ * @param {string} inputString Terraform apply failure error messages
+ * @param {string} varFile Var file to be used for the imports
+ * @returns 
+ */
+function generateTerraformImports(inputString, varFile) {
+  const commands = [];
+
+  // Regex to capture the resource ID, type, and name across multiple lines
+  const regex = /ID "(.*?)" already exists.*?with (.*?)\.(.*?),/gs;
+
+  let match;
+  while ((match = regex.exec(inputString)) !== null) {
+    const resourceId = match[1]; // The resource ID
+    const resourceType = match[2]; // The resource type (e.g., azurerm_private_endpoint)
+    const resourceName = match[3]; // The resource name (e.g., database)
+
+    // Construct the command
+    const command = `terraform import -var-file=${varFile} '${resourceType}.${resourceName}' '${resourceId}'`;
+    commands.push(command);
+  }
+
+  return commands.join('\n');
+}
+
+// Replace with _all_ of the failures from the TF apply. Ensure first line formatting matches as shown.
+const inputString = `
+│ Error: A resource with the ID "/subscriptions/AZURE_RESOURCE_ID" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_private_endpoint" for more information.
+│
+│   with azurerm_private_endpoint.database,
+│   on database.networking.tf line 7, in resource "azurerm_private_endpoint" "database":
+│    7: resource "azurerm_private_endpoint" "database" {
+│`;
+
+const varFile = '../terraform-stg.tfvars'; //replace with appropriate TF vars file
+const result = generateTerraformImports(inputString, varFile);
+console.log(result);

--- a/terraform/container-app/upgrade-scripts/create-import-statements.js
+++ b/terraform/container-app/upgrade-scripts/create-import-statements.js
@@ -26,12 +26,18 @@ function generateTerraformImports(inputString, varFile) {
 
 // Replace with _all_ of the failures from the TF apply. Ensure first line formatting matches as shown.
 const inputString = `
-│ Error: A resource with the ID "/subscriptions/AZURE_RESOURCE_ID" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_private_endpoint" for more information.
+│ Error: A resource with the ID "/subscriptions/abc/resourceGroups/xyz/providers/Microsoft.ServiceName/resourceType/resourcename" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_private_endpoint" for more information.
 │
 │   with azurerm_private_endpoint.database,
 │   on database.networking.tf line 7, in resource "azurerm_private_endpoint" "database":
 │    7: resource "azurerm_private_endpoint" "database" {
-│`;
+│
+│ Error: A resource with the ID "/subscriptions/abc/resourceGroups/xyz/providers/Microsoft.ServiceName/resourceType/resourcename" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_private_endpoint" for more information.
+│   with azurerm_private_endpoint.another_database,
+│   on another_database.networking.tf line 7, in resource "azurerm_private_endpoint" "another_database":
+│    7: resource "azurerm_private_endpoint" "another_database" {
+`;
+
 
 const varFile = '../terraform-stg.tfvars'; //replace with appropriate TF vars file
 const result = generateTerraformImports(inputString, varFile);

--- a/terraform/container-app/upgrade-scripts/shared/keyvault/state_import.sh
+++ b/terraform/container-app/upgrade-scripts/shared/keyvault/state_import.sh
@@ -24,5 +24,5 @@ if [[ -z "$SECRET_ID" ]]; then
   exit 1
 fi
 
-echo "Running command: terraform import -var-file=${TFVAR_PATH} $TF_ID_NAME $SECRET_ID"
-terraform import -var-file=../$TF_VARS $TF_NAME $secret_id
+echo "Running command: terraform import -var-file=${TFVAR_PATH} '$TF_ID_NAME' '$SECRET_ID'"
+terraform import -var-file=$TFVAR_PATH $TF_ID_NAME $SECRET_ID


### PR DESCRIPTION
## Overview

- Adds a variable for the SQL DB, which is "needed" for staging + prod environments
- Adds missing tags 
- Couple of little helpers for future TF usage

## Changes

### Minor

- Adds tags to various resources where they were missing
- Adds ability to set `mssql_max_size_gb`, which is used in staging + production due to the SQL plan differences
- Creates a script that creates Terraform import statements for you (from the error output generated in an apply), to allow easy importing of various resources if appropriate
- Fixes variables in `state_import.sh` (I renamed them previously at one point and missed a few)

### Non-functional changes (e.g. documentation)

- Adds a grep/command in the `upgrade-scripts/README.md` that allows you to clean up the TF plan output easily

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [x] Terraform has been updated
- [x] Documentation has been updated where relevant
