### PR TITLE
chore: Rename section status

### DIFF
--- a/src/Dfe.PlanTech.Application/Submissions/Queries/SubmissionStatusProcessor.cs
+++ b/src/Dfe.PlanTech.Application/Submissions/Queries/SubmissionStatusProcessor.cs
@@ -24,7 +24,7 @@ public class SubmissionStatusProcessor : ISubmissionStatusProcessor
     }
     public IUser User { get; init; }
     public Question? NextQuestion { get; set; }
-    public SectionStatusNew? SectionStatus { get; private set; }
+    public SectionStatus? SectionStatus { get; private set; }
     public SubmissionStatus Status { get; set; }
 
     public SubmissionStatusProcessor(IGetSectionQuery getSectionQuery,

--- a/src/Dfe.PlanTech.Domain/Interfaces/IGetSubmissionStatusesQuery.cs
+++ b/src/Dfe.PlanTech.Domain/Interfaces/IGetSubmissionStatusesQuery.cs
@@ -7,7 +7,7 @@ public interface IGetSubmissionStatusesQuery
 {
     Task<List<SectionStatusDto>> GetSectionSubmissionStatuses(string categoryId);
 
-    Task<SectionStatusNew> GetSectionSubmissionStatusAsync(int establishmentId,
+    Task<SectionStatus> GetSectionSubmissionStatusAsync(int establishmentId,
                                                            ISectionComponent section,
                                                            bool completed,
                                                            CancellationToken cancellationToken);

--- a/src/Dfe.PlanTech.Domain/Submissions/Interfaces/ISubmissionStatusProcessor.cs
+++ b/src/Dfe.PlanTech.Domain/Submissions/Interfaces/ISubmissionStatusProcessor.cs
@@ -17,7 +17,7 @@ public interface ISubmissionStatusProcessor
     public SubmissionStatus Status { get; set; }
     public Question? NextQuestion { get; set; }
     public ISectionComponent Section { get; }
-    public SectionStatusNew? SectionStatus { get; }
+    public SectionStatus? SectionStatus { get; }
 
     Task GetJourneyStatusForSection(string sectionSlug, CancellationToken cancellationToken);
     Task GetJourneyStatusForSectionRecommendation(string sectionSlug, CancellationToken cancellationToken);

--- a/src/Dfe.PlanTech.Domain/Submissions/Models/SectionStatus.cs
+++ b/src/Dfe.PlanTech.Domain/Submissions/Models/SectionStatus.cs
@@ -2,20 +2,7 @@
 
 namespace Dfe.PlanTech.Domain.Submissions.Models;
 
-public class SectionStatusDto
-{
-    public string SectionId { get; set; } = null!;
-
-    public bool Completed { get; set; }
-
-    public string? LastMaturity { get; set; }
-
-    public DateTime DateCreated { get; set; }
-
-    public DateTime DateUpdated { get; set; }
-}
-
-public record SectionStatusNew
+public record SectionStatus
 {
     public string SectionId { get; set; } = null!;
 

--- a/src/Dfe.PlanTech.Domain/Submissions/Models/SectionStatusDto.cs
+++ b/src/Dfe.PlanTech.Domain/Submissions/Models/SectionStatusDto.cs
@@ -2,13 +2,13 @@ namespace Dfe.PlanTech.Domain.Submissions.Models;
 
 public class SectionStatusDto
 {
-  public string SectionId { get; set; } = null!;
+    public string SectionId { get; set; } = null!;
 
-  public bool Completed { get; set; }
+    public bool Completed { get; set; }
 
-  public string? LastMaturity { get; set; }
+    public string? LastMaturity { get; set; }
 
-  public DateTime DateCreated { get; set; }
+    public DateTime DateCreated { get; set; }
 
-  public DateTime DateUpdated { get; set; }
+    public DateTime DateUpdated { get; set; }
 }

--- a/src/Dfe.PlanTech.Domain/Submissions/Models/SectionStatusDto.cs
+++ b/src/Dfe.PlanTech.Domain/Submissions/Models/SectionStatusDto.cs
@@ -1,0 +1,14 @@
+namespace Dfe.PlanTech.Domain.Submissions.Models;
+
+public class SectionStatusDto
+{
+  public string SectionId { get; set; } = null!;
+
+  public bool Completed { get; set; }
+
+  public string? LastMaturity { get; set; }
+
+  public DateTime DateCreated { get; set; }
+
+  public DateTime DateUpdated { get; set; }
+}

--- a/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/CheckAnswersOrNextQuestionCheckerTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/CheckAnswersOrNextQuestionCheckerTests.cs
@@ -12,9 +12,9 @@ namespace Dfe.PlanTech.Application.UnitTests.Submissions.Queries;
 
 public class CheckAnswersOrNextQuestionCheckerTests
 {
-    public readonly ISubmissionStatusChecker StatusChecker = CheckAnswersOrNextQuestionChecker.CheckAnswersOrNextQuestion;
+  public readonly ISubmissionStatusChecker StatusChecker = CheckAnswersOrNextQuestionChecker.CheckAnswersOrNextQuestion;
 
-    public static readonly List<Question> Questions = new() {
+  public static readonly List<Question> Questions = new() {
     new(){
       Sys = new SystemDetails(){ Id = "Question-One" },
       Answers = new()
@@ -37,7 +37,7 @@ public class CheckAnswersOrNextQuestionCheckerTests
     },
   };
 
-    public readonly List<Answer> Answers = new(){
+  public readonly List<Answer> Answers = new(){
           new(){
             Sys = new SystemDetails(){
               Id = "Answer-One"
@@ -62,10 +62,10 @@ public class CheckAnswersOrNextQuestionCheckerTests
         };
 
 
-    public SubmissionResponsesDto ResponsesForSubmissionDto = new()
-    {
-        Responses = [
-          new QuestionWithAnswer()
+  public SubmissionResponsesDto ResponsesForSubmissionDto = new()
+  {
+    Responses = [
+        new QuestionWithAnswer()
           {
               QuestionRef = "Question-One",
               AnswerRef = "Answer-One"
@@ -91,119 +91,119 @@ public class CheckAnswersOrNextQuestionCheckerTests
                 AnswerRef = "Answer-Four"
             },
         ]
-    };
+  };
 
-    public CheckAnswersOrNextQuestionCheckerTests()
+  public CheckAnswersOrNextQuestionCheckerTests()
+  {
+    foreach (var question in Questions)
     {
-        foreach (var question in Questions)
-        {
-            question.Answers.AddRange(Answers);
-        }
+      question.Answers.AddRange(Answers);
     }
+  }
 
-    [Fact]
-    public void Should_Match_InProgress_Status()
-    {
-        var processor = Substitute.For<ISubmissionStatusProcessor>();
-        processor.Section.Returns(new Section() { });
-        processor.SectionStatus.Returns(new SectionStatusNew() { Status = Status.InProgress });
+  [Fact]
+  public void Should_Match_InProgress_Status()
+  {
+    var processor = Substitute.For<ISubmissionStatusProcessor>();
+    processor.Section.Returns(new Section() { });
+    processor.SectionStatus.Returns(new SectionStatus() { Status = Status.InProgress });
 
-        var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
+    var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
 
-        Assert.True(matches);
-    }
+    Assert.True(matches);
+  }
 
-    [Fact]
-    public void Should_Not_Match_NotStarted_Status()
-    {
-        var processor = Substitute.For<ISubmissionStatusProcessor>();
-        processor.Section.Returns(new Section() { });
-        processor.SectionStatus.Returns(new SectionStatusNew() { Status = Status.NotStarted });
+  [Fact]
+  public void Should_Not_Match_NotStarted_Status()
+  {
+    var processor = Substitute.For<ISubmissionStatusProcessor>();
+    processor.Section.Returns(new Section() { });
+    processor.SectionStatus.Returns(new SectionStatus() { Status = Status.NotStarted });
 
-        var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
+    var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
 
-        Assert.False(matches);
-    }
+    Assert.False(matches);
+  }
 
-    [Fact]
-    public void Should_Not_Match_Completed_Status()
-    {
-        var processor = Substitute.For<ISubmissionStatusProcessor>();
-        processor.Section.Returns(new Section() { });
-        processor.SectionStatus.Returns(new SectionStatusNew() { Status = Status.Completed });
+  [Fact]
+  public void Should_Not_Match_Completed_Status()
+  {
+    var processor = Substitute.For<ISubmissionStatusProcessor>();
+    processor.Section.Returns(new Section() { });
+    processor.SectionStatus.Returns(new SectionStatus() { Status = Status.Completed });
 
-        var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
+    var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
 
-        Assert.False(matches);
-    }
+    Assert.False(matches);
+  }
 
-    [Fact]
-    public async Task Should_SetStatus_To_CheckAnswers_When_No_NextQuestion()
-    {
-        var processor = Substitute.For<ISubmissionStatusProcessor>();
+  [Fact]
+  public async Task Should_SetStatus_To_CheckAnswers_When_No_NextQuestion()
+  {
+    var processor = Substitute.For<ISubmissionStatusProcessor>();
 
-        var user = Substitute.For<IUser>();
-        user.GetEstablishmentId().Returns(1);
-        processor.User.Returns(user);
+    var user = Substitute.For<IUser>();
+    user.GetEstablishmentId().Returns(1);
+    processor.User.Returns(user);
 
-        var getResponsesQuery = Substitute.For<IGetLatestResponsesQuery>();
-        getResponsesQuery.GetLatestResponses(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(ResponsesForSubmissionDto);
+    var getResponsesQuery = Substitute.For<IGetLatestResponsesQuery>();
+    getResponsesQuery.GetLatestResponses(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(ResponsesForSubmissionDto);
 
-        processor.GetResponsesQuery.Returns(getResponsesQuery);
+    processor.GetResponsesQuery.Returns(getResponsesQuery);
 
-        var section = Substitute.For<ISectionComponent>();
-        section.GetOrderedResponsesForJourney(Arg.Any<IEnumerable<QuestionWithAnswer>>())
-                .Returns(new[] {
+    var section = Substitute.For<ISectionComponent>();
+    section.GetOrderedResponsesForJourney(Arg.Any<IEnumerable<QuestionWithAnswer>>())
+            .Returns(new[] {
               ResponsesForSubmissionDto.Responses[0],ResponsesForSubmissionDto.Responses[1],ResponsesForSubmissionDto.Responses[4]
-                });
+            });
 
-        section.Sys.Returns(new SystemDetails()
-        {
-            Id = "section-id"
-        });
-
-        section.Questions.Returns(Questions);
-
-        processor.Section.Returns(section);
-        processor.SectionStatus.Returns(new SectionStatusNew() { Status = Status.InProgress });
-
-        await StatusChecker.ProcessSubmission(processor, default);
-
-        Assert.Equal(SubmissionStatus.CheckAnswers, processor.Status);
-    }
-
-    [Fact]
-    public async Task Should_SetStatus_To_CheckAnswers_When_NextQuestion()
+    section.Sys.Returns(new SystemDetails()
     {
-        var processor = Substitute.For<ISubmissionStatusProcessor>();
+      Id = "section-id"
+    });
 
-        var user = Substitute.For<IUser>();
-        user.GetEstablishmentId().Returns(1);
-        processor.User.Returns(user);
+    section.Questions.Returns(Questions);
 
-        var getResponsesQuery = Substitute.For<IGetLatestResponsesQuery>();
-        getResponsesQuery.GetLatestResponses(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(ResponsesForSubmissionDto);
+    processor.Section.Returns(section);
+    processor.SectionStatus.Returns(new SectionStatus() { Status = Status.InProgress });
 
-        processor.GetResponsesQuery.Returns(getResponsesQuery);
+    await StatusChecker.ProcessSubmission(processor, default);
 
-        var section = Substitute.For<ISectionComponent>();
-        section.GetOrderedResponsesForJourney(Arg.Any<IEnumerable<QuestionWithAnswer>>())
-                .Returns([ResponsesForSubmissionDto.Responses[0], ResponsesForSubmissionDto.Responses[1]]);
+    Assert.Equal(SubmissionStatus.CheckAnswers, processor.Status);
+  }
 
-        section.Sys.Returns(new SystemDetails()
-        {
-            Id = "section-id"
-        });
+  [Fact]
+  public async Task Should_SetStatus_To_CheckAnswers_When_NextQuestion()
+  {
+    var processor = Substitute.For<ISubmissionStatusProcessor>();
 
-        section.Questions.Returns(Questions);
+    var user = Substitute.For<IUser>();
+    user.GetEstablishmentId().Returns(1);
+    processor.User.Returns(user);
 
-        processor.Section.Returns(section);
-        processor.SectionStatus.Returns(new SectionStatusNew() { Status = Status.InProgress });
+    var getResponsesQuery = Substitute.For<IGetLatestResponsesQuery>();
+    getResponsesQuery.GetLatestResponses(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(ResponsesForSubmissionDto);
 
-        await StatusChecker.ProcessSubmission(processor, default);
+    processor.GetResponsesQuery.Returns(getResponsesQuery);
 
-        Assert.Equal(SubmissionStatus.NextQuestion, processor.Status);
-        Assert.Equal(Questions[3], processor.NextQuestion);
-    }
+    var section = Substitute.For<ISectionComponent>();
+    section.GetOrderedResponsesForJourney(Arg.Any<IEnumerable<QuestionWithAnswer>>())
+            .Returns([ResponsesForSubmissionDto.Responses[0], ResponsesForSubmissionDto.Responses[1]]);
+
+    section.Sys.Returns(new SystemDetails()
+    {
+      Id = "section-id"
+    });
+
+    section.Questions.Returns(Questions);
+
+    processor.Section.Returns(section);
+    processor.SectionStatus.Returns(new SectionStatus() { Status = Status.InProgress });
+
+    await StatusChecker.ProcessSubmission(processor, default);
+
+    Assert.Equal(SubmissionStatus.NextQuestion, processor.Status);
+    Assert.Equal(Questions[3], processor.NextQuestion);
+  }
 
 }

--- a/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/CheckAnswersOrNextQuestionCheckerTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/CheckAnswersOrNextQuestionCheckerTests.cs
@@ -12,9 +12,9 @@ namespace Dfe.PlanTech.Application.UnitTests.Submissions.Queries;
 
 public class CheckAnswersOrNextQuestionCheckerTests
 {
-  public readonly ISubmissionStatusChecker StatusChecker = CheckAnswersOrNextQuestionChecker.CheckAnswersOrNextQuestion;
+    public readonly ISubmissionStatusChecker StatusChecker = CheckAnswersOrNextQuestionChecker.CheckAnswersOrNextQuestion;
 
-  public static readonly List<Question> Questions = new() {
+    public static readonly List<Question> Questions = new() {
     new(){
       Sys = new SystemDetails(){ Id = "Question-One" },
       Answers = new()
@@ -37,7 +37,7 @@ public class CheckAnswersOrNextQuestionCheckerTests
     },
   };
 
-  public readonly List<Answer> Answers = new(){
+    public readonly List<Answer> Answers = new(){
           new(){
             Sys = new SystemDetails(){
               Id = "Answer-One"
@@ -62,10 +62,10 @@ public class CheckAnswersOrNextQuestionCheckerTests
         };
 
 
-  public SubmissionResponsesDto ResponsesForSubmissionDto = new()
-  {
-    Responses = [
-        new QuestionWithAnswer()
+    public SubmissionResponsesDto ResponsesForSubmissionDto = new()
+    {
+        Responses = [
+          new QuestionWithAnswer()
           {
               QuestionRef = "Question-One",
               AnswerRef = "Answer-One"
@@ -91,119 +91,119 @@ public class CheckAnswersOrNextQuestionCheckerTests
                 AnswerRef = "Answer-Four"
             },
         ]
-  };
+    };
 
-  public CheckAnswersOrNextQuestionCheckerTests()
-  {
-    foreach (var question in Questions)
+    public CheckAnswersOrNextQuestionCheckerTests()
     {
-      question.Answers.AddRange(Answers);
+        foreach (var question in Questions)
+        {
+            question.Answers.AddRange(Answers);
+        }
     }
-  }
 
-  [Fact]
-  public void Should_Match_InProgress_Status()
-  {
-    var processor = Substitute.For<ISubmissionStatusProcessor>();
-    processor.Section.Returns(new Section() { });
-    processor.SectionStatus.Returns(new SectionStatus() { Status = Status.InProgress });
+    [Fact]
+    public void Should_Match_InProgress_Status()
+    {
+        var processor = Substitute.For<ISubmissionStatusProcessor>();
+        processor.Section.Returns(new Section() { });
+        processor.SectionStatus.Returns(new SectionStatus() { Status = Status.InProgress });
 
-    var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
+        var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
 
-    Assert.True(matches);
-  }
+        Assert.True(matches);
+    }
 
-  [Fact]
-  public void Should_Not_Match_NotStarted_Status()
-  {
-    var processor = Substitute.For<ISubmissionStatusProcessor>();
-    processor.Section.Returns(new Section() { });
-    processor.SectionStatus.Returns(new SectionStatus() { Status = Status.NotStarted });
+    [Fact]
+    public void Should_Not_Match_NotStarted_Status()
+    {
+        var processor = Substitute.For<ISubmissionStatusProcessor>();
+        processor.Section.Returns(new Section() { });
+        processor.SectionStatus.Returns(new SectionStatus() { Status = Status.NotStarted });
 
-    var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
+        var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
 
-    Assert.False(matches);
-  }
+        Assert.False(matches);
+    }
 
-  [Fact]
-  public void Should_Not_Match_Completed_Status()
-  {
-    var processor = Substitute.For<ISubmissionStatusProcessor>();
-    processor.Section.Returns(new Section() { });
-    processor.SectionStatus.Returns(new SectionStatus() { Status = Status.Completed });
+    [Fact]
+    public void Should_Not_Match_Completed_Status()
+    {
+        var processor = Substitute.For<ISubmissionStatusProcessor>();
+        processor.Section.Returns(new Section() { });
+        processor.SectionStatus.Returns(new SectionStatus() { Status = Status.Completed });
 
-    var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
+        var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
 
-    Assert.False(matches);
-  }
+        Assert.False(matches);
+    }
 
-  [Fact]
-  public async Task Should_SetStatus_To_CheckAnswers_When_No_NextQuestion()
-  {
-    var processor = Substitute.For<ISubmissionStatusProcessor>();
+    [Fact]
+    public async Task Should_SetStatus_To_CheckAnswers_When_No_NextQuestion()
+    {
+        var processor = Substitute.For<ISubmissionStatusProcessor>();
 
-    var user = Substitute.For<IUser>();
-    user.GetEstablishmentId().Returns(1);
-    processor.User.Returns(user);
+        var user = Substitute.For<IUser>();
+        user.GetEstablishmentId().Returns(1);
+        processor.User.Returns(user);
 
-    var getResponsesQuery = Substitute.For<IGetLatestResponsesQuery>();
-    getResponsesQuery.GetLatestResponses(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(ResponsesForSubmissionDto);
+        var getResponsesQuery = Substitute.For<IGetLatestResponsesQuery>();
+        getResponsesQuery.GetLatestResponses(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(ResponsesForSubmissionDto);
 
-    processor.GetResponsesQuery.Returns(getResponsesQuery);
+        processor.GetResponsesQuery.Returns(getResponsesQuery);
 
-    var section = Substitute.For<ISectionComponent>();
-    section.GetOrderedResponsesForJourney(Arg.Any<IEnumerable<QuestionWithAnswer>>())
-            .Returns(new[] {
+        var section = Substitute.For<ISectionComponent>();
+        section.GetOrderedResponsesForJourney(Arg.Any<IEnumerable<QuestionWithAnswer>>())
+                .Returns(new[] {
               ResponsesForSubmissionDto.Responses[0],ResponsesForSubmissionDto.Responses[1],ResponsesForSubmissionDto.Responses[4]
-            });
+                });
 
-    section.Sys.Returns(new SystemDetails()
+        section.Sys.Returns(new SystemDetails()
+        {
+            Id = "section-id"
+        });
+
+        section.Questions.Returns(Questions);
+
+        processor.Section.Returns(section);
+        processor.SectionStatus.Returns(new SectionStatus() { Status = Status.InProgress });
+
+        await StatusChecker.ProcessSubmission(processor, default);
+
+        Assert.Equal(SubmissionStatus.CheckAnswers, processor.Status);
+    }
+
+    [Fact]
+    public async Task Should_SetStatus_To_CheckAnswers_When_NextQuestion()
     {
-      Id = "section-id"
-    });
+        var processor = Substitute.For<ISubmissionStatusProcessor>();
 
-    section.Questions.Returns(Questions);
+        var user = Substitute.For<IUser>();
+        user.GetEstablishmentId().Returns(1);
+        processor.User.Returns(user);
 
-    processor.Section.Returns(section);
-    processor.SectionStatus.Returns(new SectionStatus() { Status = Status.InProgress });
+        var getResponsesQuery = Substitute.For<IGetLatestResponsesQuery>();
+        getResponsesQuery.GetLatestResponses(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(ResponsesForSubmissionDto);
 
-    await StatusChecker.ProcessSubmission(processor, default);
+        processor.GetResponsesQuery.Returns(getResponsesQuery);
 
-    Assert.Equal(SubmissionStatus.CheckAnswers, processor.Status);
-  }
+        var section = Substitute.For<ISectionComponent>();
+        section.GetOrderedResponsesForJourney(Arg.Any<IEnumerable<QuestionWithAnswer>>())
+                .Returns([ResponsesForSubmissionDto.Responses[0], ResponsesForSubmissionDto.Responses[1]]);
 
-  [Fact]
-  public async Task Should_SetStatus_To_CheckAnswers_When_NextQuestion()
-  {
-    var processor = Substitute.For<ISubmissionStatusProcessor>();
+        section.Sys.Returns(new SystemDetails()
+        {
+            Id = "section-id"
+        });
 
-    var user = Substitute.For<IUser>();
-    user.GetEstablishmentId().Returns(1);
-    processor.User.Returns(user);
+        section.Questions.Returns(Questions);
 
-    var getResponsesQuery = Substitute.For<IGetLatestResponsesQuery>();
-    getResponsesQuery.GetLatestResponses(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(ResponsesForSubmissionDto);
+        processor.Section.Returns(section);
+        processor.SectionStatus.Returns(new SectionStatus() { Status = Status.InProgress });
 
-    processor.GetResponsesQuery.Returns(getResponsesQuery);
+        await StatusChecker.ProcessSubmission(processor, default);
 
-    var section = Substitute.For<ISectionComponent>();
-    section.GetOrderedResponsesForJourney(Arg.Any<IEnumerable<QuestionWithAnswer>>())
-            .Returns([ResponsesForSubmissionDto.Responses[0], ResponsesForSubmissionDto.Responses[1]]);
-
-    section.Sys.Returns(new SystemDetails()
-    {
-      Id = "section-id"
-    });
-
-    section.Questions.Returns(Questions);
-
-    processor.Section.Returns(section);
-    processor.SectionStatus.Returns(new SectionStatus() { Status = Status.InProgress });
-
-    await StatusChecker.ProcessSubmission(processor, default);
-
-    Assert.Equal(SubmissionStatus.NextQuestion, processor.Status);
-    Assert.Equal(Questions[3], processor.NextQuestion);
-  }
+        Assert.Equal(SubmissionStatus.NextQuestion, processor.Status);
+        Assert.Equal(Questions[3], processor.NextQuestion);
+    }
 
 }

--- a/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/GetSubmissionStatusesQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/GetSubmissionStatusesQueryTests.cs
@@ -122,10 +122,10 @@ public class GetSubmissionStatusesQueryTests
 
         Db.GetSubmissions.Returns(submissions.AsQueryable());
 
-        Db.FirstOrDefaultAsync(Arg.Any<IQueryable<SectionStatusNew>>(), Arg.Any<CancellationToken>())
+        Db.FirstOrDefaultAsync(Arg.Any<IQueryable<SectionStatus>>(), Arg.Any<CancellationToken>())
             .Returns((callinfo) =>
             {
-                var queryable = callinfo.ArgAt<IQueryable<SectionStatusNew>>(0);
+                var queryable = callinfo.ArgAt<IQueryable<SectionStatus>>(0);
 
                 return queryable.FirstOrDefault();
             });

--- a/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/SectionCompleteStatusCheckerTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/SectionCompleteStatusCheckerTests.cs
@@ -9,40 +9,40 @@ namespace Dfe.PlanTech.Application.UnitTests.Submissions.Queries;
 
 public class SectionCompleteStatusCheckerTests
 {
-    public readonly ISubmissionStatusChecker StatusChecker = SectionCompleteStatusChecker.SectionComplete;
+  public readonly ISubmissionStatusChecker StatusChecker = SectionCompleteStatusChecker.SectionComplete;
 
-    [Fact]
-    public void Should_Match_Completed_Status()
+  [Fact]
+  public void Should_Match_Completed_Status()
+  {
+    var processor = Substitute.For<ISubmissionStatusProcessor>();
+    processor.Section.Returns(new Section() { });
+    processor.SectionStatus.Returns(new SectionStatus() { Status = Status.Completed, Completed = true });
+
+    var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
+
+    Assert.True(matches);
+  }
+
+  [Theory]
+  [InlineData(Status.NotStarted)]
+  [InlineData(Status.InProgress)]
+  public void Should_Not_Match_AnyOtherStatus(Status status)
+  {
+    var processor = Substitute.For<ISubmissionStatusProcessor>();
+    processor.Section.Returns(new Section() { });
+    processor.SectionStatus.Returns(new SectionStatus() { Status = status, Completed = false });
+
+    var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
+
+    Assert.False(matches);
+  }
+
+  [Fact]
+  public async Task Should_Set_SubmissionStatus_And_FirstQuestion()
+  {
+    var section = new Section()
     {
-        var processor = Substitute.For<ISubmissionStatusProcessor>();
-        processor.Section.Returns(new Section() { });
-        processor.SectionStatus.Returns(new SectionStatusNew() { Status = Status.Completed, Completed = true });
-
-        var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
-
-        Assert.True(matches);
-    }
-
-    [Theory]
-    [InlineData(Status.NotStarted)]
-    [InlineData(Status.InProgress)]
-    public void Should_Not_Match_AnyOtherStatus(Status status)
-    {
-        var processor = Substitute.For<ISubmissionStatusProcessor>();
-        processor.Section.Returns(new Section() { });
-        processor.SectionStatus.Returns(new SectionStatusNew() { Status = status, Completed = false });
-
-        var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
-
-        Assert.False(matches);
-    }
-
-    [Fact]
-    public async Task Should_Set_SubmissionStatus_And_FirstQuestion()
-    {
-        var section = new Section()
-        {
-            Questions = new()
+      Questions = new()
           {
         new Question(){
           Slug = "question-one"
@@ -51,13 +51,13 @@ public class SectionCompleteStatusCheckerTests
           Slug = "question-two"
         }
           }
-        };
-        var processor = Substitute.For<ISubmissionStatusProcessor>();
-        processor.Section.Returns(section);
-        processor.SectionStatus.Returns(new SectionStatusNew() { Status = Status.Completed, Completed = true });
+    };
+    var processor = Substitute.For<ISubmissionStatusProcessor>();
+    processor.Section.Returns(section);
+    processor.SectionStatus.Returns(new SectionStatus() { Status = Status.Completed, Completed = true });
 
-        await StatusChecker.ProcessSubmission(processor, default);
-        Assert.Equal(SubmissionStatus.Completed, processor.Status);
-        Assert.Equal(section.Questions.First(), processor.NextQuestion);
-    }
+    await StatusChecker.ProcessSubmission(processor, default);
+    Assert.Equal(SubmissionStatus.Completed, processor.Status);
+    Assert.Equal(section.Questions.First(), processor.NextQuestion);
+  }
 }

--- a/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/SectionCompleteStatusCheckerTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/SectionCompleteStatusCheckerTests.cs
@@ -9,40 +9,40 @@ namespace Dfe.PlanTech.Application.UnitTests.Submissions.Queries;
 
 public class SectionCompleteStatusCheckerTests
 {
-  public readonly ISubmissionStatusChecker StatusChecker = SectionCompleteStatusChecker.SectionComplete;
+    public readonly ISubmissionStatusChecker StatusChecker = SectionCompleteStatusChecker.SectionComplete;
 
-  [Fact]
-  public void Should_Match_Completed_Status()
-  {
-    var processor = Substitute.For<ISubmissionStatusProcessor>();
-    processor.Section.Returns(new Section() { });
-    processor.SectionStatus.Returns(new SectionStatus() { Status = Status.Completed, Completed = true });
-
-    var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
-
-    Assert.True(matches);
-  }
-
-  [Theory]
-  [InlineData(Status.NotStarted)]
-  [InlineData(Status.InProgress)]
-  public void Should_Not_Match_AnyOtherStatus(Status status)
-  {
-    var processor = Substitute.For<ISubmissionStatusProcessor>();
-    processor.Section.Returns(new Section() { });
-    processor.SectionStatus.Returns(new SectionStatus() { Status = status, Completed = false });
-
-    var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
-
-    Assert.False(matches);
-  }
-
-  [Fact]
-  public async Task Should_Set_SubmissionStatus_And_FirstQuestion()
-  {
-    var section = new Section()
+    [Fact]
+    public void Should_Match_Completed_Status()
     {
-      Questions = new()
+        var processor = Substitute.For<ISubmissionStatusProcessor>();
+        processor.Section.Returns(new Section() { });
+        processor.SectionStatus.Returns(new SectionStatus() { Status = Status.Completed, Completed = true });
+
+        var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
+
+        Assert.True(matches);
+    }
+
+    [Theory]
+    [InlineData(Status.NotStarted)]
+    [InlineData(Status.InProgress)]
+    public void Should_Not_Match_AnyOtherStatus(Status status)
+    {
+        var processor = Substitute.For<ISubmissionStatusProcessor>();
+        processor.Section.Returns(new Section() { });
+        processor.SectionStatus.Returns(new SectionStatus() { Status = status, Completed = false });
+
+        var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
+
+        Assert.False(matches);
+    }
+
+    [Fact]
+    public async Task Should_Set_SubmissionStatus_And_FirstQuestion()
+    {
+        var section = new Section()
+        {
+            Questions = new()
           {
         new Question(){
           Slug = "question-one"
@@ -51,13 +51,13 @@ public class SectionCompleteStatusCheckerTests
           Slug = "question-two"
         }
           }
-    };
-    var processor = Substitute.For<ISubmissionStatusProcessor>();
-    processor.Section.Returns(section);
-    processor.SectionStatus.Returns(new SectionStatus() { Status = Status.Completed, Completed = true });
+        };
+        var processor = Substitute.For<ISubmissionStatusProcessor>();
+        processor.Section.Returns(section);
+        processor.SectionStatus.Returns(new SectionStatus() { Status = Status.Completed, Completed = true });
 
-    await StatusChecker.ProcessSubmission(processor, default);
-    Assert.Equal(SubmissionStatus.Completed, processor.Status);
-    Assert.Equal(section.Questions.First(), processor.NextQuestion);
-  }
+        await StatusChecker.ProcessSubmission(processor, default);
+        Assert.Equal(SubmissionStatus.Completed, processor.Status);
+        Assert.Equal(section.Questions.First(), processor.NextQuestion);
+    }
 }

--- a/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/SectionNotStartedStatusCheckerTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/SectionNotStartedStatusCheckerTests.cs
@@ -9,40 +9,40 @@ namespace Dfe.PlanTech.Application.UnitTests.Submissions.Queries;
 
 public class SectionNotStartedStatusCheckerTests
 {
-  public readonly ISubmissionStatusChecker StatusChecker = SectionNotStartedStatusChecker.SectionNotStarted;
+    public readonly ISubmissionStatusChecker StatusChecker = SectionNotStartedStatusChecker.SectionNotStarted;
 
-  [Fact]
-  public void Should_Match_NotStarted_Status()
-  {
-    var processor = Substitute.For<ISubmissionStatusProcessor>();
-    processor.Section.Returns(new Section() { });
-    processor.SectionStatus.Returns(new SectionStatus() { Status = Status.NotStarted, Completed = false });
-
-    var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
-
-    Assert.True(matches);
-  }
-
-  [Theory]
-  [InlineData(Status.InProgress)]
-  [InlineData(Status.Completed)]
-  public void Should_Not_Match_AnyOtherStatus(Status status)
-  {
-    var processor = Substitute.For<ISubmissionStatusProcessor>();
-    processor.Section.Returns(new Section() { });
-    processor.SectionStatus.Returns(new SectionStatus() { Status = status, Completed = status == Status.Completed });
-
-    var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
-
-    Assert.False(matches);
-  }
-
-  [Fact]
-  public async Task Should_Set_SubmissionStatus_And_FirstQuestion()
-  {
-    var section = new Section()
+    [Fact]
+    public void Should_Match_NotStarted_Status()
     {
-      Questions = new()
+        var processor = Substitute.For<ISubmissionStatusProcessor>();
+        processor.Section.Returns(new Section() { });
+        processor.SectionStatus.Returns(new SectionStatus() { Status = Status.NotStarted, Completed = false });
+
+        var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
+
+        Assert.True(matches);
+    }
+
+    [Theory]
+    [InlineData(Status.InProgress)]
+    [InlineData(Status.Completed)]
+    public void Should_Not_Match_AnyOtherStatus(Status status)
+    {
+        var processor = Substitute.For<ISubmissionStatusProcessor>();
+        processor.Section.Returns(new Section() { });
+        processor.SectionStatus.Returns(new SectionStatus() { Status = status, Completed = status == Status.Completed });
+
+        var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
+
+        Assert.False(matches);
+    }
+
+    [Fact]
+    public async Task Should_Set_SubmissionStatus_And_FirstQuestion()
+    {
+        var section = new Section()
+        {
+            Questions = new()
           {
         new Question(){
           Slug = "question-one"
@@ -51,13 +51,13 @@ public class SectionNotStartedStatusCheckerTests
           Slug = "question-two"
         }
           }
-    };
-    var processor = Substitute.For<ISubmissionStatusProcessor>();
-    processor.Section.Returns(section);
-    processor.SectionStatus.Returns(new SectionStatus() { Status = Status.NotStarted, Completed = false });
+        };
+        var processor = Substitute.For<ISubmissionStatusProcessor>();
+        processor.Section.Returns(section);
+        processor.SectionStatus.Returns(new SectionStatus() { Status = Status.NotStarted, Completed = false });
 
-    await StatusChecker.ProcessSubmission(processor, default);
-    Assert.Equal(SubmissionStatus.NotStarted, processor.Status);
-    Assert.Equal(section.Questions.First(), processor.NextQuestion);
-  }
+        await StatusChecker.ProcessSubmission(processor, default);
+        Assert.Equal(SubmissionStatus.NotStarted, processor.Status);
+        Assert.Equal(section.Questions.First(), processor.NextQuestion);
+    }
 }

--- a/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/SectionNotStartedStatusCheckerTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/SectionNotStartedStatusCheckerTests.cs
@@ -9,40 +9,40 @@ namespace Dfe.PlanTech.Application.UnitTests.Submissions.Queries;
 
 public class SectionNotStartedStatusCheckerTests
 {
-    public readonly ISubmissionStatusChecker StatusChecker = SectionNotStartedStatusChecker.SectionNotStarted;
+  public readonly ISubmissionStatusChecker StatusChecker = SectionNotStartedStatusChecker.SectionNotStarted;
 
-    [Fact]
-    public void Should_Match_NotStarted_Status()
+  [Fact]
+  public void Should_Match_NotStarted_Status()
+  {
+    var processor = Substitute.For<ISubmissionStatusProcessor>();
+    processor.Section.Returns(new Section() { });
+    processor.SectionStatus.Returns(new SectionStatus() { Status = Status.NotStarted, Completed = false });
+
+    var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
+
+    Assert.True(matches);
+  }
+
+  [Theory]
+  [InlineData(Status.InProgress)]
+  [InlineData(Status.Completed)]
+  public void Should_Not_Match_AnyOtherStatus(Status status)
+  {
+    var processor = Substitute.For<ISubmissionStatusProcessor>();
+    processor.Section.Returns(new Section() { });
+    processor.SectionStatus.Returns(new SectionStatus() { Status = status, Completed = status == Status.Completed });
+
+    var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
+
+    Assert.False(matches);
+  }
+
+  [Fact]
+  public async Task Should_Set_SubmissionStatus_And_FirstQuestion()
+  {
+    var section = new Section()
     {
-        var processor = Substitute.For<ISubmissionStatusProcessor>();
-        processor.Section.Returns(new Section() { });
-        processor.SectionStatus.Returns(new SectionStatusNew() { Status = Status.NotStarted, Completed = false });
-
-        var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
-
-        Assert.True(matches);
-    }
-
-    [Theory]
-    [InlineData(Status.InProgress)]
-    [InlineData(Status.Completed)]
-    public void Should_Not_Match_AnyOtherStatus(Status status)
-    {
-        var processor = Substitute.For<ISubmissionStatusProcessor>();
-        processor.Section.Returns(new Section() { });
-        processor.SectionStatus.Returns(new SectionStatusNew() { Status = status, Completed = status == Status.Completed });
-
-        var matches = StatusChecker.IsMatchingSubmissionStatus(processor);
-
-        Assert.False(matches);
-    }
-
-    [Fact]
-    public async Task Should_Set_SubmissionStatus_And_FirstQuestion()
-    {
-        var section = new Section()
-        {
-            Questions = new()
+      Questions = new()
           {
         new Question(){
           Slug = "question-one"
@@ -51,13 +51,13 @@ public class SectionNotStartedStatusCheckerTests
           Slug = "question-two"
         }
           }
-        };
-        var processor = Substitute.For<ISubmissionStatusProcessor>();
-        processor.Section.Returns(section);
-        processor.SectionStatus.Returns(new SectionStatusNew() { Status = Status.NotStarted, Completed = false });
+    };
+    var processor = Substitute.For<ISubmissionStatusProcessor>();
+    processor.Section.Returns(section);
+    processor.SectionStatus.Returns(new SectionStatus() { Status = Status.NotStarted, Completed = false });
 
-        await StatusChecker.ProcessSubmission(processor, default);
-        Assert.Equal(SubmissionStatus.NotStarted, processor.Status);
-        Assert.Equal(section.Questions.First(), processor.NextQuestion);
-    }
+    await StatusChecker.ProcessSubmission(processor, default);
+    Assert.Equal(SubmissionStatus.NotStarted, processor.Status);
+    Assert.Equal(section.Questions.First(), processor.NextQuestion);
+  }
 }

--- a/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/SubmissionStatusProcessorTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/SubmissionStatusProcessorTests.cs
@@ -77,7 +77,7 @@ public class SubmissionStatusProcessorTests
                                                                              _user);
 
         _getSubmissionStatusesQuery.GetSectionSubmissionStatusAsync(Arg.Any<int>(), Arg.Any<Section>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
-                                   .Returns(new SectionStatusNew());
+                                   .Returns(new SectionStatus());
 
         await processor.GetJourneyStatusForSection(SectionSlug, default);
 
@@ -102,7 +102,7 @@ public class SubmissionStatusProcessorTests
                                                                              _user);
 
         _getSubmissionStatusesQuery.GetSectionSubmissionStatusAsync(Arg.Any<int>(), Arg.Any<Section>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
-                                   .Returns(new SectionStatusNew());
+                                   .Returns(new SectionStatus());
 
         await Assert.ThrowsAnyAsync<InvalidDataException>(() => processor.GetJourneyStatusForSection(SectionSlug, default));
     }

--- a/tests/Dfe.PlanTech.Web.UnitTests/Routing/GetRecommendationRouterTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Routing/GetRecommendationRouterTests.cs
@@ -386,7 +386,7 @@ public class GetRecommendationRouterTests
             .Do((callinfo) =>
             {
                 _submissionStatusProcessor.Status = SubmissionStatus.Completed;
-                _submissionStatusProcessor.SectionStatus.Returns(new SectionStatusNew()
+                _submissionStatusProcessor.SectionStatus.Returns(new SectionStatus()
                 {
                     Maturity = null
                 });
@@ -406,7 +406,7 @@ public class GetRecommendationRouterTests
             {
                 _submissionStatusProcessor.Status = SubmissionStatus.Completed;
                 _submissionStatusProcessor.Section.Returns(_section);
-                _submissionStatusProcessor.SectionStatus.Returns(new SectionStatusNew()
+                _submissionStatusProcessor.SectionStatus.Returns(new SectionStatus()
                 {
                     Maturity = "High"
                 });
@@ -430,7 +430,7 @@ public class GetRecommendationRouterTests
             {
                 _submissionStatusProcessor.Status = SubmissionStatus.Completed;
                 _submissionStatusProcessor.Section.Returns(_section);
-                _submissionStatusProcessor.SectionStatus.Returns(new SectionStatusNew()
+                _submissionStatusProcessor.SectionStatus.Returns(new SectionStatus()
                 {
                     Maturity = "not a real maturity"
                 });
@@ -589,7 +589,7 @@ public class GetRecommendationRouterTests
             {
                 _submissionStatusProcessor.Status = SubmissionStatus.Completed;
                 _submissionStatusProcessor.Section.Returns(_section);
-                _submissionStatusProcessor.SectionStatus.Returns(new SectionStatusNew()
+                _submissionStatusProcessor.SectionStatus.Returns(new SectionStatus()
                 {
                     Maturity = "High"
                 });


### PR DESCRIPTION
## Overview

Renames `SectionStatusNew` to `SectionStatus`.

`SectionStatusNew` was named as such whilst it was being used at the _same time_ as `SectionStatus`.

The original `SectionStatus` class has gone. The `New` can now be renamed to what it should be. Rejoice.

## Changes

### Minor

- Renames `SectionStatusNew` to `SectionStatus`.


## How to review the PR

- Run the tests
- Poke around on the app
- Everything good?
## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [x] Unit tests have been added/updated
- [x] E2E tests have been added/updated