### PR TITLE
fix: Ignore subtopic name when retrieving submission

### DIFF
--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240827_1056_CreateGetCurrentSubmissionIdProcedure.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240827_1056_CreateGetCurrentSubmissionIdProcedure.sql
@@ -1,0 +1,15 @@
+CREATE OR ALTER PROCEDURE GetCurrentSubmissionId
+    @sectionId NVARCHAR(50),
+    @establishmentId INT,
+    @submissionId INT OUTPUT
+AS
+
+SELECT @submissionId = (
+    SELECT TOP 1 Id
+    FROM [dbo].[submission]
+    WHERE completed = 0
+        AND deleted = 0
+        AND sectionId = @sectionId
+        AND establishmentId = @establishmentId
+    ORDER BY dateCreated DESC
+)

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240827_1058_UpdateSelectOrInsertSubmissionIdProcedure.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240827_1058_UpdateSelectOrInsertSubmissionIdProcedure.sql
@@ -1,0 +1,29 @@
+ALTER PROCEDURE SelectOrInsertSubmissionId
+    @sectionId NVARCHAR(50),
+    @sectionName NVARCHAR(50),
+    @establishmentId INT,
+    @submissionId INT OUTPUT
+AS
+
+BEGIN TRY
+    BEGIN TRAN
+        EXEC GetCurrentSubmissionId
+            @sectionid=@sectionId,
+            @establishmentId=@establishmentId,
+            @submissionId=@submissionId OUTPUT
+
+        IF @submissionId IS NULL
+            BEGIN
+                INSERT INTO [dbo].[submission]
+                    (establishmentId, completed, sectionId, sectionName)
+                OUTPUT INSERTED.ID
+                VALUES
+                    (@establishmentId, 0, @sectionId, @sectionName)
+
+                SELECT @submissionId = SCOPE_IDENTITY()
+            END
+    COMMIT TRAN
+END TRY
+BEGIN CATCH
+    ROLLBACK TRAN
+END CATCH

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240827_1102_UpdateDeleteCurrentSubmissionProcedure.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240827_1102_UpdateDeleteCurrentSubmissionProcedure.sql
@@ -1,0 +1,25 @@
+CREATE OR ALTER PROCEDURE DeleteCurrentSubmission
+    @sectionId NVARCHAR(50),
+    @sectionName NVARCHAR(50),
+    @establishmentId INT
+AS
+    BEGIN TRY
+        DECLARE @submissionId INT
+
+        EXEC GetCurrentSubmissionId
+            @sectionid=@sectionId,
+            @establishmentId=@establishmentId,
+            @submissionId=@submissionId OUTPUT
+
+        BEGIN TRAN
+            UPDATE S
+            SET deleted = 1
+            FROM [dbo].[submission] S
+            WHERE S.id = @submissionId
+        COMMIT TRAN
+        
+    END TRY
+    BEGIN CATCH
+        ROLLBACK TRAN
+    END CATCH
+GO


### PR DESCRIPTION
## Overview

Addresses ticket #225614

If a subtopic name changes, and a user is mid-way through a journey on that subtopic, their journey will be broken. Submitting any answer will cause them to be redirected back to the self-assessment page with an error message.

This is caused by:
1. When creating, soft-deleting, or submitting a new response for a submission, we check that the `sectionName` matches
2. When retrieving the current submission responses _from the web app_ to validate the user's journey, we _do not_ check that the `sectionName` matches

There were 2 possible fixes for this:
1. Remove the `sectionName` comparison from 1
2. Or add a `sectionName` comparison to 2

I chose 1 given that IMO there's no good reason for the sectionName to be matched (as it doesn't affect the journey, or the user), and by adding it to 2 we would _force a user to restart that subtopic if the name changes part way through, even though no content/questions/answers have changed otherwise_.

## Changes

### Minor

- Remove comparison of `sectionName` when looking for a `submission`. Now only compare `establishmentId` and `sectionId`
- Creates a new procedure (`GetCurrentSubmissionId`) for retrieving the ID for the current submission. Prevents having to change the query in multiple places, and keeps it consistent.

## How to review the PR

### Recreating bug

1. Go to dev/test
4. Answer one or more questions for a subtopic. Don't get to check answers page.
5. Change the _name_ of a subtopic. E.g. change `Back-up broadband` to `Backup broadband`.
6. Go back to the self-assessment page, and F5 until the changed subtopic name shows
7. Go to the next question in the subtopic, try submitting an answer

You should be redirected to the self-assessment page, with an error message.

### Testing fix

1. Execute the 3 new SQL scripts against the same environment from the recreating bug part
    - [20240827_1056_CreateGetCurrentSubmissionIdProcedure.sql](src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240827_1056_CreateGetCurrentSubmissionIdProcedure.sql)
    - [20240827_1058_UpdateSelectOrInsertSubmissionIdProcedure.sql](src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240827_1058_UpdateSelectOrInsertSubmissionIdProcedure.sql)
    - [20240827_1102_UpdateDeleteCurrentSubmissionProcedure.sql](src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240827_1102_UpdateDeleteCurrentSubmissionProcedure.sql)
4. Repeat the bug recreation steps 1-5
5. The answer should be submitted successfully, and you should be directed to the next question for the subtopic journey.

Once the fix has been tested, please revert the SQL back to how it was for someone else to test. This can be done by executing these 2 SQL scripts:
- [20240524_1635_CreateDeleteCurrentSubmissionProcedure.sql](src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240524_1635_CreateDeleteCurrentSubmissionProcedure.sql)
- [20240524_1715_UpdateSelectOrInsertSubmissionIdProcedure.sql](src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240524_1715_UpdateSelectOrInsertSubmissionIdProcedure.sql)

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
