### PR TITLE
fix: Add ID to support links header

### DIFF
--- a/src/Dfe.PlanTech.Web/Views/Shared/_Footer.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/_Footer.cshtml
@@ -2,7 +2,7 @@
     <div class="govuk-width-container ">
         <div class="govuk-footer__meta">
             <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-                <h2 class="govuk-visually-hidden">Support links</h2>
+                <h2 class="govuk-visually-hidden" id="support-links">Support links</h2>
                     @await Component.InvokeAsync("FooterLinks")
                 <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo"
                     xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">


### PR DESCRIPTION
## Overview

Adds an ID to the heading "support-links" in the footer.

This is being removed by changes in C&S, as the C&S layout is using our `_Footer` partial view due to the names matching.

## Changes

### Minor

- Adds ID to the "Support Links" heading in the footer to prevent it being made visible

## Checklist

Delete any rows that do not apply to the PR.

- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch