### PR TITLE
fix: Correct authorisation checking for non-page controller routes

### DIFF
--- a/src/Dfe.PlanTech.Web/Authorisation/PageAuthorisationRequirement.cs
+++ b/src/Dfe.PlanTech.Web/Authorisation/PageAuthorisationRequirement.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace Dfe.PlanTech.Web.Authorisation;
+
+public class PageAuthorisationRequirement : IAuthorizationRequirement
+{
+    public PageAuthorisationRequirement()
+    {
+
+    }
+}

--- a/src/Dfe.PlanTech.Web/Authorisation/PageModelAuthorisationPolicy.cs
+++ b/src/Dfe.PlanTech.Web/Authorisation/PageModelAuthorisationPolicy.cs
@@ -6,30 +6,25 @@ using Microsoft.AspNetCore.Authorization;
 namespace Dfe.PlanTech.Web.Authorisation;
 
 /// <summary>
-/// Retrieves a given <see cref="Page"/> from Contentful, and authorises the user based off that
+/// Checks user authorisation for the current page, and retrieves a given <see cref="Page"/> from Contentful if needed for the request.
 /// </summary>
 public class PageModelAuthorisationPolicy(ILogger<PageModelAuthorisationPolicy> logger) : AuthorizationHandler<PageAuthorisationRequirement>
 {
-    public const string PolicyName = "UsePageAuthentication";
-    public const string RoutesValuesRouteNameKey = "route";
-    public const string RouteValuesControllerNameKey = "controller";
     private const string IndexSlug = "/";
-    private readonly ILogger<PageModelAuthorisationPolicy> _logger;
-
-    public PageModelAuthorisationPolicy(ILogger<PageModelAuthorisationPolicy> logger)
-    {
-        _logger = logger;
-    }
+    public const string PolicyName = "UsePageAuthentication";
+    public const string RouteValuesActionNameKey = "action";
+    public const string RouteValuesControllerNameKey = "controller";
+    public const string RoutesValuesRouteNameKey = "route";
 
     protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, PageAuthorisationRequirement requirement)
     {
         if (context.Resource is not HttpContext httpContext)
         {
-            _logger.LogError("Expected resource to be HttpContext but received {type}", context.Resource?.GetType());
+            logger.LogError("Expected resource to be HttpContext but received {type}", context.Resource?.GetType());
             return;
         }
 
-        bool success = await ProcessPage(httpContext);
+        var success = await UserAuthenticationMatchesRouteRequirements(httpContext);
 
         if (success)
         {
@@ -41,7 +36,22 @@ public class PageModelAuthorisationPolicy(ILogger<PageModelAuthorisationPolicy> 
         }
     }
 
-    private static async Task<bool> ProcessPage(HttpContext httpContext)
+    /// <summary>
+    /// Checks whether the user's authentication matches the requirements for the route
+    /// </summary>
+    /// <remarks>
+    /// Process:
+    /// 1. Is the request to the PagesController?
+    ///    - If not, return whether they are authenticated or not
+    /// 2. If it is the pages controller, retrieve the relevant page for the request from DB/Contentful
+    /// 3. Return whether the user's authentication status matches the page's authentication requirements
+    ///    - Page does not require authentication? Then return true
+    ///    - Page requires authentication? Return whether the user is authenticated or not
+    /// </remarks>
+    /// <param name="httpContext"></param>
+    /// <returns></returns>
+    /// <exception cref="KeyNotFoundException"></exception>
+    private async Task<bool> UserAuthenticationMatchesRouteRequirements(HttpContext httpContext)
     {
         string? slug = GetRequestRoute(httpContext);
 
@@ -53,43 +63,76 @@ public class PageModelAuthorisationPolicy(ILogger<PageModelAuthorisationPolicy> 
         using var scope = httpContext.RequestServices.CreateAsyncScope();
         var pageQuery = scope.ServiceProvider.GetRequiredService<IGetPageQuery>();
 
-        Page page = await GetPageForSlug(httpContext, slug, pageQuery) ?? throw new KeyNotFoundException($"Could not find page for {slug}");
-
-        httpContext.Items.Add(nameof(Page), page);
+        Page page = await GetPageForSlug(httpContext, slug, pageQuery);
 
         return !page.RequiresAuthorisation || UserIsAuthenticated(httpContext);
     }
 
+    /// <summary>
+    /// Retrieves the relevant page from Contentful/DB, and adds it to the HttpContext.
+    /// </summary>
+    /// <remarks>
+    /// The page ias added to the HttpContext for use in the <see cref="PageModelBinder"/>, 
+    /// to prevent the page being loaded multiple times for a single request
+    /// </remarks>
     private static async Task<Page> GetPageForSlug(HttpContext httpContext, string slug, IGetPageQuery pageQuery)
-    => await pageQuery.GetPageBySlug(slug, httpContext.RequestAborted) ?? throw new KeyNotFoundException($"Could not find page with slug {slug}");
+    {
+        var page = await pageQuery.GetPageBySlug(slug, httpContext.RequestAborted) ?? throw new KeyNotFoundException($"Could not find page with slug {slug}");
+        httpContext.Items.Add(nameof(Page), page);
+
+        return page;
+    }
 
     private static bool UserIsAuthenticated(HttpContext httpContext) => httpContext.User.Identity?.IsAuthenticated == true;
 
-    private static string? GetRequestRoute(HttpContext httpContext)
+    /// <summary>
+    /// Gets the slug from the route if on the pages controller, or null if not.
+    /// </summary>
+    /// <param name="httpContext"></param>
+    /// <returns></returns>
+    private string? GetRequestRoute(HttpContext httpContext)
     {
-        var controllerName = httpContext.Request.RouteValues[RouteValuesControllerNameKey];
-        if (controllerName == null || controllerName is not string controllerString || controllerString != PagesController.ControllerName)
+        if (!ControllerIsPagesController(httpContext))
         {
+            logger.LogTrace("Request is not from/to the Pages controller. Request is to controller {ControllerName} and action {ActioName}",
+                            httpContext.Request.RouteValues[RouteValuesControllerNameKey],
+                            httpContext.Request.RouteValues[RouteValuesActionNameKey]);
+
             return null;
         }
 
+        return GetSlugFromRoute(httpContext);
+    }
+
+    /// <summary>
+    /// Gets the slug of the page from the request route values, or the index page slug if none is found
+    /// </summary>
+    /// <param name="httpContext"></param>
+    /// <returns></returns>
+    private string GetSlugFromRoute(HttpContext httpContext)
+    {
         var slug = httpContext.Request.RouteValues[RoutesValuesRouteNameKey];
 
         if (slug is not string slugString)
         {
+            logger.LogTrace("Route is null - request is to index page");
             httpContext.Request.RouteValues[RoutesValuesRouteNameKey] = IndexSlug;
             return IndexSlug;
         }
 
+        logger.LogTrace("Route slug for request is {Slug}", slug);
         return slugString;
     }
-}
 
-
-public class PageAuthorisationRequirement : IAuthorizationRequirement
-{
-    public PageAuthorisationRequirement()
+    /// <summary>
+    /// Checks whether the request is from the PagesController
+    /// </summary>
+    /// <param name="httpContext"></param>
+    /// <returns></returns>
+    private static bool ControllerIsPagesController(HttpContext httpContext)
     {
+        var controllerName = httpContext.Request.RouteValues[RouteValuesControllerNameKey];
 
+        return controllerName is string controllerString && controllerString == PagesController.ControllerName;
     }
 }

--- a/src/Dfe.PlanTech.Web/Controllers/PagesController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/PagesController.cs
@@ -22,7 +22,7 @@ public class PagesController : BaseController<PagesController>
     {
     }
 
-    [Authorize(Policy = PageModelAuthorisationPolicy.POLICY_NAME)]
+    [Authorize(Policy = PageModelAuthorisationPolicy.PolicyName)]
     [HttpGet("{route?}", Name = "GetPage")]
     public IActionResult GetByRoute([ModelBinder(typeof(PageModelBinder))] Page page, [FromServices] IUser user)
     {

--- a/src/Dfe.PlanTech.Web/Program.cs
+++ b/src/Dfe.PlanTech.Web/Program.cs
@@ -82,7 +82,7 @@ builder.Services.AddAutoMapper(typeof(Dfe.PlanTech.Application.Mappings.CmsMappi
 
 builder.Services.AddAuthentication();
 builder.Services.AddAuthorizationBuilder()
-                .AddDefaultPolicy(PageModelAuthorisationPolicy.POLICY_NAME, policy =>
+                .AddDefaultPolicy(PageModelAuthorisationPolicy.PolicyName, policy =>
                 {
                     policy.Requirements.Add(new PageAuthorisationRequirement());
                 });

--- a/tests/Dfe.PlanTech.Web.UnitTests/Authorisation/PageModelAuthorisationPolicyTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Authorisation/PageModelAuthorisationPolicyTests.cs
@@ -41,7 +41,7 @@ public class PageModelAuthorisationPolicyTests
         serviceProvider.GetService(typeof(IGetPageQuery)).Returns(_getPageQuery);
 
         _httpContext.Request.RouteValues = new RouteValueDictionary();
-        _httpContext.Request.RouteValues[PageModelAuthorisationPolicy.ROUTE_NAME] = "/slug";
+        _httpContext.Request.RouteValues[PageModelAuthorisationPolicy.RoutesValuesRouteNameKey] = "/slug";
 
         _httpContext.Items = new Dictionary<object, object?>();
 
@@ -133,11 +133,11 @@ public class PageModelAuthorisationPolicyTests
             RequiresAuthorisation = true
         });
 
-        _httpContext.Request.RouteValues.Remove(PageModelAuthorisationPolicy.ROUTE_NAME);
+        _httpContext.Request.RouteValues.Remove(PageModelAuthorisationPolicy.RoutesValuesRouteNameKey);
 
         await _policy.HandleAsync(_authContext);
 
-        Assert.True(_httpContext.Request.RouteValues.ContainsKey(PageModelAuthorisationPolicy.ROUTE_NAME));
-        Assert.Equal("/", _httpContext.Request.RouteValues[PageModelAuthorisationPolicy.ROUTE_NAME]);
+        Assert.True(_httpContext.Request.RouteValues.ContainsKey(PageModelAuthorisationPolicy.RoutesValuesRouteNameKey));
+        Assert.Equal("/", _httpContext.Request.RouteValues[PageModelAuthorisationPolicy.RoutesValuesRouteNameKey]);
     }
 }


### PR DESCRIPTION
## Overview

Addresses ticket 224797

The current authorisation implementation is not _quite right_.

When a user visits a page that _requires authorisation_ but is not a "page" content type (i.e. a question page, check answers page, or a recommendations page), they currently receive an error message about no organisation.

They should _instead_ be redirected to the DFE Sign In login page.

This PR fixes the above.

## Changes

### Minor

- Amend authorisation to handle non-"page" authentication better.

## How to review the PR

1. Run the web app
2. Make sure you are not logged in. Log out if necessary.
3. Try to visit a page (via URL) that requires authorisation and is _not_ loaded from the page controller
    - I.e. a question page, check answers page, or recommendations page
4. You should be redirected to the DFE Sign In page.

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [x] Unit tests have been added/updated