### PR TITLE
fix: Turn off multilanguage support to stop incorrect coverage

### DIFF
--- a/.github/workflows/code-pr-check.yml
+++ b/.github/workflows/code-pr-check.yml
@@ -110,7 +110,8 @@ jobs:
           /d:sonar.coverage.exclusions=**/Program.cs,**/gulpfile.js,**/wwwroot/**,**/contentandsupport/**,**/Dfe.PlanTech.Web.SeedTestData/** \
           /d:sonar.issue.ignore.multicriteria=e1 \
           /d:sonar.issue.ignore.multicriteria.e1.ruleKey=csharpsquid:S6602 \
-          /d:sonar.issue.ignore.multicriteria.e1.resourceKey=src/**/*.cs
+          /d:sonar.issue.ignore.multicriteria.e1.resourceKey=src/**/*.cs \
+          /d:sonar.scanner.scanAll=false
 
       - name: Build web app
         uses: ./.github/actions/build-dotnet-app


### PR DESCRIPTION
## Overview

An update to sonar cloud scanner results in it now including multiple languages by default, so its picking up all our e2e tests and other file types during coverage checks and failing to hit the required percentage. This turns it off as per the guidance here so we can continue reporting coverage for the C# code only 

https://docs.sonarsource.com/sonarqube/9.9/analyzing-source-code/scanners/sonarscanner-for-dotnet/#known-issues

## Changes

### Minor

- Update code PR check pipeline to disable multiple language support

## How to review the PR

See https://github.com/DFE-Digital/sts-plan-technology-for-your-school/pull/756 for this working
Once merged we should check that the coverage on development goes back to the expected amount

## Checklist

- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch
- [ ] GitHub workflows/actions have been added/updated
