### PR TITLE
Fix: Azure function setting defaults after entity update

### DIFF
--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/EntityUpdater.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/EntityUpdater.cs
@@ -28,10 +28,10 @@ public class EntityUpdater(ILogger<EntityUpdater> logger, CmsDbContext db)
             CmsEvent = cmsEvent
         };
 
-        mappedEntity.UpdateEntity();
+        mappedEntity.UpdateEntity(Db);
         await postUpdateEntityCallback(mappedEntity);
 
-        if (!mappedEntity.IsValidComponent(Db, _logger) || mappedEntity.IsMinimalPayloadEvent)
+        if (!mappedEntity.IsValidComponent(_logger) || mappedEntity.IsMinimalPayloadEvent)
         {
             return mappedEntity;
         }

--- a/src/Dfe.PlanTech.AzureFunctions/Models/MappedEntity.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Models/MappedEntity.cs
@@ -33,7 +33,7 @@ public class MappedEntity
     /// <param name="dontCopyAttribute">The attribute to exclude from the validation.</param>
     /// <param name="logger">The logger instance.</param>
     /// <returns>True if the entity is valid, false otherwise.</returns>
-    public bool IsValidComponent(CmsDbContext db, ILogger logger)
+    public bool IsValidComponent(ILogger logger)
     {
         if (IsMinimalPayloadEvent)
         {
@@ -41,19 +41,19 @@ public class MappedEntity
             return true;
         }
 
-        // Set missing required properties on the incoming entity to a default value, excluding ones we don't process
-        IsValid = SetDefaultsOnRequiredProperties(db, _dontCopyValueAttribute);
-
-        // Log a message if the entity is not valid.
         if (!IsValid)
             logger.LogWarning("Content Component with ID {Id} has required properties that could not be set to a default value", IncomingEntity.Id);
 
         return IsValid;
     }
 
-    public void UpdateEntity()
+    /// <summary>
+    /// Sets defaults on the incoming entity before properties are copied to the existing one
+    /// </summary>
+    public void UpdateEntity(CmsDbContext db)
     {
         UpdateEntityStatus();
+        IsValid = SetDefaultsOnRequiredProperties(db, _dontCopyValueAttribute);
 
         if (ShouldCopyProperties)
         {

--- a/tests/Dfe.PlanTech.AzureFunctions.E2ETests/Generators/RecommendationChunkGenerator.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.E2ETests/Generators/RecommendationChunkGenerator.cs
@@ -20,8 +20,6 @@ public class RecommendationChunkGenerator : BaseGenerator<RecommendationChunk>
         RuleFor(recommendationChunk => recommendationChunk.Answers, faker => answers.Count > 0 ? AnswerGeneratorHelper.GetEntities(faker, 2, 5) : []);
         RuleFor(recommendationChunk => recommendationChunk.Content, faker => contents.Count > 0 ? ContentComponentGeneratorHelper.GetEntities(faker, 2, 5) : []);
         RuleFor(recommendationChunk => recommendationChunk.Header, faker => headers.Count > 0 ? HeaderGeneratorHelper.GetEntity(faker) : null!);
-        RuleFor(recommendationChunk => recommendationChunk.CSLink.Url, faker => faker.Internet.Url().OrNull());
-        RuleFor(recommendationChunk => recommendationChunk.CSLink.LinkText, faker => faker.Lorem.Sentence().OrNull());
     }
 
     public List<RecommendationChunk> GenerateRecommendationChunksAndSaveToDb(CmsDbContext db, int count)
@@ -40,7 +38,6 @@ public class RecommendationChunkGenerator : BaseGenerator<RecommendationChunk>
         Id = recommendationChunk.Sys.Id,
         Answers = recommendationChunk.Answers.Select(answer => new AnswerDbEntity() { Id = answer.Sys.Id }).ToList(),
         HeaderId = recommendationChunk.Header.Sys.Id,
-        CSLink = recommendationChunk.CSLink,
         Published = true,
         Archived = false,
         Deleted = false,

--- a/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Models/MappedEntityTests.cs
+++ b/tests/Dfe.PlanTech.AzureFunctions.UnitTests/Models/MappedEntityTests.cs
@@ -68,7 +68,8 @@ public class MappedEntityTests
             IncomingEntity = new InvalidMockDbEntity(),
             CmsEvent = CmsEvent.CREATE,
         };
-        Assert.False(mappedEntity.IsValidComponent(_cmsDbContextMock, _logger));
+        mappedEntity.UpdateEntity(_cmsDbContextMock);
+        Assert.False(mappedEntity.IsValidComponent(_logger));
     }
 
     [Fact]
@@ -80,7 +81,8 @@ public class MappedEntityTests
             IncomingEntity = incoming,
             CmsEvent = CmsEvent.CREATE,
         };
-        Assert.True(mappedEntity.IsValidComponent(_cmsDbContextMock, _logger));
+        mappedEntity.UpdateEntity(_cmsDbContextMock);
+        Assert.True(mappedEntity.IsValidComponent(_logger));
         Assert.Equal("", incoming.String);
         Assert.Equal(0, incoming.Int);
         Assert.False(incoming.Bool);


### PR DESCRIPTION
## Overview

Follow on fix for [#220759](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_boards/board/t/Plan%20Tech/Stories/?workitem=220759)

This fixes an issue where the Azure function
1. Has an update with an incomplete bit of content
2. Updates the existing entity with the null fields from the incoming one
3. And _only then_ sets the defaults on the Incoming entity
4. The entity is deemed valid, but might fail to insert into the database due to a null field

The intent for the ticket was to set defaults and then save them, so just needed a small tweak to when the setdefaults method is called

## Changes

### Minor

- Swap the setting of defaults from the validation check to UpdateEntity which is always called first
- Remove some code from the Azure function E2E tests which breaks them (will raise a follow on to fix this properly, the csLinks need their own generators now that they're a separate content type)

## How to review the PR

1. Make a new CSLink 
2. Add nothing to it
3. Check the database in dev, it should have the CSLink
4. Change the link text but *Not* the url
5. Should find it doesn't update (due to the bug)
6. Now run the azure function locally instead and edit the link text
7. Ensure it saves

Azure function should continue functioning as expected for other changes

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [x] Unit tests have been added/updated
- [x] E2E tests have been added/updated
