### PR TITLE
Rollback azure functions worker sdk

### DIFF
--- a/src/Dfe.PlanTech.AzureFunctions/Dfe.PlanTech.AzureFunctions.csproj
+++ b/src/Dfe.PlanTech.AzureFunctions/Dfe.PlanTech.AzureFunctions.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.21.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.17.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />


### PR DESCRIPTION
Based off reported issues online about SDK version 1.17.4 - rollback to the previously known working version 1.17.2