### PR TITLE
fix: Include the hidden function dependencies

### DIFF
--- a/.github/workflows/build-azure-function.yml
+++ b/.github/workflows/build-azure-function.yml
@@ -43,3 +43,4 @@ jobs:
         with:
           name: ${{ inputs.artifact }}
           path: ./build
+          include-hidden-files: true


### PR DESCRIPTION
## Overview

Recently, a breaking change has been made in the upload-artifact runners in GitHub Actions 
https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/

This results in them not including hidden files - and consequently not including the `.azurefunction` dependencies we need in our build. This PR is to include them so it goes back to building

## How to review the PR

Best test for this is to merge into dev and just see if it works

## Release requirements

Check we are happy with this approach, there may be a better alternative to including the hidden files, but this will verify that its the issue 

## Checklist

- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch
- [ ] GitHub workflows/actions have been added/updated
