### PR TITLE
Feat: Simplify headers on recommendation chunks

### DIFF
--- a/contentful/content-migrations/.env.example
+++ b/contentful/content-migrations/.env.example
@@ -1,0 +1,4 @@
+MANAGEMENT_TOKEN="Contentful management token"
+DELIVERY_TOKEN="Contentful delivery token for environment"
+SPACE_ID="Contentful space id"
+ENVIRONMENT="PlanTech_DevAndTest"

--- a/contentful/content-migrations/.gitignore
+++ b/contentful/content-migrations/.gitignore
@@ -1,0 +1,2 @@
+#Env variables
+.env

--- a/contentful/content-migrations/README.md
+++ b/contentful/content-migrations/README.md
@@ -1,0 +1,25 @@
+# Scripting Contentful Migrations
+
+Guidance for making modifications to content types and updating entries programatically in contentful
+
+## Setup
+
+1. Setup `.env` (copy `.env.example` and setup fields as necessary)
+2. cd into the `content-migrations` directory
+3. run `npm install`
+
+## Usage
+
+Currently migrations are run manually, there will likely be a follow on piece to run these as part of a pipeline
+
+1. Add your migration script following the convention of `YYYYMMDD-HHMM-description-of-migration.js`
+2. run the migration script
+    ```bash
+    npm run migration YYYYMMDD-HHMM-description-of-migration.js
+    ```
+3. This will show you a plan for the migration about to happen, type `Y/N` to confirm
+
+## References
+
+This follows the guidance in the contentful documentation on [scripting migrations](https://www.contentful.com/developers/docs/tutorials/cli/scripting-migrations/)
+Code examples for various migrations can be found [here](https://github.com/contentful/contentful-migration/tree/main/examples)

--- a/contentful/content-migrations/migrations/20240913-1700-simplify-recommendation-headers.js
+++ b/contentful/content-migrations/migrations/20240913-1700-simplify-recommendation-headers.js
@@ -1,0 +1,34 @@
+module.exports = function (migration, { makeRequest }) {
+    const contentType = 'recommendationChunk'
+    const recommendationChunk = migration.editContentType(contentType)
+
+    // Add new header as a short text field
+    recommendationChunk.createField('newHeader', {
+        name: 'Header',
+        type: 'Symbol',
+        required: true,
+    });
+
+    // Populate new field with text from existing linked header
+    migration.transformEntries({
+        contentType: contentType,
+        from: ["header"],
+        to: ["newHeader"],
+        transformEntryForLocale: async (from, locale) => {
+            const headerId = from.header[locale].sys.id
+            const header = await makeRequest({
+                method: 'GET',
+                url: `/entries/${headerId}`
+            })
+            return {
+                newHeader: header.fields["text"][locale]
+            }
+        }
+    })
+
+    // delete the old header and replace it with the new one
+    recommendationChunk.deleteField("header")
+    recommendationChunk.changeFieldId('newHeader', 'header')
+    recommendationChunk.moveField("header").afterField("internalName")
+    recommendationChunk.resetFieldControl('header');
+}

--- a/contentful/content-migrations/migrations/20240913-1700-simplify-recommendation-headers.js
+++ b/contentful/content-migrations/migrations/20240913-1700-simplify-recommendation-headers.js
@@ -1,11 +1,11 @@
 module.exports = function (migration, { makeRequest }) {
-    const contentType = 'recommendationChunk'
-    const recommendationChunk = migration.editContentType(contentType)
+    const contentType = "recommendationChunk";
+    const recommendationChunk = migration.editContentType(contentType);
 
     // Add new header as a short text field
-    recommendationChunk.createField('newHeader', {
-        name: 'Header',
-        type: 'Symbol',
+    recommendationChunk.createField("newHeader", {
+        name: "Header",
+        type: "Symbol",
         required: true,
     });
 
@@ -15,20 +15,26 @@ module.exports = function (migration, { makeRequest }) {
         from: ["header"],
         to: ["newHeader"],
         transformEntryForLocale: async (from, locale) => {
-            const headerId = from.header[locale].sys.id
-            const header = await makeRequest({
-                method: 'GET',
-                url: `/entries/${headerId}`
-            })
-            return {
-                newHeader: header.fields["text"][locale]
+            if (!from.header) {
+                return { newHeader: null };
             }
-        }
-    })
+            const headerId = from.header[locale].sys.id;
+            const header = await makeRequest({
+                method: "GET",
+                url: `/entries/${headerId}`,
+            });
+            return {
+                newHeader:
+                    header && header.fields["text"]
+                        ? header.fields["text"][locale]
+                        : null,
+            };
+        },
+    });
 
     // delete the old header and replace it with the new one
-    recommendationChunk.deleteField("header")
-    recommendationChunk.changeFieldId('newHeader', 'header')
-    recommendationChunk.moveField("header").afterField("internalName")
-    recommendationChunk.resetFieldControl('header');
-}
+    recommendationChunk.deleteField("header");
+    recommendationChunk.changeFieldId("newHeader", "header");
+    recommendationChunk.moveField("header").afterField("internalName");
+    recommendationChunk.resetFieldControl("header");
+};

--- a/contentful/content-migrations/package-lock.json
+++ b/contentful/content-migrations/package-lock.json
@@ -1,0 +1,1629 @@
+{
+    "name": "content-migrations",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "content-migrations",
+            "version": "1.0.0",
+            "license": "ISC",
+            "dependencies": {
+                "contentful-migration": "^4.23.2"
+            }
+        },
+        "node_modules/@babel/runtime": {
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.6.tgz",
+            "integrity": "sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==",
+            "license": "MIT",
+            "dependencies": {
+                "regenerator-runtime": "^0.14.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@contentful/rich-text-types": {
+            "version": "16.8.4",
+            "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.8.4.tgz",
+            "integrity": "sha512-EZ9438DQS+bU8N39qjT1c3TqadP3F71tXJeMKOqYzQetvpP5U9iHEF1jl5RB+0fWfvI6xHiHsiUOWCqC9bR39A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@hapi/hoek": {
+            "version": "11.0.4",
+            "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
+            "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@hapi/topo": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+            "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@hapi/hoek": "^9.0.0"
+            }
+        },
+        "node_modules/@hapi/topo/node_modules/@hapi/hoek": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+            "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@sideway/address": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+            "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@hapi/hoek": "^9.0.0"
+            }
+        },
+        "node_modules/@sideway/address/node_modules/@hapi/hoek": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+            "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@sideway/formula": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+            "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@sideway/pinpoint": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+            "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/aggregate-error": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+            "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+            "license": "MIT",
+            "dependencies": {
+                "clean-stack": "^2.0.0",
+                "indent-string": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-escapes": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+            "license": "MIT",
+            "dependencies": {
+                "type-fest": "^0.21.3"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/ansicolors": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+            "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
+            "license": "MIT"
+        },
+        "node_modules/astral-regex": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+            "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "license": "MIT"
+        },
+        "node_modules/axios": {
+            "version": "1.7.7",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+            "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+            "license": "MIT",
+            "dependencies": {
+                "follow-redirects": "^1.15.6",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
+            }
+        },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/bl": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+            "license": "MIT",
+            "dependencies": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+            }
+        },
+        "node_modules/bluebird": {
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+            "license": "MIT"
+        },
+        "node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
+        },
+        "node_modules/call-bind": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+            "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
+                "set-function-length": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/callsites": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/camelcase": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/cardinal": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
+            "integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
+            "license": "MIT",
+            "dependencies": {
+                "ansicolors": "~0.3.2",
+                "redeyed": "~2.1.0"
+            },
+            "bin": {
+                "cdl": "bin/cdl.js"
+            }
+        },
+        "node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/chardet": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+            "license": "MIT"
+        },
+        "node_modules/clean-stack": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/cli-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+            "license": "MIT",
+            "dependencies": {
+                "restore-cursor": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cli-spinners": {
+            "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+            "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cli-truncate": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+            "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+            "license": "MIT",
+            "dependencies": {
+                "slice-ansi": "^3.0.0",
+                "string-width": "^4.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cli-width": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+            "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+            "license": "ISC",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/cliui": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+            "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^6.2.0"
+            }
+        },
+        "node_modules/clone": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+            "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "license": "MIT"
+        },
+        "node_modules/colorette": {
+            "version": "2.0.20",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+            "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+            "license": "MIT"
+        },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "license": "MIT",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/contentful-management": {
+            "version": "11.33.0",
+            "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.33.0.tgz",
+            "integrity": "sha512-QIpKV9BWGQ4M9TTTeyJiIyCElMnQvzMijMpQA31uFAdFxfokRcyA6zyYoVA7tIsyOmpWIAcFbGcDiGROAMR+zA==",
+            "license": "MIT",
+            "dependencies": {
+                "@contentful/rich-text-types": "^16.6.1",
+                "axios": "^1.7.4",
+                "contentful-sdk-core": "^8.3.1",
+                "fast-copy": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/contentful-migration": {
+            "version": "4.23.2",
+            "resolved": "https://registry.npmjs.org/contentful-migration/-/contentful-migration-4.23.2.tgz",
+            "integrity": "sha512-AL4Ol4uPg7M5gJkKOzPYhlRGbihosJTvLdFxATvf2ssZ7y05wOU3ELoOM9mxpOgLz2A5O03jdCDupgBzDgy2Bg==",
+            "license": "MIT",
+            "dependencies": {
+                "@hapi/hoek": "^11.0.4",
+                "axios": "^1.6.2",
+                "bluebird": "^3.7.2",
+                "callsites": "^3.1.0",
+                "cardinal": "^2.1.1",
+                "chalk": "^4.0.0",
+                "contentful-management": "^11.15.0",
+                "didyoumean2": "^5.0.0",
+                "https-proxy-agent": "^5.0.0",
+                "inquirer": "^8.1.2",
+                "joi": "^17.4.0",
+                "kind-of": "^6.0.3",
+                "listr2": "^3.13.5",
+                "lodash": "^4.17.15",
+                "p-throttle": "^4.1.1",
+                "uuid": "^10.0.0",
+                "yargs": "^15.3.1"
+            },
+            "bin": {
+                "contentful-migration": "bin/contentful-migration"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/contentful-sdk-core": {
+            "version": "8.3.1",
+            "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-8.3.1.tgz",
+            "integrity": "sha512-HYy4ecFA76ERxz7P0jW7hgDcL8jH+bRckv2QfAwQ4k1yPP9TvxpZwrKnlLM69JOStxVkCXP37HvbjbFnjcoWdg==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-copy": "^2.1.7",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "p-throttle": "^4.1.1",
+                "qs": "^6.11.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/contentful-sdk-core/node_modules/fast-copy": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
+            "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA==",
+            "license": "MIT"
+        },
+        "node_modules/debug": {
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+            "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/defaults": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+            "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+            "license": "MIT",
+            "dependencies": {
+                "clone": "^1.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/define-data-property": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/didyoumean2": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/didyoumean2/-/didyoumean2-5.0.0.tgz",
+            "integrity": "sha512-Plha9WCF08aSGB39IsOhlk0AHecwcXtq/gMbHgylRNEv7JV3lnlt7akfdax7mnUHndEuuh57CmBaKSSXns7+YA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.10.2",
+                "fastest-levenshtein": "^1.0.12",
+                "lodash.deburr": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=12.13"
+            }
+        },
+        "node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "license": "MIT"
+        },
+        "node_modules/es-define-property": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+            "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+            "license": "MIT",
+            "dependencies": {
+                "get-intrinsic": "^1.2.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "license": "BSD-2-Clause",
+            "bin": {
+                "esparse": "bin/esparse.js",
+                "esvalidate": "bin/esvalidate.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/external-editor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+            "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+            "license": "MIT",
+            "dependencies": {
+                "chardet": "^0.7.0",
+                "iconv-lite": "^0.4.24",
+                "tmp": "^0.0.33"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/fast-copy": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
+            "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
+            "license": "MIT"
+        },
+        "node_modules/fastest-levenshtein": {
+            "version": "1.0.16",
+            "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+            "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4.9.1"
+            }
+        },
+        "node_modules/figures": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+            "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+            "license": "MIT",
+            "dependencies": {
+                "escape-string-regexp": "^1.0.5"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/find-up": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/follow-redirects": {
+            "version": "1.15.8",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.8.tgz",
+            "integrity": "sha512-xgrmBhBToVKay1q2Tao5LI26B83UhrB/vM1avwVSDzt8rx3rO6AizBAaF46EgksTVr+rFTQaqZZ9MVBfUe4nig==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/form-data": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "license": "MIT",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "license": "ISC",
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
+            }
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+            "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "has-proto": "^1.0.1",
+                "has-symbols": "^1.0.3",
+                "hasown": "^2.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/gopd": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+            "license": "MIT",
+            "dependencies": {
+                "get-intrinsic": "^1.1.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/has-property-descriptors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-proto": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+            "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "license": "ISC"
+        },
+        "node_modules/inquirer": {
+            "version": "8.2.6",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
+            "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.1.1",
+                "cli-cursor": "^3.1.0",
+                "cli-width": "^3.0.0",
+                "external-editor": "^3.0.3",
+                "figures": "^3.0.0",
+                "lodash": "^4.17.21",
+                "mute-stream": "0.0.8",
+                "ora": "^5.4.1",
+                "run-async": "^2.4.0",
+                "rxjs": "^7.5.5",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0",
+                "through": "^2.3.6",
+                "wrap-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-interactive": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+            "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-unicode-supported": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/joi": {
+            "version": "17.13.3",
+            "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+            "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@hapi/hoek": "^9.3.0",
+                "@hapi/topo": "^5.1.0",
+                "@sideway/address": "^4.1.5",
+                "@sideway/formula": "^3.0.1",
+                "@sideway/pinpoint": "^2.0.0"
+            }
+        },
+        "node_modules/joi/node_modules/@hapi/hoek": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+            "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/kind-of": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/listr2": {
+            "version": "3.14.0",
+            "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.14.0.tgz",
+            "integrity": "sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==",
+            "license": "MIT",
+            "dependencies": {
+                "cli-truncate": "^2.1.0",
+                "colorette": "^2.0.16",
+                "log-update": "^4.0.0",
+                "p-map": "^4.0.0",
+                "rfdc": "^1.3.0",
+                "rxjs": "^7.5.1",
+                "through": "^2.3.8",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "enquirer": ">= 2.3.0 < 3"
+            },
+            "peerDependenciesMeta": {
+                "enquirer": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/listr2/node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/locate-path": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "license": "MIT"
+        },
+        "node_modules/lodash.deburr": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-4.1.0.tgz",
+            "integrity": "sha512-m/M1U1f3ddMCs6Hq2tAsYThTBDaAKFDX3dwDo97GEYzamXi9SqUpjWi/Rrj/gf3X2n8ktwgZrlP1z6E3v/IExQ==",
+            "license": "MIT"
+        },
+        "node_modules/lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+            "license": "MIT"
+        },
+        "node_modules/lodash.isstring": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+            "license": "MIT"
+        },
+        "node_modules/log-symbols": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.1.0",
+                "is-unicode-supported": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/log-update": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+            "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-escapes": "^4.3.0",
+                "cli-cursor": "^3.1.0",
+                "slice-ansi": "^4.0.0",
+                "wrap-ansi": "^6.2.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/log-update/node_modules/slice-ansi": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+            "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "astral-regex": "^2.0.0",
+                "is-fullwidth-code-point": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+            }
+        },
+        "node_modules/mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "license": "MIT"
+        },
+        "node_modules/mute-stream": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+            "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+            "license": "ISC"
+        },
+        "node_modules/object-inspect": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+            "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/onetime": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ora": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+            "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+            "license": "MIT",
+            "dependencies": {
+                "bl": "^4.1.0",
+                "chalk": "^4.1.0",
+                "cli-cursor": "^3.1.0",
+                "cli-spinners": "^2.5.0",
+                "is-interactive": "^1.0.0",
+                "is-unicode-supported": "^0.1.0",
+                "log-symbols": "^4.1.0",
+                "strip-ansi": "^6.0.0",
+                "wcwidth": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "license": "MIT",
+            "dependencies": {
+                "p-try": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-locate": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/p-map": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+            "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+            "license": "MIT",
+            "dependencies": {
+                "aggregate-error": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-throttle": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-4.1.1.tgz",
+            "integrity": "sha512-TuU8Ato+pRTPJoDzYD4s7ocJYcNSEZRvlxoq3hcPI2kZDZ49IQ1Wkj7/gDJc3X7XiEAAvRGtDzdXJI0tC3IL1g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-try": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/path-exists": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "license": "MIT"
+        },
+        "node_modules/qs": {
+            "version": "6.13.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "side-channel": "^1.0.6"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/redeyed": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
+            "integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
+            "license": "MIT",
+            "dependencies": {
+                "esprima": "~4.0.0"
+            }
+        },
+        "node_modules/regenerator-runtime": {
+            "version": "0.14.1",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+            "license": "MIT"
+        },
+        "node_modules/require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/require-main-filename": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+            "license": "ISC"
+        },
+        "node_modules/restore-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+            "license": "MIT",
+            "dependencies": {
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/rfdc": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+            "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+            "license": "MIT"
+        },
+        "node_modules/run-async": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+            "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/rxjs": {
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+            "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.1.0"
+            }
+        },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "license": "MIT"
+        },
+        "node_modules/set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+            "license": "ISC"
+        },
+        "node_modules/set-function-length": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+            "license": "MIT",
+            "dependencies": {
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/side-channel": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+            "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.7",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.4",
+                "object-inspect": "^1.13.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "license": "ISC"
+        },
+        "node_modules/slice-ansi": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+            "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "astral-regex": "^2.0.0",
+                "is-fullwidth-code-point": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
+        "node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+            "license": "MIT"
+        },
+        "node_modules/tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "license": "MIT",
+            "dependencies": {
+                "os-tmpdir": "~1.0.2"
+            },
+            "engines": {
+                "node": ">=0.6.0"
+            }
+        },
+        "node_modules/tslib": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+            "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+            "license": "0BSD"
+        },
+        "node_modules/type-fest": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+            "license": "MIT"
+        },
+        "node_modules/uuid": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+            "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/wcwidth": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+            "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+            "license": "MIT",
+            "dependencies": {
+                "defaults": "^1.0.3"
+            }
+        },
+        "node_modules/which-module": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+            "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+            "license": "ISC"
+        },
+        "node_modules/wrap-ansi": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/y18n": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+            "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+            "license": "ISC"
+        },
+        "node_modules/yargs": {
+            "version": "15.4.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+            "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^6.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^4.1.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^4.2.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^18.1.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yargs-parser": {
+            "version": "18.1.3",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+            "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+            "license": "ISC",
+            "dependencies": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        }
+    }
+}

--- a/contentful/content-migrations/package.json
+++ b/contentful/content-migrations/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "content-migrations",
+    "version": "1.0.0",
+    "description": "migration scripts for programmatic contentful changes",
+    "main": "run-migrations.js",
+    "scripts": {
+        "migration": "node run-migration.js"
+    },
+    "keywords": [],
+    "author": "",
+    "license": "ISC",
+    "dependencies": {
+        "contentful-migration": "^4.23.2"
+    }
+}

--- a/contentful/content-migrations/run-migration.js
+++ b/contentful/content-migrations/run-migration.js
@@ -1,0 +1,22 @@
+const { runMigration } = require("contentful-migration");
+const path = require("path")
+const fs = require("fs")
+
+async function main() {
+    const fileName = process.argv[2]
+    const filePath = fileName && path.join(__dirname, 'migrations', fileName)
+
+    if (!fs.existsSync(filePath)) {
+        console.error("Invalid migration filename provided")
+        return
+    }
+
+    await runMigration({
+        filePath: filePath,
+        spaceId: process.env.SPACE_ID,
+        environmentId: process.env.ENVIRONMENT,
+        accessToken: process.env.MANAGEMENT_TOKEN,
+    }).catch(console.error)
+}
+
+main();

--- a/contentful/content-migrations/run-migration.js
+++ b/contentful/content-migrations/run-migration.js
@@ -1,14 +1,14 @@
 const { runMigration } = require("contentful-migration");
-const path = require("path")
-const fs = require("fs")
+const path = require("path");
+const fs = require("fs");
 
 async function main() {
-    const fileName = process.argv[2]
-    const filePath = fileName && path.join(__dirname, 'migrations', fileName)
+    const fileName = process.argv[2];
+    const filePath = fileName && path.join(__dirname, "migrations", fileName);
 
     if (!fs.existsSync(filePath)) {
-        console.error("Invalid migration filename provided")
-        return
+        console.error("Invalid migration filename provided");
+        return;
     }
 
     await runMigration({
@@ -16,7 +16,7 @@ async function main() {
         spaceId: process.env.SPACE_ID,
         environmentId: process.env.ENVIRONMENT,
         accessToken: process.env.MANAGEMENT_TOKEN,
-    }).catch(console.error)
+    }).catch(console.error);
 }
 
 main();

--- a/src/Dfe.PlanTech.AzureFunctions/Mappings/RecommendationChunkMapper.cs
+++ b/src/Dfe.PlanTech.AzureFunctions/Mappings/RecommendationChunkMapper.cs
@@ -10,14 +10,11 @@ namespace Dfe.PlanTech.AzureFunctions.Mappings;
 
 public class RecommendationChunkMapper(EntityRetriever retriever, EntityUpdater updater, CmsDbContext db, ILogger<RecommendationChunkMapper> logger, JsonSerializerOptions jsonSerialiserOptions) : JsonToDbMapper<RecommendationChunkDbEntity>(retriever, updater, logger, jsonSerialiserOptions)
 {
-    private readonly CmsDbContext _db = db;
-
     private List<AnswerDbEntity> _incomingAnswers = [];
     private List<ContentComponentDbEntity> _incomingContent = [];
 
     public override Dictionary<string, object?> PerformAdditionalMapping(Dictionary<string, object?> values)
     {
-        values = MoveValueToNewKey(values, "header", "headerId");
         values = MoveValueToNewKey(values, "csLink", "csLinkId");
 
         _incomingAnswers = _entityUpdater.GetAndOrderReferencedEntities<AnswerDbEntity>(values, "answers").ToList();
@@ -36,16 +33,16 @@ public class RecommendationChunkMapper(EntityRetriever retriever, EntityUpdater 
             //as the existing entity is being tracked by EF Core's ChangeTracker, and EF Core is aware of the relationship.
             if (existing.Answers == null || existing.Answers.Count == 0)
             {
-                await _db.RecommendationChunkAnswers.IgnoreQueryFilters().Where(recChunkAnswer => recChunkAnswer.RecommendationChunkId == existing.Id).Include(rca => rca.Answer).ToListAsync();
+                await db.RecommendationChunkAnswers.IgnoreQueryFilters().Where(recChunkAnswer => recChunkAnswer.RecommendationChunkId == existing.Id).Include(rca => rca.Answer).ToListAsync();
             }
 
             if (existing.Content == null || existing.Content.Count == 0)
             {
-                await _db.RecommendationChunkContents.IgnoreQueryFilters().Where(recChunkContent => recChunkContent.RecommendationChunkId == existing.Id).Include(rca => rca.ContentComponent).ToListAsync();
+                await db.RecommendationChunkContents.IgnoreQueryFilters().Where(recChunkContent => recChunkContent.RecommendationChunkId == existing.Id).Include(rca => rca.ContentComponent).ToListAsync();
             }
         }
 
-        await _entityUpdater.UpdateReferences(incomingEntity: incoming, existingEntity: existing, (recChunk) => recChunk.Answers, _incomingAnswers, _db.Answers, false);
-        await _entityUpdater.UpdateReferences(incomingEntity: incoming, existingEntity: existing, (recChunk) => recChunk.Content, _incomingContent, _db.ContentComponents, true);
+        await _entityUpdater.UpdateReferences(incomingEntity: incoming, existingEntity: existing, (recChunk) => recChunk.Answers, _incomingAnswers, db.Answers, false);
+        await _entityUpdater.UpdateReferences(incomingEntity: incoming, existingEntity: existing, (recChunk) => recChunk.Content, _incomingContent, db.ContentComponents, true);
     }
 }

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240903_1600_SimplifyRecommendationChunkHeaders.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20240903_1600_SimplifyRecommendationChunkHeaders.sql
@@ -1,0 +1,26 @@
+DROP TABLE IF EXISTS #RecChunks
+
+SELECT
+    RC.Id,
+    RC.HeaderId,
+    RC.CSLinkId,
+    H.Text
+INTO #RecChunks
+FROM Contentful.RecommendationChunks RC
+JOIN Contentful.Headers H ON RC.HeaderId = H.Id
+
+ALTER TABLE Contentful.RecommendationChunks
+    DROP CONSTRAINT FK_RecommendationChunks_Headers_HeaderId
+ALTER TABLE Contentful.RecommendationChunks
+    DROP COLUMN HeaderId
+ALTER TABLE Contentful.RecommendationChunks
+    ADD Header NVARCHAR(MAX)
+
+UPDATE RC
+SET RC.Header = Temp.Text
+From #RecChunks Temp
+Join Contentful.RecommendationChunks RC ON Temp.Id = RC.Id
+
+Delete H
+From Contentful.Headers H
+Join #RecChunks RC ON RC.HeaderId = H.Id

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IHeaderWithContent.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IHeaderWithContent.cs
@@ -6,7 +6,7 @@ public interface IHeaderWithContent
 {
     public string SlugifiedHeader { get; }
 
-    public Header Header { get; }
+    public string HeaderText { get; }
 
     public List<ContentComponent> Content { get; }
 }

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationChunk.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationChunk.cs
@@ -2,12 +2,11 @@ using Dfe.PlanTech.Domain.Content.Interfaces;
 
 namespace Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
-public interface IRecommendationChunk<TAnswer, TContentComponent, THeader>
+public interface IRecommendationChunk<TAnswer, TContentComponent>
 where TAnswer : IAnswer
 where TContentComponent : IContentComponentType
-where THeader : IHeader
 {
-    public THeader Header { get; }
+    public string Header { get; }
 
     public List<TContentComponent> Content { get; }
 

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationSection.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IRecommendationSection.cs
@@ -4,11 +4,10 @@ namespace Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
 public interface IRecommendationSection { }
 
-public interface IRecommendationSection<TAnswer, TContentComponent, THeader, TRecommendationChunk> : IRecommendationSection
+public interface IRecommendationSection<TAnswer, TContentComponent, TRecommendationChunk> : IRecommendationSection
 where TAnswer : IAnswer
 where TContentComponent : IContentComponentType
-where TRecommendationChunk : IRecommendationChunk<TAnswer, TContentComponent, THeader>
-where THeader : IHeader
+where TRecommendationChunk : IRecommendationChunk<TAnswer, TContentComponent>
 {
     public List<TAnswer> Answers { get; }
 

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/ISubTopicRecommendation.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/ISubTopicRecommendation.cs
@@ -4,13 +4,12 @@ namespace Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
 public interface ISubTopicRecommendation { }
 
-public interface ISubTopicRecommendation<TAnswer, TContentComponent, THeader, TRecommendationChunk, TRecommendationIntro, TRecommendationSection, TSection> : ISubTopicRecommendation
+public interface ISubTopicRecommendation<TAnswer, TContentComponent, TRecommendationChunk, TRecommendationIntro, TRecommendationSection, TSection> : ISubTopicRecommendation
 where TAnswer : IAnswer
 where TContentComponent : IContentComponentType
-where THeader : IHeader
-where TRecommendationChunk : IRecommendationChunk<TAnswer, TContentComponent, THeader>
+where TRecommendationChunk : IRecommendationChunk<TAnswer, TContentComponent>
 where TRecommendationIntro : IRecommendationIntro
-where TRecommendationSection : IRecommendationSection<TAnswer, TContentComponent, THeader, TRecommendationChunk>
+where TRecommendationSection : IRecommendationSection<TAnswer, TContentComponent, TRecommendationChunk>
 where TSection : ISection
 {
     public List<TRecommendationIntro> Intros { get; }

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationChunk.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationChunk.cs
@@ -3,15 +3,17 @@ using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
 namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
-public class RecommendationChunk : ContentComponent, IRecommendationChunk<Answer, ContentComponent, Header>, IHeaderWithContent
+public class RecommendationChunk : ContentComponent, IRecommendationChunk<Answer, ContentComponent>, IHeaderWithContent
 {
-    public Header Header { get; init; } = null!;
+    public string Header { get; init; } = null!;
 
     public List<ContentComponent> Content { get; init; } = [];
 
     public List<Answer> Answers { get; init; } = [];
 
-    public string SlugifiedHeader => Header.Text.Slugify();
+    public string SlugifiedHeader => Header.Slugify();
 
     public CSLink? CSLink { get; init; }
+
+    public string HeaderText => Header;
 }

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationChunkDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationChunkDbEntity.cs
@@ -6,11 +6,9 @@ namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
 public class RecommendationChunkDbEntity
     : ContentComponentDbEntity,
-        IRecommendationChunk<AnswerDbEntity, ContentComponentDbEntity, HeaderDbEntity>
+        IRecommendationChunk<AnswerDbEntity, ContentComponentDbEntity>
 {
-    public string HeaderId { get; set; } = null!;
-
-    public HeaderDbEntity Header { get; init; } = null!;
+    public string Header { get; init; } = null!;
 
     [NotMapped]
     public List<ContentComponentDbEntity> Content { get; init; } = [];

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationIntro.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationIntro.cs
@@ -16,4 +16,6 @@ public class RecommendationIntro : ContentComponent, IRecommendationIntro<Header
     public List<ContentComponent> Content { get; init; } = [];
 
     public string SlugifiedHeader => Header.Text.Slugify();
+
+    public string HeaderText => Header.Text;
 }

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationSection.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationSection.cs
@@ -4,7 +4,7 @@ using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
 namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
-public class RecommendationSection : ContentComponent, IRecommendationSection<Answer, ContentComponent, Header, RecommendationChunk>
+public class RecommendationSection : ContentComponent, IRecommendationSection<Answer, ContentComponent, RecommendationChunk>
 {
     [NotMapped]
     public List<Answer> Answers { get; init; } = [];

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationSectionDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationSectionDbEntity.cs
@@ -3,7 +3,7 @@ using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
 namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
-public class RecommendationSectionDbEntity : ContentComponentDbEntity, IRecommendationSection<AnswerDbEntity, ContentComponentDbEntity, HeaderDbEntity, RecommendationChunkDbEntity>
+public class RecommendationSectionDbEntity : ContentComponentDbEntity, IRecommendationSection<AnswerDbEntity, ContentComponentDbEntity, RecommendationChunkDbEntity>
 {
     [DontCopyValue]
     public List<AnswerDbEntity> Answers { get; init; } = [];

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/SubtopicRecommendation.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/SubtopicRecommendation.cs
@@ -4,7 +4,7 @@ using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
 namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
-public class SubtopicRecommendation : ContentComponent, ISubTopicRecommendation<Answer, ContentComponent, Header, RecommendationChunk, RecommendationIntro, RecommendationSection, Section>
+public class SubtopicRecommendation : ContentComponent, ISubTopicRecommendation<Answer, ContentComponent, RecommendationChunk, RecommendationIntro, RecommendationSection, Section>
 {
     public List<RecommendationIntro> Intros { get; init; } = [];
 

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/SubtopicRecommendationDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/SubtopicRecommendationDbEntity.cs
@@ -3,7 +3,7 @@ using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
 namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
-public class SubtopicRecommendationDbEntity : ContentComponentDbEntity, ISubTopicRecommendation<AnswerDbEntity, ContentComponentDbEntity, HeaderDbEntity, RecommendationChunkDbEntity, RecommendationIntroDbEntity, RecommendationSectionDbEntity, SectionDbEntity>
+public class SubtopicRecommendationDbEntity : ContentComponentDbEntity, ISubTopicRecommendation<AnswerDbEntity, ContentComponentDbEntity, RecommendationChunkDbEntity, RecommendationIntroDbEntity, RecommendationSectionDbEntity, SectionDbEntity>
 {
     [DontCopyValue]
     public List<RecommendationIntroDbEntity> Intros { get; init; } = [];

--- a/src/Dfe.PlanTech.Infrastructure.Data/Repositories/RecommendationsRepository.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Data/Repositories/RecommendationsRepository.cs
@@ -43,7 +43,7 @@ public class RecommendationsRepository(ICmsDbContext db, ILogger<IRecommendation
         var chunks = await _db.RecommendationChunks.Where(chunk => chunk.RecommendationSections.Any(section => section.Id == recommendation.SectionId))
                                                     .Select(chunk => new RecommendationChunkDbEntity()
                                                     {
-                                                        Header = new HeaderDbEntity() { Text = chunk.Header.Text, Size = chunk.Header.Size, Tag = chunk.Header.Tag },
+                                                        Header = chunk.Header,
                                                         Answers = chunk.Answers.Select(answer => new AnswerDbEntity() { Id = answer.Id }).ToList(),
                                                         Id = chunk.Id,
                                                         Order = chunk.Order,
@@ -100,7 +100,6 @@ public class RecommendationsRepository(ICmsDbContext db, ILogger<IRecommendation
                 {
                     Id = chunk.Id,
                     Header = chunk.Header,
-                    HeaderId = chunk.HeaderId,
                     Answers = chunk.Answers,
                     Content = [.. chunkContent.Where(content => content.RecommendationChunkId == chunk.Id && content.ContentComponent != null)
                                             .Select(content => content.ContentComponent)

--- a/src/Dfe.PlanTech.Infrastructure.Data/Repositories/RecommendationsRepository.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Data/Repositories/RecommendationsRepository.cs
@@ -1,5 +1,4 @@
 using Dfe.PlanTech.Application.Persistence.Interfaces;
-using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 using Dfe.PlanTech.Domain.Questionnaire.Models;
 using Dfe.PlanTech.Questionnaire.Models;

--- a/src/Dfe.PlanTech.Web/Models/RecommendationsChecklistViewModel.cs
+++ b/src/Dfe.PlanTech.Web/Models/RecommendationsChecklistViewModel.cs
@@ -16,12 +16,7 @@ public class RecommendationsChecklistViewModel
     private static RecommendationChunk ConvertToNumberedChunk(RecommendationChunk content, int index)
     => new()
     {
-        Header = new Header
-        {
-            Text = $"{index + 1}. {content.Header.Text}",
-            Tag = HeaderTag.H3,
-            Size = HeaderSize.Medium
-        },
+        Header = $"{index + 1}. {content.Header}",
         Content = content.Content,
     };
 

--- a/src/Dfe.PlanTech.Web/Models/RecommendationsChecklistViewModel.cs
+++ b/src/Dfe.PlanTech.Web/Models/RecommendationsChecklistViewModel.cs
@@ -1,5 +1,3 @@
-using Dfe.PlanTech.Domain.Content.Enums;
-using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 using Dfe.PlanTech.Domain.Questionnaire.Models;
 

--- a/src/Dfe.PlanTech.Web/Views/Recommendations/RecommendationContent.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/RecommendationContent.cshtml
@@ -5,10 +5,10 @@
 @foreach (var headerWithContent in Model.AllContent)
 {
     <div class="recommendation-piece-container" id="@headerWithContent.SlugifiedHeader">
-    <div class="recommendation-piece-header">
-            @{
-                await Html.RenderPartialAsync("Components/Header", headerWithContent.Header);
-            }
+        <div class="recommendation-piece-header">
+            <div class="recommendation-piece-header">
+                <h1 class="govuk-heading-xl">@headerWithContent.HeaderText</h1>
+            </div>
         </div>
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-third">

--- a/src/Dfe.PlanTech.Web/Views/Recommendations/RecommendationPrintContent.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/RecommendationPrintContent.cshtml
@@ -14,9 +14,9 @@
         else
         {
             <div class="recommendation-action-header">
-                @{
-                    await Html.RenderPartialAsync("Components/Header", headerWithContent.Header);
-                }
+                <div class="recommendation-piece-header">
+                    <h1 class="govuk-heading-xl">@headerWithContent.HeaderText</h1>
+                </div>
             </div>
             <div class="recommendation-action-content">
                 @foreach (var content in headerWithContent.Content)

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/HeaderWithContent.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/HeaderWithContent.cshtml
@@ -1,21 +1,21 @@
 @model Dfe.PlanTech.Domain.Questionnaire.Interfaces.IHeaderWithContent;
 
 @{
-  var parentContainerClass = ViewData["ParentContainerClass"] ?? "header-with-content-container";
-  var headerClass = ViewData["HeaderClass"] ?? "header-with-content-header";
-  var contentClass = ViewData["ContentClass"] ?? "header-with-content-content";
+    var parentContainerClass = ViewData["ParentContainerClass"] ?? "header-with-content-container";
+    var headerClass = ViewData["HeaderClass"] ?? "header-with-content-header";
+    var contentClass = ViewData["ContentClass"] ?? "header-with-content-content";
 }
 
 <div class="@parentContainerClass" id="@Model.SlugifiedHeader">
-  <div class="@headerClass">
-    @{
-      await Html.RenderPartialAsync("Components/Header", Model.Header);
-    }
-  </div>
-  <div class="@contentClass">
-    @foreach (var content in Model.Content)
-    {
-      await Html.RenderPartialAsync("Components/PageComponentFactory", content);
-    }
-  </div>
+    <div class="@headerClass">
+        <div class="recommendation-piece-header">
+            <h1 class="govuk-heading-xl">@Model.HeaderText</h1>
+        </div>
+    </div>
+    <div class="@contentClass">
+        @foreach (var content in Model.Content)
+        {
+            await Html.RenderPartialAsync("Components/PageComponentFactory", content);
+        }
+    </div>
 </div>

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/VerticalNavigation/Default.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/VerticalNavigation/Default.cshtml
@@ -10,7 +10,7 @@
                 : "";
 
             <li class="dfe-vertical-nav__section-item">
-                <a class="dfe-vertical-nav__link @classes" href="#@chunk.SlugifiedHeader">@chunk.Header.Text</a>
+                <a class="dfe-vertical-nav__link @classes" href="#@chunk.SlugifiedHeader">@chunk.Header</a>
             </li>
         }
     </ul>

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationFromContentfulQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationFromContentfulQueryTests.cs
@@ -53,13 +53,7 @@ public class GetSubTopicRecommendationFromContentfulQueryTests
                             Sys = new SystemDetails() { Id = "3" }
                         }
                     },
-
-                    Header = new Header()
-                    {
-                        Tag = HeaderTag.H1,
-                        Size = HeaderSize.Large,
-                        Text = "chunk1"
-                    }
+                    Header = "chunk1"
 
                 },
                 new RecommendationChunk()
@@ -79,13 +73,7 @@ public class GetSubTopicRecommendationFromContentfulQueryTests
                             Sys = new SystemDetails() { Id = "6" }
                         }
                     },
-
-                    Header = new Header()
-                    {
-                        Tag = HeaderTag.H1,
-                        Size = HeaderSize.Large,
-                        Text = "chunk3"
-                    }
+                    Header = "chunk3"
 
                 },
                 new RecommendationChunk()
@@ -105,13 +93,7 @@ public class GetSubTopicRecommendationFromContentfulQueryTests
                             Sys = new SystemDetails() { Id = "9" }
                         }
                     },
-
-                    Header = new Header()
-                    {
-                        Tag = HeaderTag.H1,
-                        Size = HeaderSize.Large,
-                        Text = "chunk2"
-                    }
+                    Header = "chunk2"
                 }
             }
         };

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationFromContentfulQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationFromContentfulQueryTests.cs
@@ -1,7 +1,6 @@
 using Dfe.PlanTech.Application.Content.Queries;
 using Dfe.PlanTech.Application.Persistence.Interfaces;
 using Dfe.PlanTech.Application.Persistence.Models;
-using Dfe.PlanTech.Domain.Content.Enums;
 using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Domain.Questionnaire.Enums;
 using Dfe.PlanTech.Domain.Questionnaire.Models;

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationFromContentfulQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationFromContentfulQueryTests.cs
@@ -248,7 +248,7 @@ public class GetSubTopicRecommendationFromContentfulQueryTests
 
         Assert.NotNull(result);
         Assert.Equal(result.RecommendationSlug, expectedIntro.Slug);
-        Assert.Equal(result.DisplayName, expectedIntro.Header.Text);
+        Assert.Equal(result.DisplayName, expectedIntro.HeaderText);
     }
 
     [Fact]

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationFromDbQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationFromDbQueryTests.cs
@@ -62,13 +62,7 @@ public class GetSubTopicRecommendationFromDbQueryTests
                             Id = "3"
                         }
                     ],
-                    Header = new HeaderDbEntity()
-                    {
-                        Tag = HeaderTag.H1,
-                        Size = HeaderSize.Large,
-                        Text = "chunk1",
-                        Id = "Header-one"
-                    },
+                    Header = "chunk1",
                     Content = [
                         new TextBodyDbEntity()
                         {
@@ -93,13 +87,7 @@ public class GetSubTopicRecommendationFromDbQueryTests
                             Id = "6"
                         }
                     ],
-                    Header = new HeaderDbEntity()
-                    {
-                        Tag = HeaderTag.H1,
-                        Size = HeaderSize.Large,
-                        Text = "chunk2",
-                        Id = "Header-two"
-                    },
+                    Header = "chunk2",
                     Content = [
                         new TextBodyDbEntity()
                         {
@@ -124,13 +112,7 @@ public class GetSubTopicRecommendationFromDbQueryTests
                             Id = "9"
                         }
                     ],
-                    Header = new HeaderDbEntity()
-                    {
-                        Tag = HeaderTag.H1,
-                        Size = HeaderSize.Large,
-                        Text = "chunk3",
-                        Id = "Header-three"
-                    },
+                    Header = "chunk3",
                     Content = [
                         new TextBodyDbEntity()
                         {

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationFromDbQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationFromDbQueryTests.cs
@@ -1,7 +1,6 @@
 using AutoMapper;
 using Dfe.PlanTech.Application.Content.Queries;
 using Dfe.PlanTech.Application.Mappings;
-using Dfe.PlanTech.Domain.Content.Enums;
 using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 using Dfe.PlanTech.Domain.Questionnaire.Models;

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationQueryTests.cs
@@ -1,5 +1,4 @@
 using Dfe.PlanTech.Application.Content.Queries;
-using Dfe.PlanTech.Domain.Content.Enums;
 using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Domain.Content.Queries;
 using Dfe.PlanTech.Domain.Questionnaire.Models;

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationQueryTests.cs
@@ -46,14 +46,7 @@ public class GetSubTopicRecommendationQueryTests
                             Sys = new SystemDetails() { Id = "3" }
                         }
                     ],
-
-                    Header = new Header()
-                    {
-                        Tag = HeaderTag.H1,
-                        Size = HeaderSize.Large,
-                        Text = "chunk1"
-                    }
-
+                    Header = "chunk1"
                 },
                 new()
                 {
@@ -72,14 +65,7 @@ public class GetSubTopicRecommendationQueryTests
                             Sys = new SystemDetails() { Id = "6" }
                         }
                     ],
-
-                    Header = new Header()
-                    {
-                        Tag = HeaderTag.H1,
-                        Size = HeaderSize.Large,
-                        Text = "chunk3"
-                    }
-
+                    Header = "chunk3",
                 },
                 new RecommendationChunk()
                 {
@@ -98,13 +84,7 @@ public class GetSubTopicRecommendationQueryTests
                             Sys = new() { Id = "9" }
                         }
                     ],
-
-                    Header = new Header()
-                    {
-                        Tag = HeaderTag.H1,
-                        Size = HeaderSize.Large,
-                        Text = "chunk2"
-                    }
+                    Header = "chunk2"
                 }
             ]
         };

--- a/tests/Dfe.PlanTech.CmsDbDataValidator/Comparators/RecommendationChunkComparator.cs
+++ b/tests/Dfe.PlanTech.CmsDbDataValidator/Comparators/RecommendationChunkComparator.cs
@@ -35,12 +35,6 @@ public class RecommendationChunksComparatorclass(CmsDbContext db, ContentfulCont
 
     protected IEnumerable<DataValidationError> GetValidationErrors(RecommendationChunkDbEntity databaseRecommendationChunk, JsonNode contentfulRecommendationChunk)
     {
-        var headerValidationResult = ValidateChild<RecommendationChunkDbEntity>(databaseRecommendationChunk, "HeaderId", contentfulRecommendationChunk, "header");
-        if (headerValidationResult != null)
-        {
-            yield return new DataValidationError("Header", headerValidationResult);
-        }
-
         foreach (var child in ValidateChildren(contentfulRecommendationChunk, "answers", databaseRecommendationChunk, dbRecommendationChunk => dbRecommendationChunk.Answers))
         {
             yield return child;
@@ -57,7 +51,7 @@ public class RecommendationChunksComparatorclass(CmsDbContext db, ContentfulCont
         return _db.RecommendationChunks.Select(chunk => new RecommendationChunkDbEntity()
         {
             Id = chunk.Id,
-            HeaderId = chunk.HeaderId,
+            Header = chunk.Header,
             Answers = chunk.Answers.Select(answer => new AnswerDbEntity()
             {
                 Id = answer.Id

--- a/tests/Dfe.PlanTech.CmsDbDataValidator/Comparators/RecommendationIntroComparator.cs
+++ b/tests/Dfe.PlanTech.CmsDbDataValidator/Comparators/RecommendationIntroComparator.cs
@@ -35,12 +35,6 @@ public class RecommendationIntrosComparator(CmsDbContext db, ContentfulContent c
 
     protected IEnumerable<DataValidationError> GetValidationErrors(RecommendationIntroDbEntity databaseRecommendationIntro, JsonNode contentfulRecommendationIntro)
     {
-        var headerValidationResult = ValidateChild<RecommendationIntroDbEntity>(databaseRecommendationIntro, "HeaderId", contentfulRecommendationIntro, "header");
-        if (headerValidationResult != null)
-        {
-            yield return new DataValidationError("Header", headerValidationResult);
-        }
-
         foreach (var child in ValidateChildren(contentfulRecommendationIntro, "content", databaseRecommendationIntro, dbRecommendationChunk => dbRecommendationChunk.Content))
         {
             yield return child;
@@ -55,7 +49,7 @@ public class RecommendationIntrosComparator(CmsDbContext db, ContentfulContent c
             Id = intro.Id,
             Slug = intro.Slug,
             Maturity = intro.Maturity,
-            HeaderId = intro.HeaderId,
+            Header = intro.Header,
             Content = intro.Content.Select(answer => new ContentComponentDbEntity()
             {
                 Id = answer.Id

--- a/tests/Dfe.PlanTech.Infrastructure.Data.UnitTests/Repositories/RecommendationsRepositoryTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Data.UnitTests/Repositories/RecommendationsRepositoryTests.cs
@@ -1,5 +1,4 @@
 using Dfe.PlanTech.Application.Persistence.Interfaces;
-using Dfe.PlanTech.Domain.Content.Enums;
 using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Domain.Questionnaire.Enums;
 using Dfe.PlanTech.Domain.Questionnaire.Interfaces;

--- a/tests/Dfe.PlanTech.Infrastructure.Data.UnitTests/Repositories/RecommendationsRepositoryTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Data.UnitTests/Repositories/RecommendationsRepositoryTests.cs
@@ -45,34 +45,39 @@ public class RecommendationsRepositoryTests
         {
             intro.SubtopicRecommendations.Add(_subtopicRecommendation);
         }
+
         _intros.AddRange(_subtopicRecommendation.Intros);
         _introContent.AddRange(_subtopicRecommendation.Intros.SelectMany((intro, introIndex) => intro.Content
-                                                                                             .Select((content, contentIndex) => new RecommendationIntroContentDbEntity()
-                                                                                             {
-                                                                                                 Id = introIndex + contentIndex,
-                                                                                                 RecommendationIntro = intro,
-                                                                                                 RecommendationIntroId = intro.Id,
-                                                                                                 ContentComponent = content,
-                                                                                                 ContentComponentId = content.Id
-                                                                                             })));
+            .Select((content, contentIndex) => new RecommendationIntroContentDbEntity()
+            {
+                Id = introIndex + contentIndex,
+                RecommendationIntro = intro,
+                RecommendationIntroId = intro.Id,
+                ContentComponent = content,
+                ContentComponentId = content.Id
+            })));
 
         foreach (var chunk in _subtopicRecommendation.Section.Chunks)
         {
             chunk.RecommendationSections.Add(_subtopicRecommendation.Section);
         }
+
         _chunks.AddRange(_subtopicRecommendation.Section.Chunks);
         _chunkContent.AddRange(_subtopicRecommendation.Section.Chunks.SelectMany((chunk, chunkIndex) => chunk.Content
-                                                                                                             .Select((content, contentIndex) => new RecommendationChunkContentDbEntity()
-                                                                                                             {
-                                                                                                                 Id = chunkIndex + contentIndex,
-                                                                                                                 RecommendationChunk = chunk,
-                                                                                                                 RecommendationChunkId = chunk.Id,
-                                                                                                                 ContentComponent = content,
-                                                                                                                 ContentComponentId = content.Id
-                                                                                                             })));
+            .Select((content, contentIndex) => new RecommendationChunkContentDbEntity()
+            {
+                Id = chunkIndex + contentIndex,
+                RecommendationChunk = chunk,
+                RecommendationChunkId = chunk.Id,
+                ContentComponent = content,
+                ContentComponentId = content.Id
+            })));
 
 
-        _answers.AddRange([.. _subtopicRecommendation.Section.Answers, .. _subtopicRecommendation.Section.Chunks.SelectMany(chunk => chunk.Answers)]);
+        _answers.AddRange([
+            .. _subtopicRecommendation.Section.Answers,
+            .. _subtopicRecommendation.Section.Chunks.SelectMany(chunk => chunk.Answers)
+        ]);
 
         var mockContext = Substitute.For<ICmsDbContext>();
 
@@ -104,11 +109,12 @@ public class RecommendationsRepositoryTests
     {
         var recommendationSectionOne = new RecommendationSectionDbEntity()
         {
-            Answers = [
-            new AnswerDbEntity()
-            {
-                Id = "section-answer-one",
-            },
+            Answers =
+            [
+                new AnswerDbEntity()
+                {
+                    Id = "section-answer-one",
+                },
                 new AnswerDbEntity()
                 {
                     Id = "section-answer-two",
@@ -119,11 +125,11 @@ public class RecommendationsRepositoryTests
                 },
             ],
             Chunks =
-              [
-              new RecommendationChunkDbEntity()
-              {
-                  Id = RecChunkOneId,
-                  Answers =
+            [
+                new RecommendationChunkDbEntity()
+                {
+                    Id = RecChunkOneId,
+                    Answers =
                     [
                         new AnswerDbEntity()
                         {
@@ -138,35 +144,30 @@ public class RecommendationsRepositoryTests
                             Id = "3"
                         }
                     ],
-                  Header = new HeaderDbEntity()
-                  {
-                      Tag = HeaderTag.H1,
-                      Size = HeaderSize.Large,
-                      Text = "chunk1",
-                      Id = "Header-one"
-                  },
-                  Content = [
+                    Header = "chunk1",
+                    Content =
+                    [
                         new TextBodyDbEntity()
                         {
                             Id = "Chunk-one-content-one",
                             Order = 0,
                         },
-                      new TextBodyDbEntity()
-                      {
-                          Id = "Chunk-one-content-two",
-                          Order = 1,
-                      },
-                      new TextBodyDbEntity()
-                      {
-                          Id = "Chunk-one-content-three",
-                          Order = 2,
-                      },
-                  ]
-              },
-                  new RecommendationChunkDbEntity()
-                  {
-                      Id = "recommendation-chunk-two",
-                      Answers =
+                        new TextBodyDbEntity()
+                        {
+                            Id = "Chunk-one-content-two",
+                            Order = 1,
+                        },
+                        new TextBodyDbEntity()
+                        {
+                            Id = "Chunk-one-content-three",
+                            Order = 2,
+                        },
+                    ]
+                },
+                new RecommendationChunkDbEntity()
+                {
+                    Id = "recommendation-chunk-two",
+                    Answers =
                     [
                         new AnswerDbEntity()
                         {
@@ -181,35 +182,30 @@ public class RecommendationsRepositoryTests
                             Id = "6"
                         }
                     ],
-                      Header = new HeaderDbEntity()
-                      {
-                          Tag = HeaderTag.H1,
-                          Size = HeaderSize.Large,
-                          Text = "chunk2",
-                          Id = "Header-two"
-                      },
-                      Content = [
+                    Header = "chunk2",
+                    Content =
+                    [
                         new TextBodyDbEntity()
                         {
                             Id = "Chunk-two-content-two",
                             Order = 1,
                         },
-                          new TextBodyDbEntity()
-                          {
-                              Id = "Chunk-two-content-thre",
-                              Order = 2,
-                          },
-                          new TextBodyDbEntity()
-                          {
-                              Id = "Chunk-two-content-one",
-                              Order = 0,
-                          }
+                        new TextBodyDbEntity()
+                        {
+                            Id = "Chunk-two-content-thre",
+                            Order = 2,
+                        },
+                        new TextBodyDbEntity()
+                        {
+                            Id = "Chunk-two-content-one",
+                            Order = 0,
+                        }
                     ]
-                  },
-                  new RecommendationChunkDbEntity()
-                  {
-                      Id = "recommendation-chunk-three",
-                      Answers =
+                },
+                new RecommendationChunkDbEntity()
+                {
+                    Id = "recommendation-chunk-three",
+                    Answers =
                     [
                         new AnswerDbEntity()
                         {
@@ -224,32 +220,27 @@ public class RecommendationsRepositoryTests
                             Id = "9"
                         }
                     ],
-                      Header = new HeaderDbEntity()
-                      {
-                          Tag = HeaderTag.H1,
-                          Size = HeaderSize.Large,
-                          Text = "chunk3",
-                          Id = "Header-three"
-                      },
-                      Content = [
+                    Header = "chunk3",
+                    Content =
+                    [
                         new TextBodyDbEntity()
                         {
                             Id = "Chunk-three-content-three",
                             Order = 2,
                         },
-                          new TextBodyDbEntity()
-                          {
-                              Id = "Chunk-three-content-two",
-                              Order = 1,
-                          },
-                          new TextBodyDbEntity()
-                          {
-                              Id = "Chunk-three-content-one",
-                              Order = 0,
-                          }
+                        new TextBodyDbEntity()
+                        {
+                            Id = "Chunk-three-content-two",
+                            Order = 1,
+                        },
+                        new TextBodyDbEntity()
+                        {
+                            Id = "Chunk-three-content-one",
+                            Order = 0,
+                        }
                     ]
-                  }
-              ],
+                }
+            ],
             Id = "recommendation-section-one"
         };
 
@@ -259,42 +250,44 @@ public class RecommendationsRepositoryTests
         {
             Intros =
             [
-              new RecommendationIntroDbEntity()
-              {
-                  Maturity = "Low",
-                  Id = RecIntroOneId,
-                  Slug = "Low-Maturity",
-                  Header = new HeaderDbEntity() { Text = "Low maturity header", Id = "Intro-header-one" },
-                  Content = [
-                    new TextBodyDbEntity()
-                    {
-                        Id = "Intro-one-content-three",
-                        Order = 2,
-                    },
-                      new TextBodyDbEntity()
-                      {
-                          Id = "Intro-one-content-two",
-                          Order = 1,
-                      },
-                      new TextBodyDbEntity()
-                      {
-                          Id = "Intro-one-content-one",
-                          Order = 0,
-                      }
-                ]
-              },
+                new RecommendationIntroDbEntity()
+                {
+                    Maturity = "Low",
+                    Id = RecIntroOneId,
+                    Slug = "Low-Maturity",
+                    Header = new HeaderDbEntity() { Text = "Low maturity header", Id = "Intro-header-one" },
+                    Content =
+                    [
+                        new TextBodyDbEntity()
+                        {
+                            Id = "Intro-one-content-three",
+                            Order = 2,
+                        },
+                        new TextBodyDbEntity()
+                        {
+                            Id = "Intro-one-content-two",
+                            Order = 1,
+                        },
+                        new TextBodyDbEntity()
+                        {
+                            Id = "Intro-one-content-one",
+                            Order = 0,
+                        }
+                    ]
+                },
                 new RecommendationIntroDbEntity()
                 {
                     Maturity = "Medium",
                     Id = "Intro-Two-Medium",
                     Slug = "Medium-Maturity",
                     Header = new HeaderDbEntity() { Text = "Medium maturity header", Id = "Intro-header-two" },
-                    Content = [
-                    new TextBodyDbEntity()
-                    {
-                        Id = "Intro-two-content-two",
-                        Order = 1,
-                    },
+                    Content =
+                    [
+                        new TextBodyDbEntity()
+                        {
+                            Id = "Intro-two-content-two",
+                            Order = 1,
+                        },
                         new TextBodyDbEntity()
                         {
                             Id = "Intro-two-content-three",
@@ -305,7 +298,7 @@ public class RecommendationsRepositoryTests
                             Id = "Intro-two-content-one",
                             Order = 0,
                         }
-                ]
+                    ]
                 },
                 new RecommendationIntroDbEntity()
                 {
@@ -313,12 +306,13 @@ public class RecommendationsRepositoryTests
                     Id = "Intro-Three-High",
                     Slug = "High-Maturity",
                     Header = new HeaderDbEntity() { Text = "High maturity header", Id = "Intro-header-three" },
-                    Content = [
-                    new TextBodyDbEntity()
-                    {
-                        Id = "Intro-three-content-three",
-                        Order = 2,
-                    },
+                    Content =
+                    [
+                        new TextBodyDbEntity()
+                        {
+                            Id = "Intro-three-content-three",
+                            Order = 2,
+                        },
                         new TextBodyDbEntity()
                         {
                             Id = "Intro-three-content-one",

--- a/tests/Dfe.PlanTech.Web.SeedTestData/ContentGenerators/ConnectivityCategory.cs
+++ b/tests/Dfe.PlanTech.Web.SeedTestData/ContentGenerators/ConnectivityCategory.cs
@@ -11,7 +11,7 @@ namespace Dfe.PlanTech.Web.SeedTestData.ContentGenerators;
 /// </summary>
 public class ConnectivityCategory(CmsDbContext db) : ContentGenerator
 {
-    private static SectionDbEntity GetWifiSubtopic()
+    private SectionDbEntity GetWifiSubtopic()
     {
         var q2 = CreateComponent(new QuestionDbEntity()
         {
@@ -32,29 +32,46 @@ public class ConnectivityCategory(CmsDbContext db) : ContentGenerator
                 }),
             ]
         });
+        var fibreAnswer = CreateComponent(new AnswerDbEntity()
+        {
+            Text = "Fibre",
+            Maturity = "Low",
+            NextQuestion = q2
+        });
+        var mobileAnswer = CreateComponent(new AnswerDbEntity()
+        {
+            Text = "Mobile",
+            Maturity = "Low",
+            NextQuestion = q2
+        });
         var q1 = CreateComponent(new QuestionDbEntity
         {
             Slug = "wifi-q1",
             Text = "What type of broadband do you have?",
             Order = 0,
-            Answers =
+            Answers = [fibreAnswer, mobileAnswer]
+        });
+
+        var recommendationSection = CreateComponent(new RecommendationSectionDbEntity()
+        {
+            Chunks =
             [
-                CreateComponent(new AnswerDbEntity()
+                CreateComponent(new RecommendationChunkDbEntity()
                 {
-                    Text = "Fibre",
-                    Maturity = "High",
-                    NextQuestion = q2
+                    Content = [CreateTextBody("recommendation chunk fibre contents")],
+                    Answers = [fibreAnswer],
+                    Header = "Recommendation for fibre"
                 }),
-                CreateComponent(new AnswerDbEntity()
+                CreateComponent(new RecommendationChunkDbEntity()
                 {
-                    Text = "Mobile",
-                    Maturity = "Medium",
-                    NextQuestion = q2
-                }),
+                    Content = [CreateTextBody("recommendation chunk mobile contents")],
+                    Answers = [mobileAnswer],
+                    Header = "Recommendation for mobile"
+                })
             ]
         });
 
-        return CreateComponent(new SectionDbEntity
+        var subtopic = CreateComponent(new SectionDbEntity
         {
             Name = "Wifi",
             InterstitialPage = CreateComponent(new PageDbEntity
@@ -80,6 +97,29 @@ public class ConnectivityCategory(CmsDbContext db) : ContentGenerator
             Order = 0,
             Questions = [q1, q2]
         });
+
+        db.SubtopicRecommendations.Add(CreateComponent(new SubtopicRecommendationDbEntity()
+        {
+            Intros =
+            [
+                CreateComponent(new RecommendationIntroDbEntity()
+                {
+                    Slug = "wifi-recommendation-intro",
+                    Maturity = "Low",
+                    Header = CreateComponent(new HeaderDbEntity()
+                    {
+                        Text = "Wifi recommendation intro",
+                        Tag = HeaderTag.H1,
+                        Size = HeaderSize.Large
+                    }),
+                    Content = [CreateTextBody("recommendation intro text")]
+                })
+            ],
+            Section = recommendationSection,
+            Subtopic = subtopic,
+        }));
+
+        return subtopic;
     }
 
     public override void CreateData()

--- a/tests/Dfe.PlanTech.Web.SeedTestData/ContentGenerators/ContentGenerator.cs
+++ b/tests/Dfe.PlanTech.Web.SeedTestData/ContentGenerators/ContentGenerator.cs
@@ -32,4 +32,23 @@ public abstract class ContentGenerator
         entity.Id = GenerateId();
         return entity;
     }
+
+    /// <summary>
+    /// Helper method for a text body with rich text contents
+    /// </summary>
+    protected static TextBodyDbEntity CreateTextBody(string text, bool published = true)
+    {
+        var textBody = CreateComponent(new TextBodyDbEntity()
+        {
+            RichText = new RichTextContentDbEntity()
+            {
+                Data = new RichTextDataDbEntity() { Uri = "uri" },
+                Marks = [new RichTextMarkDbEntity() { Type = "Bold" }],
+                Value = text,
+                NodeType = "paragraph"
+            }
+        });
+        if (!published) textBody.Published = false;
+        return textBody;
+    }
 }

--- a/tests/Dfe.PlanTech.Web.SeedTestData/ContentGenerators/ContentGenerator.cs
+++ b/tests/Dfe.PlanTech.Web.SeedTestData/ContentGenerators/ContentGenerator.cs
@@ -48,7 +48,8 @@ public abstract class ContentGenerator
                 NodeType = "paragraph"
             }
         });
-        if (!published) textBody.Published = false;
+        if (!published)
+            textBody.Published = false;
         return textBody;
     }
 }

--- a/tests/Dfe.PlanTech.Web.SeedTestData/ContentGenerators/MissingDataCategory.cs
+++ b/tests/Dfe.PlanTech.Web.SeedTestData/ContentGenerators/MissingDataCategory.cs
@@ -119,7 +119,7 @@ public class MissingDataCategory(CmsDbContext db) : ContentGenerator
             Answers = [answer]
         });
 
-        var recommendationChunkNoHeader = CreateDraftComponent(new RecommendationChunkDbEntity()
+        var recommendationChunkBlankHeader = CreateDraftComponent(new RecommendationChunkDbEntity()
         {
             Content =
             [
@@ -134,23 +134,19 @@ public class MissingDataCategory(CmsDbContext db) : ContentGenerator
                     }
                 })
             ],
-            Answers = [answer]
+            Answers = [answer],
+            Header = ""
         });
         var recommendationChunkNoContent = CreateDraftComponent(new RecommendationChunkDbEntity()
         {
-            Header = CreateComponent(new HeaderDbEntity()
-            {
-                Text = "Recommendation Chunk with no content",
-                Tag = HeaderTag.H1,
-                Size = HeaderSize.Large
-            }),
+            Header = "Recommendation Chunk with no content",
             Answers = [answer]
         });
 
         var recommendationSection = CreateComponent(new RecommendationSectionDbEntity()
         {
             Answers = [],
-            Chunks = [recommendationChunkNoHeader, recommendationChunkNoContent]
+            Chunks = [recommendationChunkBlankHeader, recommendationChunkNoContent]
         });
 
         var subtopic = CreateComponent(new SectionDbEntity
@@ -191,7 +187,7 @@ public class MissingDataCategory(CmsDbContext db) : ContentGenerator
                 })
             ],
             Section = recommendationSection,
-            Subtopic = subtopic
+            Subtopic = subtopic,
         }));
 
         return subtopic;

--- a/tests/Dfe.PlanTech.Web.UnitTests/Models/ComponentBuilder.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Models/ComponentBuilder.cs
@@ -73,7 +73,7 @@ namespace Dfe.PlanTech.Web.UnitTests.Models
 
         public static RecommendationIntro BuildRecommendationIntro(string header) => new() { Header = new Header() { Text = header } };
 
-        public static RecommendationChunk BuildRecommendationChunk(string header, string title = "Title") => new() { Header = new Header() { Text = header } };
+        public static RecommendationChunk BuildRecommendationChunk(string header, string title = "Title") => new() { Header = header };
 
         private static List<Question> BuildQuestions()
         {

--- a/tests/Dfe.PlanTech.Web.UnitTests/Models/ComponentModelTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Models/ComponentModelTests.cs
@@ -92,6 +92,7 @@ namespace Dfe.PlanTech.Web.UnitTests.Models
             var recommendationIntro = ComponentBuilder.BuildRecommendationIntro(header);
 
             Assert.Equal(header, recommendationIntro.Header.Text);
+            Assert.Equal(header, recommendationIntro.HeaderText);
             Assert.Equal(expectedResult, recommendationIntro.SlugifiedHeader);
         }
 

--- a/tests/Dfe.PlanTech.Web.UnitTests/Routing/GetRecommendationRouterTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Routing/GetRecommendationRouterTests.cs
@@ -157,42 +157,27 @@ public class GetRecommendationRouterTests
             [
                 new()
                 {
-                    Header = new()
-                    {
-                        Text = "test-header-1"
-                    },
+                    Header = "test-header-1",
                     Answers = [AnswerOne]
                 },
                 new()
                 {
-                    Header = new()
-                    {
-                        Text = "test-header-2"
-                    },
+                    Header = "test-header-2",
                     Answers = [AnswerTwo]
                 },
                 new()
                 {
-                    Header = new()
-                    {
-                        Text = "test-header-3"
-                    },
+                    Header = "test-header-3",
                     Answers = [AnswerThree]
                 },
                 new()
                 {
-                    Header = new()
-                    {
-                        Text = "test-header-4"
-                    },
+                    Header = "test-header-4",
                     Answers = [AnswerFour]
                 },
                 new()
                 {
-                    Header = new()
-                    {
-                        Text = "test-header-5"
-                    },
+                    Header = "test-header-5",
                     Answers = [AnswerFive]
                 }
             ]

--- a/tests/Dfe.PlanTech.Web.UnitTests/ViewComponents/CategorySectionViewComponentTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/ViewComponents/CategorySectionViewComponentTests.cs
@@ -151,7 +151,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
                         return null;
                     }
 
-                    return new RecommendationsViewDto(introForMaturity.Slug, introForMaturity.Header.Text);
+                    return new RecommendationsViewDto(introForMaturity.Slug, introForMaturity.HeaderText);
                 });
 
             var viewContext = new ViewContext();
@@ -493,7 +493,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
             var recommendation = model.CategorySectionDto.First().Recommendation;
             Assert.NotNull(recommendation);
             Assert.Equal(_subtopic.Intros[0].Slug, recommendation.RecommendationSlug);
-            Assert.Equal(_subtopic.Intros[0].Header.Text, recommendation.RecommendationDisplayName);
+            Assert.Equal(_subtopic.Intros[0].HeaderText, recommendation.RecommendationDisplayName);
             Assert.Null(recommendation.NoRecommendationFoundErrorMessage);
         }
 
@@ -525,7 +525,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
 
             Assert.NotNull(_subtopic);
             Assert.Equal(_subtopic.Intros[0].Slug, recommendation.RecommendationSlug);
-            Assert.Equal(_subtopic.Intros[0].Header.Text, recommendation.RecommendationDisplayName);
+            Assert.Equal(_subtopic.Intros[0].HeaderText, recommendation.RecommendationDisplayName);
             Assert.Null(recommendation.NoRecommendationFoundErrorMessage);
             _loggerCategory.ReceivedWithAnyArgs(1).LogError("An exception has occurred while trying to retrieve section progress with the following message - test");
         }
@@ -616,7 +616,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
             var recommendation = model.CategorySectionDto.First().Recommendation;
             Assert.NotNull(recommendation);
             Assert.Equal(_subtopic.Intros[0].Slug, recommendation.RecommendationSlug);
-            Assert.Equal(_subtopic.Intros[0].Header.Text, recommendation.RecommendationDisplayName);
+            Assert.Equal(_subtopic.Intros[0].HeaderText, recommendation.RecommendationDisplayName);
             Assert.Null(recommendation.NoRecommendationFoundErrorMessage);
         }
     }


### PR DESCRIPTION
## Overview

Addresses ticket [#226338](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/226338)

Changes RecommendationChunks to have a short text field for Headers instead of a separate Header content type. This is to simplify the creation process for content designers

## Changes

### Major

- RecommendationChunk no longer has a linked Header, but a text field for the Header
- Creates the groundwork for doing contentful migrations programatically, manual at the moment

### Minor

- Added some content to the seeded test db for running the database script and testing this locally
- Changes IHeaderWithContent to have a `HeaderText` field instead of `Header` so that both `RecommendationIntro` with a separate header, and `RecommendationChunk` with a text base one can inherit from it
  - I considered a few different ways to go about this, such as having only the intro inherit from it, and treating chunks and intros separately, but it didn't work particularly well so I think this is the better of the options

## How to review the PR

The column has already been added to the database in dev (but the id column not removed) so this should run locally already 

The seeded test database can also be used to check that the change is working, headers have been added of the new style to the connectivity test category

The migration script can be tested before its run across dev by
- Go to contentful
- Duplicate the Recommendation Chunk content type
- Update the migration script and change `content_type` to your test content type
- Add some chunks with your duplicated type
- Run the migration script following the readme instructions
- Verify that your chunks of the duplicated type have swapped linked headers for text headers

## Release requirements

The contentful migration script will need to be run manually just after the code merges.
This will transform all the recommendation chunks, but it won't delete the old headers. the headers also need removing

I'm looking into the best solution to that. The contentful-migration cli does not support deleting entries but the contentful-management one does. They don't go together particularly well so this may have to be a separate setup. 

## Checklist

- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch
- [ ] Unit tests have been added/updated
- [ ] E2E tests have been added/updated
- [ ] Documentation has been updated where relevant
