### PR TITLE
Fix timezone for recommendation print page

### DIFF
--- a/plan-technology-for-your-school.sln
+++ b/plan-technology-for-your-school.sln
@@ -41,6 +41,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dfe.ContentSupport.Web", "c
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dfe.PlanTech.Web.SeedTestData", "tests\Dfe.PlanTech.Web.SeedTestData\Dfe.PlanTech.Web.SeedTestData.csproj", "{0E05B7CD-6CDC-41EE-89BB-AE415A359085}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dfe.PlanTech.Domain.UnitTests", "tests\Dfe.PlanTech.Domain.UnitTests\Dfe.PlanTech.Domain.UnitTests.csproj", "{199DF118-68E9-42D6-ABB2-47FCC9BFD515}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -115,6 +117,10 @@ Global
 		{902F3AA9-FF2C-4D89-98F2-74467B043BA0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{902F3AA9-FF2C-4D89-98F2-74467B043BA0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{902F3AA9-FF2C-4D89-98F2-74467B043BA0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{199DF118-68E9-42D6-ABB2-47FCC9BFD515}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{199DF118-68E9-42D6-ABB2-47FCC9BFD515}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{199DF118-68E9-42D6-ABB2-47FCC9BFD515}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{199DF118-68E9-42D6-ABB2-47FCC9BFD515}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -136,6 +142,7 @@ Global
 		{B82ED911-FFCD-4EFF-BD9E-405394811F13} = {33DA2E55-0921-4BEA-A7F4-96CC77F09928}
 		{66E92A5E-5C8A-4245-A55F-087FE2D96EEF} = {33DA2E55-0921-4BEA-A7F4-96CC77F09928}
 		{0E05B7CD-6CDC-41EE-89BB-AE415A359085} = {33DA2E55-0921-4BEA-A7F4-96CC77F09928}
+		{199DF118-68E9-42D6-ABB2-47FCC9BFD515} = {33DA2E55-0921-4BEA-A7F4-96CC77F09928}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2661FAF0-D2EA-4265-846E-E6AB213C854C}

--- a/src/Dfe.PlanTech.Domain/CategorySection/CategorySectionDto.cs
+++ b/src/Dfe.PlanTech.Domain/CategorySection/CategorySectionDto.cs
@@ -51,7 +51,7 @@ public class CategorySectionDto
     {
         if (date == null)
             return null;
-        var localTime = systemTime.ToUkTime(date.Value);
+        var localTime = TimeZoneHelpers.ToUkTime(date.Value);
         return localTime.Date == systemTime.Today.Date
             ? DateTimeFormatter.FormattedTime(localTime)
             : DateTimeFormatter.FormattedDateShort(localTime);

--- a/src/Dfe.PlanTech.Domain/CategorySection/CategorySectionDto.cs
+++ b/src/Dfe.PlanTech.Domain/CategorySection/CategorySectionDto.cs
@@ -1,4 +1,5 @@
 using Dfe.PlanTech.Domain.Constants;
+using Dfe.PlanTech.Domain.Helpers;
 using Dfe.PlanTech.Domain.Interfaces;
 using Dfe.PlanTech.Domain.Questionnaire.Models;
 using Dfe.PlanTech.Domain.Submissions.Models;
@@ -50,8 +51,9 @@ public class CategorySectionDto
     {
         if (date == null)
             return null;
-        var britishTimeZone = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
-        var localTime = TimeZoneInfo.ConvertTimeFromUtc(date.Value, britishTimeZone);
-        return localTime.Date == systemTime.Today.Date ? $"{localTime:h:mmtt}".ToLower() : $"{localTime:d MMM yyyy}";
+        var localTime = systemTime.ToUkTime(date.Value);
+        return localTime.Date == systemTime.Today.Date
+            ? DateTimeFormatter.FormattedTime(localTime)
+            : DateTimeFormatter.FormattedDateShort(localTime);
     }
 }

--- a/src/Dfe.PlanTech.Domain/Helpers/DateTimeFormatter.cs
+++ b/src/Dfe.PlanTech.Domain/Helpers/DateTimeFormatter.cs
@@ -1,0 +1,10 @@
+namespace Dfe.PlanTech.Domain.Helpers;
+
+public static class DateTimeFormatter
+{
+    public static string FormattedTime(DateTime dateTime) => $"{dateTime:h:mmtt}".ToLower();
+
+    public static string FormattedDateLong(DateTime dateTime) => $"{dateTime:d MMMM yyyy}";
+
+    public static string FormattedDateShort(DateTime dateTime) => $"{dateTime:d MMM yyyy}";
+}

--- a/src/Dfe.PlanTech.Domain/Helpers/SystemTime.cs
+++ b/src/Dfe.PlanTech.Domain/Helpers/SystemTime.cs
@@ -7,4 +7,13 @@ public class SystemTime : ISystemTime
     public DateTime Now => DateTime.Now;
 
     public DateTime Today => DateTime.Today;
+
+    public DateTime UkNow => ToUkTime(DateTime.UtcNow);
+
+    public DateTime ToUkTime(DateTime utcDateTime)
+    {
+        var britishTimeZone = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
+        var localTime = TimeZoneInfo.ConvertTimeFromUtc(utcDateTime, britishTimeZone);
+        return localTime;
+    }
 }

--- a/src/Dfe.PlanTech.Domain/Helpers/SystemTime.cs
+++ b/src/Dfe.PlanTech.Domain/Helpers/SystemTime.cs
@@ -4,7 +4,7 @@ namespace Dfe.PlanTech.Domain.Helpers;
 
 public class SystemTime : ISystemTime
 {
-    public DateTime Today => DateTime.Today;
+    public DateTime Today => UkNow.Date;
 
     public DateTime UkNow => TimeZoneHelpers.ToUkTime(DateTime.UtcNow);
 }

--- a/src/Dfe.PlanTech.Domain/Helpers/SystemTime.cs
+++ b/src/Dfe.PlanTech.Domain/Helpers/SystemTime.cs
@@ -4,16 +4,7 @@ namespace Dfe.PlanTech.Domain.Helpers;
 
 public class SystemTime : ISystemTime
 {
-    public DateTime Now => DateTime.Now;
-
     public DateTime Today => DateTime.Today;
 
-    public DateTime UkNow => ToUkTime(DateTime.UtcNow);
-
-    public DateTime ToUkTime(DateTime utcDateTime)
-    {
-        var britishTimeZone = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
-        var localTime = TimeZoneInfo.ConvertTimeFromUtc(utcDateTime, britishTimeZone);
-        return localTime;
-    }
+    public DateTime UkNow => TimeZoneHelpers.ToUkTime(DateTime.UtcNow);
 }

--- a/src/Dfe.PlanTech.Domain/Helpers/TimeZoneHelpers.cs
+++ b/src/Dfe.PlanTech.Domain/Helpers/TimeZoneHelpers.cs
@@ -1,0 +1,11 @@
+namespace Dfe.PlanTech.Domain.Helpers;
+
+public static class TimeZoneHelpers
+{
+    public static DateTime ToUkTime(DateTime utcDateTime)
+    {
+        var britishTimeZone = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
+        var localTime = TimeZoneInfo.ConvertTimeFromUtc(utcDateTime, britishTimeZone);
+        return localTime;
+    }
+}

--- a/src/Dfe.PlanTech.Domain/Interfaces/ISystemTime.cs
+++ b/src/Dfe.PlanTech.Domain/Interfaces/ISystemTime.cs
@@ -2,11 +2,7 @@ namespace Dfe.PlanTech.Domain.Interfaces;
 
 public interface ISystemTime
 {
-    public DateTime Now { get; }
-
     public DateTime Today { get; }
 
     public DateTime UkNow { get; }
-
-    public DateTime ToUkTime(DateTime utcDateTime);
 }

--- a/src/Dfe.PlanTech.Domain/Interfaces/ISystemTime.cs
+++ b/src/Dfe.PlanTech.Domain/Interfaces/ISystemTime.cs
@@ -5,4 +5,8 @@ public interface ISystemTime
     public DateTime Now { get; }
 
     public DateTime Today { get; }
+
+    public DateTime UkNow { get; }
+
+    public DateTime ToUkTime(DateTime utcDateTime);
 }

--- a/src/Dfe.PlanTech.Web/Views/Recommendations/RecommendationsChecklist.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/RecommendationsChecklist.cshtml
@@ -1,7 +1,11 @@
+@using Dfe.PlanTech.Domain.Helpers
+@using Dfe.PlanTech.Domain.Interfaces
 @model Dfe.PlanTech.Web.Models.RecommendationsChecklistViewModel
+@inject ISystemTime systemTime
 
 @{
     Layout = "_PrintLayout";
+    var currentTime = systemTime.UkNow;
 }
 
 <div class="govuk-grid-row" id="top">
@@ -11,7 +15,7 @@
             <p class="govuk-body">Plan technology for your school</p>
         </div>
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible"/>
-        <p class="govuk-!-margin-top-4 govuk-body" id="printed-date-time">Date and time this document was printed: @($"{DateTime.Now:ddd MMM yyyy HH:mm:ss zzz}")</p>
+        <p class="govuk-!-margin-top-4 govuk-body" id="printed-date-time">Date and time this document was printed: @($"{DateTimeFormatter.FormattedDateLong(currentTime)} at {DateTimeFormatter.FormattedTime(currentTime)}")</p>
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible"/>
         <partial name="RecommendationPrintContent" model="@Model.AllContent"/>
     </div>

--- a/tests/Dfe.PlanTech.Domain.UnitTests/Dfe.PlanTech.Domain.UnitTests.csproj
+++ b/tests/Dfe.PlanTech.Domain.UnitTests/Dfe.PlanTech.Domain.UnitTests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+        <PackageReference Include="xunit" Version="2.5.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Dfe.PlanTech.Domain\Dfe.PlanTech.Domain.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Dfe.PlanTech.Domain.UnitTests/Helpers/DateTimeFormatterTests.cs
+++ b/tests/Dfe.PlanTech.Domain.UnitTests/Helpers/DateTimeFormatterTests.cs
@@ -1,0 +1,35 @@
+using System.Globalization;
+using Dfe.PlanTech.Domain.Helpers;
+
+namespace Dfe.PlanTech.Domain.UnitTests.Helpers;
+
+public class DateTimeFormatterTests
+{
+    [Theory]
+    [InlineData("2015/10/15 10:35:00", "10:35am")]
+    [InlineData("2015/10/15 09:35:00", "9:35am")]
+    [InlineData("2015/10/15 14:20:00", "2:20pm")]
+    public void FormattedTime_Should_Display_Correctly(string inputDate, string expected)
+    {
+        var dateTime = DateTime.Parse(inputDate, new CultureInfo("en-GB"));
+        Assert.Equal(expected, DateTimeFormatter.FormattedTime(dateTime));
+    }
+
+    [Theory]
+    [InlineData("2015/09/15", "15 September 2015")]
+    [InlineData("2020/01/09", "9 January 2020")]
+    public void FormattedDateLong_Should_Display_Correctly(string inputDate, string expected)
+    {
+        var dateTime = DateTime.Parse(inputDate, new CultureInfo("en-GB"));
+        Assert.Equal(expected, DateTimeFormatter.FormattedDateLong(dateTime));
+    }
+
+    [Theory]
+    [InlineData("2015/09/15", "15 Sep 2015")]
+    [InlineData("2020/01/09", "9 Jan 2020")]
+    public void FormattedDateShort_Should_Display_Correctly(string inputDate, string expected)
+    {
+        var dateTime = DateTime.Parse(inputDate, new CultureInfo("en-GB"));
+        Assert.Equal(expected, DateTimeFormatter.FormattedDateShort(dateTime));
+    }
+}

--- a/tests/Dfe.PlanTech.Domain.UnitTests/Helpers/TimeZoneHelpersTests.cs
+++ b/tests/Dfe.PlanTech.Domain.UnitTests/Helpers/TimeZoneHelpersTests.cs
@@ -1,0 +1,18 @@
+using System.Globalization;
+using Dfe.PlanTech.Domain.Helpers;
+
+namespace Dfe.PlanTech.Domain.UnitTests.Helpers;
+
+public class TimeZoneHelpersTests
+{
+    [Theory]
+    [InlineData("2015/11/15 10:30:00", "2015/11/15 10:30:00")]
+    [InlineData("2020/06/10 10:30:00", "2020/06/10 11:30:00")] // BST
+    [InlineData("2020/06/10 23:59:00", "2020/06/11 00:59:00")] // BST
+    public void ToUkTime_Should_Convert_Utc_Time_Correctly(string inputDate, string ukTime)
+    {
+        var dateTime = DateTime.Parse(inputDate, new CultureInfo("en-GB"));
+        var expected = DateTime.Parse(ukTime, new CultureInfo("en-GB"));
+        Assert.Equal(expected, TimeZoneHelpers.ToUkTime(dateTime));
+    }
+}

--- a/tests/Dfe.PlanTech.Web.UnitTests/ViewComponents/CategorySectionViewComponentTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/ViewComponents/CategorySectionViewComponentTests.cs
@@ -213,7 +213,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
         [InlineData("2015/10/16 12:13:00", "last completed 1:13pm")] // British summer time GMT + 1
         public async Task Returns_CategorySectionInfo_If_Slug_Exists_And_SectionIsCompleted(string utcTime, string expectedBadge)
         {
-            _systemTime.Today.Returns(_ => new DateTime(2015, 10, 16));
+            _systemTime.Today.Returns(_ => new DateTime(2015, 10, 16, 0, 0, 0, DateTimeKind.Utc));
             _category.SectionStatuses.Add(new SectionStatusDto()
             {
                 SectionId = "Section1",
@@ -260,7 +260,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
         [InlineData("2015/03/06 10:13:00", "in progress 10:13am")] // GMT
         public async Task Returns_CategorySelectionInfo_If_Slug_Exists_And_SectionIsNotCompleted(string utcTime, string expectedBadge)
         {
-            _systemTime.Today.Returns(_ => new DateTime(2015, 3, 6));
+            _systemTime.Today.Returns(_ => new DateTime(2015, 3, 6, 0, 0, 0, DateTimeKind.Utc));
             _category.Completed = 0;
 
             _category.SectionStatuses.Add(new SectionStatusDto()


### PR DESCRIPTION
## Overview

Addresses ticket [#228152](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/228152)

Fixes a bug where the time on the recommendations printout is one hour behind

## Changes

### Minor

- Add some shared formatting methods that can be reused by other times to encourage consistency
  - based off the govuk date guidance and requirements on ticket https://www.gov.uk/guidance/style-guide/a-to-z#dates
- Add a UkNow property to the system time helper that does the conversion

## How to review the PR

Check format is correct as per ticket and that time is showing correctly

## Checklist

- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch