### PR TITLE
Fix: Add middleware to handle head requests

### DIFF
--- a/src/Dfe.PlanTech.Web/Middleware/HeadRequestMiddleware.cs
+++ b/src/Dfe.PlanTech.Web/Middleware/HeadRequestMiddleware.cs
@@ -1,0 +1,29 @@
+namespace Dfe.PlanTech.Web.Middleware;
+
+/// <summary>
+/// Middleware to handle head requests automatically
+/// </summary>
+public class HeadRequestMiddleware(RequestDelegate next)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        await HandleHeadRequests(context);
+    }
+
+    /// <summary>
+    /// Strip out the body for any Head Requests
+    /// </summary>
+    private async Task HandleHeadRequests(HttpContext context)
+    {
+        if (context.Request.Method == HttpMethod.Head.Method)
+        {
+            context.Request.Method = HttpMethod.Get.Method;
+            await next(context);
+            context.Response.Body = Stream.Null;
+        }
+        else
+        {
+            await next(context);
+        }
+    }
+}

--- a/src/Dfe.PlanTech.Web/Program.cs
+++ b/src/Dfe.PlanTech.Web/Program.cs
@@ -96,6 +96,7 @@ builder.Services.AddTransient<IUserJourneyMissingContentExceptionHandler, UserJo
 var app = builder.Build();
 
 app.UseSecurityHeaders();
+app.UseMiddleware<HeadRequestMiddleware>();
 
 app.UseCookiePolicy(
     new CookiePolicyOptions

--- a/tests/Dfe.PlanTech.Web.UnitTests/Middleware/HeadRequestMiddlewareTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Middleware/HeadRequestMiddlewareTests.cs
@@ -1,0 +1,52 @@
+using Dfe.PlanTech.Web.Middleware;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Dfe.PlanTech.Web.UnitTests.Middleware;
+
+public class HeadRequestMiddlewareTests
+{
+    private static async Task _next(HttpContext hc)
+    {
+        hc.Response.StatusCode = StatusCodes.Status200OK;
+        await hc.Response.WriteAsync("Response Body");
+    }
+
+    [Fact]
+    public async Task Head_Requests_Should_Return_200_With_No_Body()
+    {
+        var context = new DefaultHttpContext()
+        {
+            Request = { Method = HttpMethods.Head },
+            Response = { Body = new MemoryStream() }
+        };
+
+        var middleware = new HeadRequestMiddleware(_next);
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(200, context.Response.StatusCode);
+        Assert.Equal(0, context.Response.Body.Length);
+        Assert.Same(Stream.Null, context.Response.Body);
+    }
+
+    [Fact]
+    public async Task Get_Requests_Should_Not_Have_Body_Removed()
+    {
+        var context = new DefaultHttpContext()
+        {
+            Request = { Method = HttpMethods.Get },
+            Response = { Body = new MemoryStream() }
+        };
+
+        var middleware = new HeadRequestMiddleware(_next);
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal(200, context.Response.StatusCode);
+        Assert.NotEqual(0, context.Response.Body.Length);
+
+        context.Response.Body.Seek(0, SeekOrigin.Begin);
+        var response = await new StreamReader(context.Response.Body).ReadToEndAsync();
+
+        Assert.Equal("Response Body", response);
+    }
+}


### PR DESCRIPTION
## Overview

Addresses ticket [#228843](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/228843)

Adds middleware to automatically handle head requests

## Changes

### Minor

- New middleware that treats HEAD requests as GET requests but strips out the body. This saves us adding it to every single controller method

## How to review the PR

To test you can:
- use postman 
- or open the network tab and after fetching a page, right click the request, "copy as fetch", and change the method to "HEAD"
- The CSP was making life difficult when testing with postman so I commented it out for local testing

## Checklist

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [x] Unit tests have been added/updated
