### PR TITLE
docs: ADR for sql caching

### DIFF
--- a/docs/adr/0038-sql-caching-mechanism.md
+++ b/docs/adr/0038-sql-caching-mechanism.md
@@ -50,4 +50,4 @@ The connection happens regardless of whether the results are cached, which limit
 
 ## Decision Outcome
 
-TBC
+Option 2. Testing this in a spike has been a success and as the complexity is fairly low, it's worthwhile to make this switch.

--- a/docs/adr/0038-sql-caching-mechanism.md
+++ b/docs/adr/0038-sql-caching-mechanism.md
@@ -1,0 +1,53 @@
+# 0038 - SQL Caching Mechanism
+
+* **Status**: proposed
+
+## Context and Problem Statement
+
+We currently use EFCoreSecondLevelCache to cache database calls.
+This caches the results for EF commands so the same command doesn't need executing again.
+However we discovered during load testing that this still makes a connection to the database before returning the cached results:
+
+A standard call with debugging logs enabled looks like this:
+- Opened a connection to database ...
+- Creating DbCommand for 'ExecuteReader'
+- Executing DbCommand
+- EFCoreSecondLevelCacheInterceptor suppressed the result with TableRows from the cache
+- Returning the cached TableRows
+- Closing data reader
+- A data reader is disposed after spending 0ms reading results
+- Closing connection to database
+- Closed connection to database
+
+The connection happens regardless of whether the results are cached, which limits the number of concurrent calls that can be made. We're therefore considering alternatives.
+
+## Decision Drivers
+
+- Ease of development
+- Reliability of the solution
+- Scalability of the solution
+
+## Considered Options
+
+### Continue using EFCoreSecondLevelCache
+
+- Pros
+    - No code changes
+    - Its a popular external library that reliably does the bulk of what we need
+- Cons
+    - Unnecessary database connections made for every query
+    - Since we don't make changes to the CMS data, we don't need the query tracking for these tables that EFCoreSecondLevelCache includes
+
+### Implement our own caching mechanism
+
+- Pros
+    - Gives us the most flexibility, and guarantees solving the problem
+    - Allows us to add in additional options like query compiling for improved performance
+    - Forces us to make all fetching of queryable results consistent
+    - As we don't require cache invalidation, the complexity is relatively low
+- Cons
+    - Relies on remembering to use the cached methods or extensions for the CMSDBContext and not the default ones
+
+## Decision Outcome
+
+TBC


### PR DESCRIPTION
## Overview

Addresses ticket [#224828](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/224828)

Adds an ADR doc for our approach to SQL caching

## How to review the PR

Please read through the ADR and comment on anything that doesn't make sense or needs more information, and approve if you're happy with the ADR outcome

## Spike notes

I've tested using a custom cache on a [temp branch](https://github.com/DFE-Digital/sts-plan-technology-for-your-school/tree/temp/sql-cache-spike) (the code is all experimental and needs tidying - but will be somewhat similar to this) and it worked successfully. I:
- ran the script to create a seeded test database
- ran plan tech against it and started all the subtopics
- severed the connection to the database
- refreshed the page of each subtopic and they all successfully loaded from the cache without making another connection

This doesn't work for the self assessment page as this loads data from the dbo tables related to user submissions which we won't be caching (and already don't) but for content only its stopped the unnecessary connections, so in particular, won't be making excess calls on the landing page anymore. It didn't take too much to add this so it seems worthwhile to do

## Checklist

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [x] Documentation has been updated where relevant
