### PR TITLE
fix: set type hidden to improve accessibility of hidden inputs

### DIFF
--- a/src/Dfe.PlanTech.Web/Views/Questions/Question.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Questions/Question.cshtml
@@ -9,11 +9,11 @@
 
 <form asp-controller="Questions" asp-action="SubmitAnswer" asp-route-sectionSlug=@Model.SectionSlug
     asp-route-questionSlug=@Model.Question.Slug method="post">
-    <input id="QuestionText" hidden value="@Model.Question.Text" name="QuestionText" />
-    <input id="QuestionId" hidden value=@Model.Question.Sys.Id name="QuestionId" />
-    <input id="SectionId" hidden value="@Model.SectionId" name="SectionId" />
-    <input id="SectionName" hidden value="@Model.SectionName" name="SectionName" />
-    
+    <input id="QuestionText" type="hidden" value="@Model.Question.Text" name="QuestionText" />
+    <input id="QuestionId" type="hidden" value=@Model.Question.Sys.Id name="QuestionId" />
+    <input id="SectionId" type="hidden" value="@Model.SectionId" name="SectionId" />
+    <input id="SectionName" type="hidden" value="@Model.SectionName" name="SectionName" />
+
     <govuk-radios name="ChosenAnswerJson">
         <govuk-radios-fieldset>
             <govuk-radios-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">


### PR DESCRIPTION
## Overview

Addresses ticket [#229447](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/229447)

Changes `hidden` to `type="hidden"` to improve accessibility of hidden inputs. The latter is designed for inputs with form data not visible to the user, whilst the former is just for hiding an element, which was still showing up for accessibility tools

## How to review the PR

Elements should still be hidden

## Checklist

- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch
