### PR TITLE
Fix e2e login following DfE signin update

### DIFF
--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/commands/login.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/commands/login.js
@@ -7,14 +7,14 @@ Cypress.Commands.add("login", ({ email, password, url }) => {
         // failing the test
         return false
     });
-    
+
   cy.visit(url);
   cy.get("input#username").type(email);
-  cy.get("div.govuk-button-group button.govuk-button").first().click();
+  cy.get("button.govuk-button").first().click();
   cy.get("input#password", { timeout: 4000 }).type(password);
     cy.get("div.govuk-button-group button.govuk-button").first().click();
     cy.wait(4000);
-}); 
+});
 
 /**
  * Login to DFE using values from the environment variables


### PR DESCRIPTION
## Overview

DfE SignIn has changed slightly and the button between email & password is not in the form group it was before, this accounts for that and fixes the tests

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [x] E2E tests have been added/updated
