### PR TITLE
fix: Application insights ordering

### DIFF
--- a/src/Dfe.PlanTech.Web/Program.cs
+++ b/src/Dfe.PlanTech.Web/Program.cs
@@ -26,20 +26,21 @@ if (builder.Environment.EnvironmentName != "E2E")
     builder.Services.AddDbWriterServices(builder.Configuration);
 }
 
+builder.Services.AddCustomTelemetry();
+
 builder.AddContentAndSupportServices()
-    .AddAuthorisationServices()
-    .AddCaching()
-    .AddContentfulServices(builder.Configuration)
-    .AddCQRSServices()
-    .AddCspConfiguration()
-    .AddCustomTelemetry()
-    .AddDatabase(builder.Configuration)
-    .AddDfeSignIn(builder.Configuration)
-    .AddExceptionHandlingServices()
-    .AddGoogleTagManager()
-    .AddGovUkFrontend()
-    .AddHttpContextAccessor()
-    .AddRoutingServices();
+        .AddAuthorisationServices()
+        .AddCaching()
+        .AddContentfulServices(builder.Configuration)
+        .AddCQRSServices()
+        .AddCspConfiguration()
+        .AddDatabase(builder.Configuration)
+        .AddDfeSignIn(builder.Configuration)
+        .AddExceptionHandlingServices()
+        .AddGoogleTagManager()
+        .AddGovUkFrontend()
+        .AddHttpContextAccessor()
+        .AddRoutingServices();
 
 builder.Services.AddSingleton<ISystemTime, SystemTime>();
 


### PR DESCRIPTION
## Overview

Fixes issue with Application Insights no longer working due to incorrect ordering of services injection.

## Changes

### Minor

- Add Application Insights services first

## How to review the PR

1. Run the latest dev version of the web app
2. Load a web page
3. Check the program output - look for any instance of `Application Insights Telemetry`. There should be none
4. Run the web app from this PR
5. Load a web page
6. Check the program output - ensure that there are instances of `Application Insights Telemetry` logged

Note: if it says `unconfigured` - that's because you're missing the environment variables for the connection string and the instrumentation key. Not a problem once actually deployed, but if you want to actually test it fully let me know and I'll provide the rest of details.

## Checklist

Delete any rows that do not apply to the PR.

- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch