### PR TITLE
fix: Handle page retrieval errors when retrieving a page from DB

### DIFF
--- a/src/Dfe.PlanTech.Application/Content/Queries/GetPageFromDbQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetPageFromDbQuery.cs
@@ -77,7 +77,7 @@ public class GetPageFromDbQuery : IGetPageQuery
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error fetching {page} from database", slug);
-            throw new InvalidOperationException("Error while fetching page from database", ex);
+            return null;
         }
     }
 


### PR DESCRIPTION
## Overview

If there is an exception thrown when retrieving a page from the DB, we re-throw another exception. This isn't caught higher up, and results in an error page for the user.

This change handles the thrown exception, meaning that the app then requests the page from Contentful instead as it should.

## Changes

### Minor

- Handle exceptions thrown by retrieving page from DB, ensuring failures are retrieving from Contentful instead

## How to review the PR

### Existing functionality

1. Ensure you cannot access the SQL DB locally (e.g. remove yourself from the network IP whitelist on the SQL server)
2. Run the web app locally - open the index page (e.g. `https://localhost:8080/`)
3. You should get an error page; verify that a request to Contentful has not been executed in the logs

### Testing fix

1. Keep the SQL server disabled as per the existing functionality
2. Run the web app locally - open the index page (e.g. `https://localhost:8080/`)
3. The page should load correctly - verify it was loaded from Contentful in the logs

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [ ] Unit tests have been added/updated