### PR TITLE
fix: Open C&S links in same tab

### DIFF
--- a/src/Dfe.PlanTech.Web/Views/Recommendations/RecommendationContent.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/RecommendationContent.cshtml
@@ -26,7 +26,7 @@
                     @if (headerWithContent is RecommendationChunk chunk && chunk.CSLink != null)
                     {
                         <div class="govuk-!-margin-top-3 govuk-!-margin-bottom-9">
-                            <a class="govuk-body govuk-link govuk-!-font-weight-bold" href=@chunk.CSLink.Url target="_blank">
+                            <a class="govuk-body govuk-link govuk-!-font-weight-bold" href=@chunk.CSLink.Url>
                                 @chunk.CSLink.LinkText
                             </a>
                         </div>


### PR DESCRIPTION
## Overview

Amends C&S links to open in same tab.

## Changes

### Minor

- Amends C&S links to open in same tab

## Additional notes

Doesn't fix all accessibility problems, but fixes something that was agreed upon.

## Checklist

Delete any rows that do not apply to the PR.

- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch