### PR TITLE
Fix: Caching not attaching entities

### DIFF
--- a/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
@@ -252,14 +252,18 @@ public class CmsDbContext : DbContext, ICmsDbContext
     public async Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
     {
         var key = GetCacheKey(queryable);
-        return await _queryCacher.GetOrCreateAsyncWithCache(key, queryable,
+        var result = await _queryCacher.GetOrCreateAsyncWithCache(key, queryable,
             (q, ctoken) => q.ToListAsync(ctoken), cancellationToken);
+        result.Where(entity => entity is not null).ToList().ForEach(entity => base.Attach(entity!));
+        return result;
     }
 
     public async Task<T?> FirstOrDefaultAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default)
     {
         var key = GetCacheKey(queryable);
-        return await _queryCacher.GetOrCreateAsyncWithCache(key, queryable,
+        var result = await _queryCacher.GetOrCreateAsyncWithCache(key, queryable,
             (q, ctoken) => q.FirstOrDefaultAsync(ctoken), cancellationToken);
+        if (result is not null) base.Attach(result);
+        return result;
     }
 }

--- a/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Data/CmsDbContext.cs
@@ -263,7 +263,8 @@ public class CmsDbContext : DbContext, ICmsDbContext
         var key = GetCacheKey(queryable);
         var result = await _queryCacher.GetOrCreateAsyncWithCache(key, queryable,
             (q, ctoken) => q.FirstOrDefaultAsync(ctoken), cancellationToken);
-        if (result is not null) base.Attach(result);
+        if (result is not null)
+            base.Attach(result);
         return result;
     }
 }


### PR DESCRIPTION
## Overview

Fixes a bug where loading page children from the db after retrieving the page from the cache fails to attach the children to the parent page

## Changes

### Minor

- The `FirstOrDefaultAsync` and `ToListAsync` methods now attach entities after retrieval so that EF core can work its magic behind the scenes to attach children as they are retrieved later

## How to review the PR

To replicate the bug on development:
1. Put a breakpoint after `var page = await GetPageFromDb(slug, cancellationToken);` in `GetPageFromDbQuery.cs`
2. Debug PT locally
3. Load the start page (`/`) and after getting the page from the db is done, cancel the page load
4. wait a few seconds
5. Start another start page load, and let the debugger continue
6. This loads the page in another query, hence getting it from the cache, but the children come straight out the db
7. The headers all load, but the content between them doesn't

This should no longer be the case on this branch

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [ ] Unit tests have been added/updated
