### PR TITLE
fix: Page children retrieval

### DIFF
--- a/src/Dfe.PlanTech.Application/Content/Queries/GetButtonWithEntryReferencesQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetButtonWithEntryReferencesQuery.cs
@@ -58,14 +58,14 @@ public class GetButtonWithEntryReferencesQuery(ICmsDbContext db, ILogger<GetButt
     {
         var buttonWithEntryReferences = db.ButtonWithEntryReferences.Where(button => button.ContentPages.Any(contentPage => contentPage.Id == page.Id));
 
-        var pageButtons = db.Pages.Where(p => buttonWithEntryReferences.Any(button => button.LinkToEntryId == p.Id))
+        var linkedPages = db.Pages.Where(p => buttonWithEntryReferences.Any(button => button.LinkToEntryId == p.Id))
                                     .Select(p => new
                                     {
                                         p.Id,
                                         p.Slug
                                     });
 
-        var questionButtons = db.Questions.Where(question => buttonWithEntryReferences.Any(button => button.LinkToEntryId == page.Id))
+        var linkedQuestions = db.Questions.Where(question => buttonWithEntryReferences.Any(button => button.LinkToEntryId == page.Id))
                                             .Select(q => new
                                             {
                                                 q.Id,
@@ -75,14 +75,12 @@ public class GetButtonWithEntryReferencesQuery(ICmsDbContext db, ILogger<GetButt
         return buttonWithEntryReferences.Select(button => new
         {
             button.Id,
-            page = pageButtons.FirstOrDefault(pageButton => pageButton.Id == button.Id),
-            question = questionButtons.FirstOrDefault(quesionButton => quesionButton.Id == button.Id),
+            page = linkedPages.FirstOrDefault(pageForButton => pageForButton.Id == button.LinkToEntryId),
+            question = linkedQuestions.FirstOrDefault(questionForButton => questionForButton.Id == button.LinkToEntryId),
         }).Select(button => new ButtonWithEntryReferenceDbEntity
         {
             Id = button.Id,
-            LinkToEntry = button.page != null ?
-                            new PageDbEntity() { Slug = button.page.Slug } :
-                            new QuestionDbEntity() { Slug = button.question!.Slug }
+            LinkToEntry = button.page != null ? new PageDbEntity { Slug = button.page.Slug } : new QuestionDbEntity { Slug = button.question!.Slug }
         });
     }
 }

--- a/src/Dfe.PlanTech.Application/Content/Queries/GetCategorySectionsQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetCategorySectionsQuery.cs
@@ -45,8 +45,7 @@ public class GetCategorySectionsQuery(ICmsDbContext db, ILogger<GetCategorySecti
 
         foreach (var cat in sectionsGroupedByCategory)
         {
-            var matching = page.Content.OfType<CategoryDbEntity>()
-                                        .FirstOrDefault(category => category != null && category.Id == cat.Key);
+            var matching = page.Content.OfType<CategoryDbEntity>().FirstOrDefault(category => category.Id == cat.Key);
 
             if (matching == null)
             {
@@ -54,7 +53,7 @@ public class GetCategorySectionsQuery(ICmsDbContext db, ILogger<GetCategorySecti
                 continue;
             }
 
-            bool sectionsValid = AllSectionsValid(sections);
+            var sectionsValid = AllSectionsValid(sections);
 
             if (!sectionsValid)
             {

--- a/src/Dfe.PlanTech.Application/Content/Queries/GetPageFromDbQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetPageFromDbQuery.cs
@@ -7,21 +7,13 @@ using Microsoft.Extensions.Logging;
 
 namespace Dfe.PlanTech.Application.Content.Queries;
 
-public class GetPageFromDbQuery : IGetPageQuery
+public class GetPageFromDbQuery(
+    ICmsDbContext db,
+    ILogger<GetPageFromDbQuery> logger,
+    IMapper mapperConfiguration,
+    IEnumerable<IGetPageChildrenQuery> getPageChildrenQueries)
+    : IGetPageQuery
 {
-    private readonly ICmsDbContext _db;
-    private readonly ILogger<GetPageFromDbQuery> _logger;
-    private readonly IMapper _mapperConfiguration;
-    private readonly IEnumerable<IGetPageChildrenQuery> _getPageChildrenQueries;
-
-    public GetPageFromDbQuery(ICmsDbContext db, ILogger<GetPageFromDbQuery> logger, IMapper mapperConfiguration, IEnumerable<IGetPageChildrenQuery> getPageChildrenQueries)
-    {
-        _db = db;
-        _logger = logger;
-        _mapperConfiguration = mapperConfiguration;
-        _getPageChildrenQueries = getPageChildrenQueries;
-    }
-
     /// <summary>
     /// Fetches page from <see cref="ICmsDbContext"/> by slug
     /// </summary>
@@ -36,11 +28,11 @@ public class GetPageFromDbQuery : IGetPageQuery
             if (page == null)
                 return null;
 
-            return _mapperConfiguration.Map<PageDbEntity, Page>(page);
+            return mapperConfiguration.Map<PageDbEntity, Page>(page);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error fetching {page} from database", slug);
+            logger.LogError(ex, "Error fetching {page} from database", slug);
             throw new InvalidOperationException("Error while fetching page", ex);
         }
     }
@@ -56,7 +48,7 @@ public class GetPageFromDbQuery : IGetPageQuery
 
         await LoadPageChildrenFromDatabase(page, cancellationToken);
 
-        _logger.LogTrace("Successfully retrieved {page} from DB", slug);
+        logger.LogTrace("Successfully retrieved {page} from DB", slug);
 
         return page;
     }
@@ -65,7 +57,7 @@ public class GetPageFromDbQuery : IGetPageQuery
     {
         try
         {
-            var page = await _db.GetPageBySlug(slug, cancellationToken);
+            var page = await db.GetPageBySlug(slug, cancellationToken);
 
             if (page == null)
                 return null;
@@ -85,14 +77,14 @@ public class GetPageFromDbQuery : IGetPageQuery
     {
         try
         {
-            foreach (var query in _getPageChildrenQueries)
+            foreach (var query in getPageChildrenQueries)
             {
                 await query.TryLoadChildren(page!, cancellationToken);
             }
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error loading children from database for {page}", page!.Id);
+            logger.LogError(ex, "Error loading children from database for {page}", page!.Id);
             throw new InvalidOperationException("Error while loading page children", ex);
         }
     }
@@ -107,16 +99,15 @@ public class GetPageFromDbQuery : IGetPageQuery
     {
         if (page == null)
         {
-            _logger.LogInformation("Could not find page {slug} in DB - checking Contentful", slug);
+            logger.LogInformation("Could not find page {slug} in DB - checking Contentful", slug);
             return false;
         }
 
-        if (page.Content == null || page.Content.Count == 0)
-        {
-            _logger.LogWarning("Page {slug} has no 'Content' in DB - checking Contentful", slug);
-            return false;
-        }
+        if (page.Content.Count != 0)
+            return true;
 
-        return true;
+        logger.LogWarning("Page {slug} has no 'Content' in DB - checking Contentful", slug);
+        return false;
+
     }
 }

--- a/src/Dfe.PlanTech.Application/Content/Queries/GetPageFromDbQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetPageFromDbQuery.cs
@@ -68,7 +68,7 @@ public class GetPageFromDbQuery(
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error fetching {page} from database", slug);
+            logger.LogError(ex, "Error fetching {page} from database", slug);
             return null;
         }
     }

--- a/src/Dfe.PlanTech.Application/Content/Queries/GetPageQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetPageQuery.cs
@@ -5,18 +5,15 @@ namespace Dfe.PlanTech.Application.Content.Queries;
 
 public class GetPageQuery(GetPageFromContentfulQuery getPageFromContentfulQuery, GetPageFromDbQuery getPageFromDbQuery) : IGetPageQuery
 {
-    private readonly GetPageFromDbQuery _getPageFromDbQuery = getPageFromDbQuery;
-    private readonly GetPageFromContentfulQuery _getPageFromContentfulQuery = getPageFromContentfulQuery;
-
     /// <summary>
     /// Fetches page from <see chref="IContentRepository"/> by slug
     /// </summary>
     /// <param name="slug">Slug for the Page</param>
+    /// <param name="cancellationToken"></param>
     /// <returns>Page matching slug</returns>
     public async Task<Page?> GetPageBySlug(string slug, CancellationToken cancellationToken = default)
     {
-        var page = await _getPageFromDbQuery.GetPageBySlug(slug, cancellationToken) ??
-                    await _getPageFromContentfulQuery.GetPageBySlug(slug, cancellationToken);
+        var page = await getPageFromDbQuery.GetPageBySlug(slug, cancellationToken) ?? await getPageFromContentfulQuery.GetPageBySlug(slug, cancellationToken);
 
         return page;
     }

--- a/src/Dfe.PlanTech.Domain/Content/Models/PageDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/PageDbEntity.cs
@@ -37,7 +37,7 @@ public class PageDbEntity : ContentComponentDbEntity, IPage<ContentComponentDbEn
     public SectionDbEntity? Section { get; set; }
 
     /// <summary>
-    /// Combined joins for <see cref="Content"/> and <see cref="BeforeTitleContent"/> 
+    /// Combined joins for <see cref="Content"/> and <see cref="BeforeTitleContent"/>
     /// </summary>
     [DontCopyValue]
     public List<PageContentDbEntity> AllPageContents { get; set; } = [];
@@ -59,4 +59,6 @@ public class PageDbEntity : ContentComponentDbEntity, IPage<ContentComponentDbEn
                             })
                             .OrderBy(joined => joined.order)
                             .Select(joined => joined.content);
+
+    public IEnumerable<T> GetAllContentOfType<T>() => Content.Concat(BeforeTitleContent).OfType<T>();
 }

--- a/src/Dfe.PlanTech.Web/TagHelpers/RichText/RichTextTagHelper.cs
+++ b/src/Dfe.PlanTech.Web/TagHelpers/RichText/RichTextTagHelper.cs
@@ -4,18 +4,12 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace Dfe.PlanTech.Web.TagHelpers.RichText;
 
-public class RichTextTagHelper : TagHelper
+public class RichTextTagHelper(ILogger<RichTextTagHelper> logger, IRichTextRenderer richTextRenderer) : TagHelper
 {
-    private readonly ILogger<RichTextTagHelper> _logger;
-    private readonly IRichTextRenderer _richTextRenderer;
+    private readonly ILogger<RichTextTagHelper> _logger = logger;
+    private readonly IRichTextRenderer _richTextRenderer = richTextRenderer;
 
     public RichTextContent? Content { get; set; }
-
-    public RichTextTagHelper(ILogger<RichTextTagHelper> logger, IRichTextRenderer richTextRenderer)
-    {
-        _logger = logger;
-        _richTextRenderer = richTextRenderer;
-    }
 
     public override void Process(TagHelperContext context, TagHelperOutput output)
     {

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/ButtonWithEntryReference.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/ButtonWithEntryReference.cshtml
@@ -20,10 +20,7 @@
                             Href = pageContent.Slug
                         };
 
-                <govuk-button-link href="@pageContent.Slug">
-                    class="govuk-link">
-                    @Model.Button.Value
-                </govuk-button-link>
+                <partial name="components/ButtonWithLink" model=@buttonWithLink/>
                 break;
             }
         case Question _:

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/ButtonWithEntryReference.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/ButtonWithEntryReference.cshtml
@@ -1,6 +1,7 @@
 @using Dfe.PlanTech.Domain.Content.Models;
 @using Dfe.PlanTech.Domain.Content.Models.Buttons;
 @using Dfe.PlanTech.Domain.Questionnaire.Models;
+@using Dfe.PlanTech.Web;
 @model Dfe.PlanTech.Domain.Content.Models.Buttons.ButtonWithEntryReference;
 
 @{
@@ -18,7 +19,11 @@
                             Button = Model.Button,
                             Href = pageContent.Slug
                         };
-                <button-with-link model=@buttonWithLink />
+
+                <govuk-button-link href="@pageContent.Slug">
+                    class="govuk-link">
+                    @Model.Button.Value
+                </govuk-button-link>
                 break;
             }
         case Question _:

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetPageQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetPageQueryTests.cs
@@ -84,7 +84,7 @@ public class GetPageQueryTests
 
                         var queries = options.Queries;
 
-                        var slugQuery = queries?.OfType<ContentQueryEquals>().Where(query => query.Field == "fields.slug").FirstOrDefault();
+                        var slugQuery = (queries?.OfType<ContentQueryEquals>()).FirstOrDefault(query => query.Field == "fields.slug");
                         if (slugQuery != null && slugQuery.Value.Equals(_page.Slug))
                         {
                             pages.Add(_page);


### PR DESCRIPTION
## Overview

Fixes various issues with loading of a page's content, where the original implementation no longer worked with the new caching method
 
## Changes

### Minor

- Explicitly assign loaded content for pages to the page - don't _just_ let EF Core do its thing
- Change how `GetButtonWithEntryReferencesQuery` queries the buttons from the DB; the original shouldn't have worked
- Change how `ButtonWithEntryReference.cshtml` renders links to pages as the original one didn't work

## How to review the PR

### Replicating page child bug

- Put a breakpoint after var page = await GetPageFromDb(slug, cancellationToken); in GetPageFromDbQuery.cs
- Debug PT locally
- Load the start page (/) and after getting the page from the db is done, cancel the page load
- Wait a few seconds
- Start another start page load, and let the debugger continue
- This loads the page in another query, hence getting it from the cache, but the children come straight out the db
- The headers all load, but the content between them doesn't

### Replicating ButtonWithEntryReference.cshtml bug

- Add a ButtonWithEntryReference that links to a _page_ on a page. I've currently added one on the start page
- Run dev web app and view page
- You shouldn't see the button

### Testing fixes

Do the steps above again but this time the rich texts should exist, and the button should show

## Checklist

Delete any rows that do not apply to the PR.

- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch
- [ ] Unit tests have been added/updated