### PR TITLE
Fix: Increase dbup timeout

### DIFF
--- a/src/Dfe.PlanTech.DatabaseUpgrader/DatabaseExecutor.cs
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/DatabaseExecutor.cs
@@ -14,6 +14,7 @@ public class DatabaseExecutor
 
     private const string SCRIPTS_NAMESPACE = "Dfe.PlanTech.DatabaseUpgrader.Scripts";
     private const string ENVIRONMENT_SPECIFIC_SCRIPTS_NAMESPACE = "Dfe.PlanTech.DatabaseUpgrader.EnvironmentSpecificScripts";
+    private const int EXECUTION_TIMEOUT_MINUTES = 10;
 
     public DatabaseExecutor(Options options, Logger logger)
     {
@@ -43,6 +44,7 @@ public class DatabaseExecutor
         return engine.LogToConsole()
         .LogScriptOutput()
         .WithTransaction()
+        .WithExecutionTimeout(TimeSpan.FromMinutes(EXECUTION_TIMEOUT_MINUTES))
         .Build();
     }
 


### PR DESCRIPTION
## Overview

Our last few runs have failed due to execution timeout of the database upgrade scripts, by default this is likely 30 seconds but the recent datafix is just over that. Increased to 10 minutes to cover anything similar

## Changes

### Minor

- DbUp timeout set to 10 minutes

## Checklist

- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch
