### PR TITLE
Fix: Saving of button with ref

### DIFF
--- a/src/Dfe.PlanTech.Domain/Content/Models/Buttons/ButtonWithEntryReferenceDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/Buttons/ButtonWithEntryReferenceDbEntity.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Runtime.Serialization;
 using Dfe.PlanTech.Domain.Content.Interfaces;
 
 namespace Dfe.PlanTech.Domain.Content.Models.Buttons;
@@ -18,9 +20,11 @@ public class ButtonWithEntryReferenceDbEntity : ContentComponentDbEntity, IButto
     public string LinkToEntryId { get; set; } = null!;
 
     [DontCopyValue]
+    [NotMapped]
     public string Slug { get; set; } = "";
 
     [DontCopyValue]
+    [NotMapped]
     public LinkToEntryType LinkType { get; set; } = LinkToEntryType.Unknown;
 }
 

--- a/src/Dfe.PlanTech.Domain/Content/Models/Buttons/ButtonWithEntryReferenceDbEntity.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/Buttons/ButtonWithEntryReferenceDbEntity.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Runtime.Serialization;
 using Dfe.PlanTech.Domain.Content.Interfaces;
 
 namespace Dfe.PlanTech.Domain.Content.Models.Buttons;

--- a/src/Dfe.PlanTech.Infrastructure.Data/EntityTypeConfigurations/ButtonWithEntryReferenceEntityTypeConfiguration.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Data/EntityTypeConfigurations/ButtonWithEntryReferenceEntityTypeConfiguration.cs
@@ -12,6 +12,7 @@ public class ButtonWithEntryReferenceEntityTypeConfiguration : IEntityTypeConfig
 {
     public void Configure(EntityTypeBuilder<ButtonWithEntryReferenceDbEntity> builder)
     {
+        builder.ToTable("ButtonWithEntryReferences", CmsDbContext.Schema);
         builder.ToView("ButtonWithEntryReferencesWithSlug");
         builder.Navigation(button => button.Button).AutoInclude();
         builder.Property(button => button.LinkType)

--- a/src/Dfe.PlanTech.Infrastructure.Data/EntityTypeConfigurations/ButtonWithEntryReferenceEntityTypeConfiguration.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Data/EntityTypeConfigurations/ButtonWithEntryReferenceEntityTypeConfiguration.cs
@@ -10,6 +10,9 @@ namespace Dfe.PlanTech.Infrastructure.Data.EntityTypeConfigurations;
 [ExcludeFromCodeCoverage]
 public class ButtonWithEntryReferenceEntityTypeConfiguration : IEntityTypeConfiguration<ButtonWithEntryReferenceDbEntity>
 {
+    /// <summary>
+    /// Configure both as table and as view so that it saves to the table but fetches from the view
+    /// </summary>
     public void Configure(EntityTypeBuilder<ButtonWithEntryReferenceDbEntity> builder)
     {
         builder.ToTable("ButtonWithEntryReferences", CmsDbContext.Schema);


### PR DESCRIPTION
## Overview

Configures the `ButtonWithEntryReferenceEntityType` as both table and view, so that saving to the table omits the view columns and fetching retrieves from the view

## How to review the PR

Run PT locally and check that

- Changes in contentful to `ButtonWithEntryReference` are working with no errors, and correctly updating the Db
- `ButtonWithEntryReference` is showing up correctly in plan tech, with correct links

## Checklist

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch