### PR TITLE
fix: Sidebar release widget 

### DIFF
--- a/contentful/content-migrations/helpers.js
+++ b/contentful/content-migrations/helpers.js
@@ -1,0 +1,61 @@
+/**
+ * @typedef {Object} ContentTypeDefinition
+ * @property {string[]} [manyChildReferences] - Collection of field IDs where the field is an array of entity references
+ */
+
+/**
+ * @typedef {Record<string, ContentTypeDefinition>} AllContentTypesMap
+ */
+
+/**
+ * A map of all available content types in the system.
+ *
+ * @type {AllContentTypesMap}
+ */
+const AllContentTypes = {
+  "button": {},
+  "buttonWithEntryReference": {},
+  "buttonWithLink": {},
+  "category": { manyChildReferences: ["content", "sections"] },
+  "componentDropDown": {},
+  "csLink": {},
+  "header": {},
+  "insetText": {},
+  "navigationLink": {},
+  "page": {
+    manyChildReferences: ["content", "beforeTitleContent"]
+  },
+  "question": {
+    manyChildReferences: ["answers"]
+  },
+  "recommendationChunk": {
+    manyChildReferences: ["answers", "content"]
+  },
+  "recommendationIntro": {
+    manyChildReferences: ["content"]
+  },
+  "recommendationSection": {
+    manyChildReferences: ["answers", "chunks"]
+  },
+  "section": {
+    manyChildReferences: ["questions"]
+  },
+  "subtopicRecommendation": {
+    manyChildReferences: ["intros"]
+  },
+  "textBody": {},
+  "title": {},
+  "warningComponent": {},
+};
+
+/**
+ * Executes a callback function for each content type in the `AllContentTypes` map.
+ *
+ * @param {function(string, ContentTypeDefinition): void} callback - The callback function to execute for each content type. It receives the content type key and its definition as arguments.
+ */
+const runForEachContentType = (callback) => Object.entries(AllContentTypes).forEach(([contetTypeId, contentType]) => callback(contetTypeId, contentType));
+
+module.exports = {
+  runForEachContentType,
+  AllContentTypes
+};

--- a/contentful/content-migrations/migrations/20241010-2222-amend-references-view.js
+++ b/contentful/content-migrations/migrations/20241010-2222-amend-references-view.js
@@ -39,11 +39,11 @@ module.exports = function (migration) {
  * @param {string[]} references 
  */
 function updateContentType(migration, contentType, references) {
-    var page = migration.editContentType(contentType);
+    var contentType = migration.editContentType(contentType);
 
     for (const reference of references) {
-        page.changeFieldControl(reference, "builtin", "entryLinksEditor", { bulkEditing: true });
+        contentType.changeFieldControl(reference, "builtin", "entryLinksEditor", { bulkEditing: true });
     }
 
-    page.addSidebarWidget("builtin", "publication-widget", undefined, "releases-widget");
+    contentType.addSidebarWidget("builtin", "releases-widget", undefined, "publication-widget");
 }

--- a/contentful/content-migrations/migrations/20241014-1117-fix-releases-widget.js
+++ b/contentful/content-migrations/migrations/20241014-1117-fix-releases-widget.js
@@ -1,0 +1,25 @@
+const Migration = require("contentful-migration");
+const { runForEachContentType } = require("../helpers");
+
+/**
+ * 
+ * @param {Migration} migration 
+ */
+module.exports = function (migration) {
+  runForEachContentType((contentTypeName) => updateContentType(migration, contentTypeName));
+};
+
+/**
+ * 
+ * @param {Migration} migration 
+ * @param {string} contentType 
+ */
+function updateContentType(migration, contentType) {
+  var contentType = migration.editContentType(contentType);
+
+  contentType.removeSidebarWidget("builtin", "releases-widget");
+
+  //6RKxbgPghdY4llDpwCFvgR was pulled from the Contentful export - _should_ be the "workflows widget"
+  //No idea why it shows as this, but it's there, and the releases widget should be first
+  contentType.addSidebarWidget("sidebar-builtin", "releases-widget", undefined, "6RKxbgPghdY4llDpwCFvgR");
+}


### PR DESCRIPTION
## Overview

Creates a new migration to fix previous migration problem.

1. Correct ordering of widget ids (i.e. first id == widget to add, second id == widget to insert before)
2. Correct widget namespace

## Changes

### Minor

- New migration to fix problem with release widget added in last migration
- Make `helpers.js` file for storing all content types, and a simple method to run a callback for _all_ content types

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch