### PR TITLE
fix: Amend default back button behaviour + text for non-JS users

### DIFF
--- a/src/Dfe.PlanTech.Web/Views/Shared/BackButton.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/BackButton.cshtml
@@ -1,1 +1,3 @@
-<govuk-back-link id="back-button-link" href="" />
+<govuk-back-link id="nonjs-back-button-link" href="/self-assessment" class="non-js-only">Home</govuk-back-link>
+
+<govuk-back-link id="back-button-link" href="/self-assessment" class="js-only"/>

--- a/src/Dfe.PlanTech.Web/Views/Shared/_BodyEnd.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/_BodyEnd.cshtml
@@ -7,6 +7,11 @@
         element.classList.remove("js-only");
     }
 
+    function deleteNonJsElement(element){
+        element.parentNode.removeChild(element);
+    }
+
     // unhide all js-only elements when js is enabled
     [...document.getElementsByClassName("js-only")].forEach(showHiddenElement);
+    [...document.getElementsByClassName("non-js-only")].forEach(deleteNonJsElement);
 </script>

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/components/back-button-link.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/components/back-button-link.cy.js
@@ -1,0 +1,10 @@
+describe("Back button link", () => {
+  beforeEach(() => {
+    cy.visit("/");
+    cy.visit("/cookies");
+  });
+
+  it("Displays a single back button, with correct 'Back' text'", () => {
+    cy.get("a.govuk-back-link").should("exist").and("be.visible").should('have.length', 1).invoke("text").should('equal', "Back");
+  });
+});


### PR DESCRIPTION
## Overview

Amends the back button link to show "Home", and redirect to the self-assessment page, for non-JS users.

## Changes

### Minor

- Duplicates back button links; one for non-JS, one for JS. 
  - JS one is hidden by default
  - If JS is enabled, the non-JS one gets deleted, and the JS one gets made visible.

## How to review the PR

1. Run web app with JS enabled
2. Go to a page that would display the back button
3. Verify that it looks and functions the same as before
4. Disable JS
5. Reload page
6. Verify that the back button now says "Home", and always directs to /self-assessment

## Additional notes

I did originally just try:
- One single back button link
- Change default HREF to '/self-assessment' and the display text to 'Home'
- When page loads, use JS to amend the HREF (which we already do), and the text to 'Back'

However, when I did this, you could visibly see it happen in the vast majority of pages loads. Which... wasn't great.

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [x] E2E tests have been added/updated