### PR TITLE
Fix: remove references to c&s git submodule

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
-          submodules: true
 
       - name: GitHub Container Registry Login
         uses: docker/login-action@v3

--- a/.github/workflows/code-pr-check.yml
+++ b/.github/workflows/code-pr-check.yml
@@ -37,12 +37,6 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
-          submodules: true
-
-      - name: Git Submodule Update
-        run: |
-            git pull --recurse-submodules
-            git submodule update --remote --recursive
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v4
@@ -106,8 +100,7 @@ jobs:
           /d:sonar.login="${{ secrets.SONAR_TOKEN }}" \
           /d:sonar.host.url="https://sonarcloud.io" \
           /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml \
-          /d:sonar.exclusions=**/contentandsupport/** \
-          /d:sonar.coverage.exclusions=**/Program.cs,**/gulpfile.js,**/wwwroot/**,**/contentandsupport/**,**/Dfe.PlanTech.Web.SeedTestData/** \
+          /d:sonar.coverage.exclusions=**/Program.cs,**/gulpfile.js,**/wwwroot/**,**/Dfe.PlanTech.Web.SeedTestData/** \
           /d:sonar.issue.ignore.multicriteria=e1 \
           /d:sonar.issue.ignore.multicriteria.e1.ruleKey=csharpsquid:S6602 \
           /d:sonar.issue.ignore.multicriteria.e1.resourceKey=src/**/*.cs \

--- a/.github/workflows/code-pr-check.yml
+++ b/.github/workflows/code-pr-check.yml
@@ -70,8 +70,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Cache SonarCloud packages
         uses: actions/cache@v4

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -34,7 +34,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
-          submodules: true
 
       - name: Azure CLI Login
         uses: ./.github/actions/azure-login
@@ -95,7 +94,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
-          submodules: true
 
       - name: Azure CLI Login
         uses: ./.github/actions/azure-login
@@ -136,8 +134,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Azure CLI Login
         uses: ./.github/actions/azure-login

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -90,8 +90,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Azure CLI Login
         uses: ./.github/actions/azure-login

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,7 +8,6 @@ on:
       - "src/**"
       - "tests/Dfe.PlanTech.Web.E2ETests/**"
       - ".github/workflows/e2e-tests.yml"
-      - "contentandsupport/**"
       - ".gitmodules"
 
 concurrency:

--- a/.github/workflows/matrix-deploy.yml
+++ b/.github/workflows/matrix-deploy.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
-          submodules: true
 
       - id: var
         run: |
@@ -56,7 +55,6 @@ jobs:
         with:
           ref: ${{ github.ref }}
           fetch-depth: 2
-          submodules: true
 
       - name: Check for Terraform File Changes
         id: terraform_changes

--- a/.github/workflows/matrix-deploy.yml
+++ b/.github/workflows/matrix-deploy.yml
@@ -7,7 +7,6 @@ on:
     paths:
       - "src/**"
       - ".github/workflows/matrix-deploy.yml"
-      - "contentandsupport/**"
       - ".gitmodules"
 
 jobs:

--- a/src/Dfe.PlanTech.Web/Dockerfile
+++ b/src/Dfe.PlanTech.Web/Dockerfile
@@ -5,7 +5,6 @@ EXPOSE 8080
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /
 COPY src/ src/
-COPY contentandsupport/ contentandsupport/
 RUN dotnet publish "src/Dfe.PlanTech.Web/Dfe.PlanTech.Web.csproj" -c Release -o /out/publish && \
     rm -rf /src && \
     rm -rf /contentandsupport


### PR DESCRIPTION
## Overview

Remove references to git submodule now that C&S code has been merged with Plan Tech

## Changes

Removes references to C&S git submodule in GitHub workflows and Dockerfile

## Checklist

Delete any rows that do not apply to the PR.

- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch
- [ ] GitHub workflows/actions have been added/updated
