### PR TITLE
fix(cicd): Add credentials for user with noorg to E2E test call

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -178,6 +178,8 @@ jobs:
           dsi_username: ${{ secrets.DSI_USERNAME }}
           dsi_password: ${{ secrets.DSI_PASSWORD }}
           environment: ${{ inputs.environment}}
+          dsi_noorg_username: ${{ secrets.DSI_NOORG_USERNAME }}
+          dsi_noorg_password: ${{ secrets.DSI_NOORG_PASSWORD }}
 
       - name: Remove Azure Firewall Rules
         if: always()


### PR DESCRIPTION
## Overview

Adds the credentials for the no organisation user to the E2E test call.

## Changes

### Minor

- Adds the credentials for the no organisation user to the E2E test call.

## Checklist

Delete any rows that do not apply to the PR.

- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch
- [ ] GitHub workflows/actions have been added/updated