### PR TITLE
fix(tf): Use correct id for container app identity

### DIFF
--- a/terraform/container-app/main-hosting.tf
+++ b/terraform/container-app/main-hosting.tf
@@ -21,7 +21,7 @@ module "main_hosting" {
 
   container_environment_variables = local.container_environment_variables
 
-  container_app_identities           = [azurerm_user_assigned_identity.user_assigned_identity.id]
+  container_app_identities           = [azurerm_user_assigned_identity.user_assigned_identity.client_id]
   container_app_use_managed_identity = false
 
   container_max_replicas           = local.container_app_max_replicas


### PR DESCRIPTION
## Overview

Use client id for container app identity, not ID.

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [x] Terraform has been updated