### PR TITLE
chore: Include intro in recommendation navigation

### DIFF
--- a/src/Dfe.PlanTech.Web/Views/Recommendations/RecommendationContent.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/RecommendationContent.cshtml
@@ -13,7 +13,7 @@
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-third">
                 @{ ViewData["VerticalNavigationSection"] = headerWithContent.SlugifiedHeader; }
-                <partial name="Components/VerticalNavigation/Default" model="@Model.Chunks"/>
+                <partial name="Components/VerticalNavigation/Default" model="@Model.AllContent"/>
             </div>
             <div class="govuk-grid-column-two-thirds">
                 <div class="govuk-section-break govuk-!-margin-top-0 govuk-section-break--m govuk-section-break--visible">

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/VerticalNavigation/Default.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/VerticalNavigation/Default.cshtml
@@ -1,4 +1,4 @@
-@model IEnumerable<Dfe.PlanTech.Domain.Questionnaire.Models.RecommendationChunk>
+@model IEnumerable<Dfe.PlanTech.Domain.Questionnaire.Interfaces.IHeaderWithContent>
 
 <nav class="dfe-vertical-nav">
     <h2 class="dfe-vertical-nav__theme govuk-heading-m">List of actions</h2>
@@ -10,7 +10,7 @@
                 : "";
 
             <li class="dfe-vertical-nav__section-item">
-                <a class="dfe-vertical-nav__link @classes" href="#@chunk.SlugifiedHeader">@chunk.Header</a>
+                <a class="dfe-vertical-nav__link @classes" href="#@chunk.SlugifiedHeader">@chunk.HeaderText</a>
             </li>
         }
     </ul>


### PR DESCRIPTION
## Overview

Addresses ticket [#234135](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/234135)

Adds the recommendation intro into the navigation options

## Changes

### Minor
- treats recommendation intro as a chunk when it comes to the navigation bar, leaves the checklist alone

## How to review the PR
Check that it meets the ACs from the ticket

## Checklist

- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch
