### PR TITLE
feat(recommendations): Add pagination

### DIFF
--- a/src/Dfe.PlanTech.Web/Views/Recommendations/RecommendationContent.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/RecommendationContent.cshtml
@@ -1,9 +1,16 @@
 @model Dfe.PlanTech.Web.Models.RecommendationsViewModel
 @using Dfe.PlanTech.Domain.Questionnaire.Models;
-
-
-@foreach (var headerWithContent in Model.AllContent)
+@{
+    var allContent = Model.AllContent.ToArray();
+}
+@for (var x = 0; x < allContent.Length; x++)
 {
+    var headerWithContent = allContent[x];
+
+    var previousContent = x - 1 >= 0 ? allContent[x - 1] : null;
+
+    var nextContent = x + 1 < allContent.Length ? allContent[x+1] : null;
+
     <div class="recommendation-piece-container" id="@headerWithContent.SlugifiedHeader">
         <div class="recommendation-piece-header">
             <div class="recommendation-piece-header">
@@ -32,7 +39,17 @@
                         </div>
                     }
                 </div>
+                <div>
+                    <govuk-pagination>
+                    @if(previousContent != null){
+                        <govuk-pagination-previous href="#@previousContent.SlugifiedHeader" label-text="@previousContent.HeaderText" />
+                    }
 
+                    @if(nextContent != null){
+                        <govuk-pagination-next href="#@nextContent.SlugifiedHeader" label-text="@nextContent.HeaderText" />
+                        }
+                    </govuk-pagination>
+                </div>
                 <div>
                     <h2 class="govuk-heading-m">Share this recommendation</h2>
                     <p class="govuk-body">

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/recommendation-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/recommendation-page.cy.js
@@ -6,7 +6,7 @@ describe("Recommendation Page", () => {
 
     cy.completeFirstSubtopic();
   });
-  
+
   beforeEach(() => {
     cy.loginWithEnv(url);
     cy.navigateToRecommendationPage();
@@ -21,43 +21,75 @@ describe("Recommendation Page", () => {
     cy.get("header.dfe-header").should("exist");
   });
 
-    it("Should have Gov.uk footer", () => {
-        cy.get("footer.govuk-footer").should("exist");
-    });
+  it("Should have Gov.uk footer", () => {
+    cy.get("footer.govuk-footer").should("exist");
+  });
 
   it("Should have Content", () => {
-      cy.get("div.recommendation-piece-content").should("exist");
+    cy.get("div.recommendation-piece-content").should("exist");
   });
 
   it("Should have vertical navigation bar", () => {
-      cy.get("nav.dfe-vertical-nav").should("exist");
+    cy.get("nav.dfe-vertical-nav").should("exist");
   });
 
   it("Should have sections in navigation bar", () => {
-      cy.get("li.dfe-vertical-nav__section-item").should("exist");
-  })
+    cy.get("li.dfe-vertical-nav__section-item").should("exist");
+  });
 
   it("Should have a link to print open the page in another tab in a checklist format", () => {
-      cy.get("a.govuk-link")
-          .contains("Share or download this recommendation in a checklist format")
-          .should("have.attr", "target", "_blank")
-  })
+    cy.get("a.govuk-link")
+      .contains("Share or download this recommendation in a checklist format")
+      .should("have.attr", "target", "_blank");
+  });
 
-    //Links
-    it("Should have no broken links", () => {
-        cy.get(".govuk-main-wrapper").within(() => {
-            cy.get("a").each(($link) => {
-                cy.wrap($link).should("have.attr", "href");
-                cy.request({ url: $link.prop("href") });
-            });
-        });
-        cy.get(".recommendation-content").within(() => {
-            cy.get("a").each(($link) => {
-                cy.wrap($link).should("have.attr", "href");
-                cy.request({url: $link.prop("href")});
-            });
-        });
+  //Links
+  it("Should have no broken links", () => {
+    cy.get(".govuk-main-wrapper").within(() => {
+      cy.get("a").each(($link) => {
+        cy.wrap($link).should("have.attr", "href");
+        cy.request({ url: $link.prop("href") });
+      });
     });
+    cy.get(".recommendation-content").within(() => {
+      cy.get("a").each(($link) => {
+        cy.wrap($link).should("have.attr", "href");
+        cy.request({ url: $link.prop("href") });
+      });
+    });
+  });
+
+  //Pagination
+  it("Should have pagination", () => {
+    //Check there's a "Next" pagination link, and that there's only one visible
+    cy.get("a.govuk-pagination__link")
+      .filter(":visible")
+      .should("have.length", 1)
+      .then(($element) => {
+        cy.wrap($element)
+          .find("span.govuk-pagination__link-title")
+          .should("exist")
+          .and("contain", "Next");
+
+        cy.wrap($element).click();
+      });
+
+    //Check that there's now two pagination links; next and previous
+    cy.get("a.govuk-pagination__link")
+      .filter(":visible")
+      .should("have.length", 2)
+      .then(($element) => {
+        cy.wrap($element)
+          .find("span.govuk-pagination__link-title")
+          .should("exist")
+          .and("contain", "Next");
+
+        cy.wrap($element)
+          .find("span.govuk-pagination__link-title")
+          .should("exist")
+          .and("contain", "Previous");
+      });
+  });
 
   //Accessibility
   it("Passes Accessibility Testing", () => {


### PR DESCRIPTION
## Overview

Addresses ticket 234475

Adds pagination to the bottom of recommendation page

## Changes

### Minor

- Add pagination to bottom of recommendation content

## Additional notes

I really dislike the approach with keeping all the different recommendation pieces on one page, and using CSS to hide/show them. It makes things like this... not ideal. However, it was chosen for some reason that I've forgotten, and it's workable, so on it goes.

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [x] E2E tests have been added/updated