### PR TITLE
fix(tf): Correct Azure Client ID

### DIFF
--- a/terraform/container-app/main-hosting.tf
+++ b/terraform/container-app/main-hosting.tf
@@ -1,5 +1,5 @@
 module "main_hosting" {
-  source = "github.com/DFE-Digital/terraform-azurerm-container-apps-hosting?ref=568617c"
+  source = "github.com/DFE-Digital/terraform-azurerm-container-apps-hosting?ref=93096d1"
 
   ###########
   # General #
@@ -16,7 +16,8 @@ module "main_hosting" {
   image_name                = local.container_app_image_name
   container_port            = local.container_port
   container_secret_environment_variables = {
-    "KeyVaultName" = local.kv_name
+    "KeyVaultName"    = local.kv_name,
+    "AZURE_CLIENT_ID" = azurerm_user_assigned_identity.user_assigned_identity.client_id,
   }
 
   container_environment_variables = local.container_environment_variables

--- a/terraform/container-app/terraform-configuration.md
+++ b/terraform/container-app/terraform-configuration.md
@@ -46,7 +46,7 @@ We use two external modules to create the majority of the resources required:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_main_hosting"></a> [main\_hosting](#module\_main\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | 568617c |
+| <a name="module_main_hosting"></a> [main\_hosting](#module\_main\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | 93096d1 |
 | <a name="module_waf"></a> [waf](#module\_waf) | github.com/dfe-digital/terraform-azurerm-front-door-app-gateway-waf | f0ca7eb |
 
 ## Resources


### PR DESCRIPTION
## Overview

Addresses ticket 234276

Adds `AZURE_CLIENT_ID` back to the container app environment variables, this time with the correct value.

**Note: this is dependant on [this PR](https://github.com/DFE-Digital/terraform-azurerm-container-apps-hosting/pull/438) in the DFE TF module. Which has not gone in yet.**

## Changes

### Minor

- Set `AZURE_CLIENT_ID` environment variable on the container app
- Increment module version

## Checklist

Delete any rows that do not apply to the PR.

- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch
- [ ] Unit tests have been added/updated
- [ ] E2E tests have been added/updated
- [ ] GitHub workflows/actions have been added/updated
- [ ] Terraform has been updated
- [ ] Documentation has been updated where relevant
- [ ] Any Key Vault secrets have been added to the development Key Vault
