### PR TITLE
fix: trim slug before replacing with hyphens

### DIFF
--- a/src/Dfe.PlanTech.Domain/Extensions/StringHelpers.cs
+++ b/src/Dfe.PlanTech.Domain/Extensions/StringHelpers.cs
@@ -21,5 +21,4 @@ public static partial class StringHelpers
 
     private static string ReplaceNonSlugCharacters(this string text, string replacement)
     => MatchNonAlphaNumericExceptHyphensPattern().Replace(text, replacement);
-
 }

--- a/src/Dfe.PlanTech.Domain/Extensions/StringHelpers.cs
+++ b/src/Dfe.PlanTech.Domain/Extensions/StringHelpers.cs
@@ -4,14 +4,22 @@ namespace Dfe.PlanTech;
 
 public static partial class StringHelpers
 {
-    private const string RemoveNonAlphanumericExceptHyphensRegexPattern = @"[^a-zA-Z0-9\s-]";
+    private const string MatchNonAlphanumericExceptHyphensRegexPattern = @"[^a-zA-Z0-9-]";
+    private const string MatchWhitespaceCharacters = @"\s";
+
+    [GeneratedRegex(MatchNonAlphanumericExceptHyphensRegexPattern)]
+    private static partial Regex MatchNonAlphaNumericExceptHyphensPattern();
+
+    [GeneratedRegex(MatchWhitespaceCharacters)]
+    private static partial Regex MatchWhitespaceCharactersPattern();
 
     // Extension method to slugify a string by removing non-alphanumeric characters (except hyphens to preserve hyphenated words), replacing spaces with hyphens, and converting to lowercase.
-    public static string Slugify(this string text)
-    => RemoveNonAlphaNumericExceptHyphensPattern().Replace(text, "").Replace(" ", "-").ToLower();
+    public static string Slugify(this string text) => text.Trim().ReplaceWhitespaceCharacters("-").ReplaceNonSlugCharacters("").ToLower();
 
-    public static string TruncateIfOverLength(this string text, int maxLength) => text.Length < maxLength ? text : text[..maxLength];
+    private static string ReplaceWhitespaceCharacters(this string text, string replacement)
+    => MatchWhitespaceCharactersPattern().Replace(text, replacement);
 
-    [GeneratedRegex(RemoveNonAlphanumericExceptHyphensRegexPattern)]
-    private static partial Regex RemoveNonAlphaNumericExceptHyphensPattern();
+    private static string ReplaceNonSlugCharacters(this string text, string replacement)
+    => MatchNonAlphaNumericExceptHyphensPattern().Replace(text, replacement);
+
 }

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationChunk.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationChunk.cs
@@ -5,13 +5,15 @@ namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
 public class RecommendationChunk : ContentComponent, IRecommendationChunk<Answer, ContentComponent>, IHeaderWithContent
 {
+    private string? _slugifiedHeader;
+
     public string Header { get; init; } = null!;
 
     public List<ContentComponent> Content { get; init; } = [];
 
     public List<Answer> Answers { get; init; } = [];
 
-    public string SlugifiedHeader => Header.Slugify();
+    public string SlugifiedHeader => _slugifiedHeader ??= Header.Slugify();
 
     public CSLink? CSLink { get; init; }
 

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationIntro.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationIntro.cs
@@ -6,6 +6,8 @@ namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
 public class RecommendationIntro : ContentComponent, IRecommendationIntro<Header, ContentComponent>, IHeaderWithContent
 {
+    private string? _slugifiedHeader;
+
     public string Slug { get; init; } = null!;
 
     public Header Header { get; init; } = null!;
@@ -15,7 +17,7 @@ public class RecommendationIntro : ContentComponent, IRecommendationIntro<Header
     [NotMapped]
     public List<ContentComponent> Content { get; init; } = [];
 
-    public string SlugifiedHeader => Header.Text.Slugify();
+    public string SlugifiedHeader => _slugifiedHeader ??= Header.Text.Slugify();
 
     public string HeaderText => Header.Text;
 }

--- a/tests/Dfe.PlanTech.Web.UnitTests/Models/ComponentModelTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Models/ComponentModelTests.cs
@@ -78,6 +78,10 @@ namespace Dfe.PlanTech.Web.UnitTests.Models
         [InlineData("Random test Topic", "random-test-topic")]
         [InlineData("Y867as ()&ycj Cool Thing", "y867as-ycj-cool-thing")]
         [InlineData("Save a back-up...", "save-a-back-up")]
+        [InlineData("This is a string with loads of spaces at the end        ", "this-is-a-string-with-loads-of-spaces-at-the-end")]
+        [InlineData("This is a string with loads of spaces at the end        and-this", "this-is-a-string-with-loads-of-spaces-at-the-end--------and-this")]
+        [InlineData(" spaces either side     ", "spaces-either-side")]
+        [InlineData(@"Line separator character ", "line-separator-character")]
         public void Slugify_Should_Slugify_Strings(string header, string expectedResult)
         {
             var recommendationChunk = ComponentBuilder.BuildRecommendationChunk(header);


### PR DESCRIPTION
## Overview

Fixes issue with slug generator.

## Changes

### Minor

#### Fix

- Trims the regex'd string _first_
- Then replace whitespace characters with hyphens
- Then remove characters that are not alphanumeric or hyphens

#### Improvement

- Add a backing field for the slugified header, to prevent it being ran 3x per content/intro.

## Additional notes

Weird one this.

Basically the header name had a load of space at the end of it, so we ended up with `name-here     -`.  Also they weren't _actual_ spaces they're actually the line separator code I believe? I digress. Bt:

1. When using the exact same property in an `anchor` element directly, (`RecommendationContent.cshtml`), the slug would end up being something like `continue-with-the-thing      -`
2. When using it with the ASP Net core package we use for the DFE/GDS components, it ended up being `continue-with-the-thing\u2028\u2028-`

I think it's because the characters were not spaces, but were lineseperators, which means they weren't actually being slugified properly, and then the taghelper vs view was treating them both differently.

Either way, this should fix the actual _cause_ of the issue; if there's a load of _not an alphanumeric character_ at the end of the header, it gets trimmed. This fixes the problem.

I've also changed the regex + functionality so that we replace the spaces _first_, and then remove everything else. The intention here is that, if the header text was something like "This is a header       o", then we'd have a similar problem. This should, at least, do something a bit cleaner; we'd end up with `this-is-a-header-----o`

I debated adding another regex to replace instances of repeat hyphens (i.e. 2 or more hyphens in a row) with just one; not sure if that's overkill? Welcome to input.

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [x] Unit tests have been added/updated
