### PR TITLE
Fix: Remove print button from recommendation printout when no JS

### DIFF
--- a/src/Dfe.PlanTech.Web/Views/Recommendations/RecommendationsChecklist.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/RecommendationsChecklist.cshtml
@@ -21,7 +21,7 @@
             await Html.RenderPartialAsync("BackButton", Model);
         }
     </div>
-    <div class="noprint govuk-!-margin-bottom-6 govuk-!-margin-top-4">
+    <div class="noprint govuk-!-margin-bottom-6 govuk-!-margin-top-4 js-only">
         <button class="govuk-link print-button govuk-!-font-size-16" id="recommendations-print-page">Print this page</button>
     </div>
     <partial name="RecommendationPrintContent" model="@Model.AllContent"/>


### PR DESCRIPTION
## Overview

Addresses ticket [#234374](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/234374)

Fixes the print button showing when JS is disabled

## How to review the PR

Ensure the print this page button is hidden on the recommendation printout when JS is disabled and unaffected otherwise

## Checklist

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
