### PR TITLE
fix: Add xunit runners to unit test projects

### DIFF
--- a/tests/Dfe.ContentSupport.Web.Tests/Dfe.ContentSupport.Web.Tests.csproj
+++ b/tests/Dfe.ContentSupport.Web.Tests/Dfe.ContentSupport.Web.Tests.csproj
@@ -1,39 +1,43 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
 
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-        <RootNamespace>Dfe.ContentSupport.Web.Tests</RootNamespace>
-    </PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>Dfe.ContentSupport.Web.Tests</RootNamespace>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="7.0.0-alpha.3" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-        <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="xunit" Version="2.9.2" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="7.0.0-alpha.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
 
-    <ItemGroup>
-        <Using Include="Xunit" />
-    </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\Dfe.ContentSupport.Web\Dfe.ContentSupport.Web.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Dfe.ContentSupport.Web\Dfe.ContentSupport.Web.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <None Update="StubData\ContentfulCollection.json">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </None>
-    </ItemGroup>
+  <ItemGroup>
+    <None Update="StubData\ContentfulCollection.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/tests/Dfe.PlanTech.Application.UnitTests/Dfe.PlanTech.Application.UnitTests.csproj
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Dfe.PlanTech.Application.UnitTests.csproj
@@ -19,11 +19,16 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dfe.PlanTech.Application\Dfe.PlanTech.Application.csproj" />
-    <ProjectReference Include="..\Dfe.PlanTech.UnitTests.Shared\Dfe.PlanTech.UnitTests.Shared.csproj" />
+    <ProjectReference
+      Include="..\Dfe.PlanTech.UnitTests.Shared\Dfe.PlanTech.UnitTests.Shared.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Dfe.PlanTech.CmsDbMigrations.E2ETests/Dfe.PlanTech.CmsDbMigrations.E2ETests.csproj
+++ b/tests/Dfe.PlanTech.CmsDbMigrations.E2ETests/Dfe.PlanTech.CmsDbMigrations.E2ETests.csproj
@@ -22,7 +22,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8" />
+
   </ItemGroup>
 
   <ItemGroup>
@@ -32,8 +33,10 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dfe.PlanTech.Application\Dfe.PlanTech.Application.csproj" />
     <ProjectReference Include="..\..\src\Dfe.PlanTech.Domain\Dfe.PlanTech.Domain.csproj" />
-    <ProjectReference Include="..\..\src\Dfe.PlanTech.Infrastructure.Data\Dfe.PlanTech.Infrastructure.Data.csproj" />
-    <ProjectReference Include="..\..\src\Dfe.PlanTech.Infrastructure.ServiceBus\Dfe.PlanTech.Infrastructure.ServiceBus.csproj" />
+    <ProjectReference
+      Include="..\..\src\Dfe.PlanTech.Infrastructure.Data\Dfe.PlanTech.Infrastructure.Data.csproj" />
+    <ProjectReference
+      Include="..\..\src\Dfe.PlanTech.Infrastructure.ServiceBus\Dfe.PlanTech.Infrastructure.ServiceBus.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Dfe.PlanTech.Domain.UnitTests/Dfe.PlanTech.Domain.UnitTests.csproj
+++ b/tests/Dfe.PlanTech.Domain.UnitTests/Dfe.PlanTech.Domain.UnitTests.csproj
@@ -1,29 +1,33 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
 
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-    </PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-        <PackageReference Include="xunit" Version="2.9.2" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
 
-    <ItemGroup>
-        <Using Include="Xunit" />
-    </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\Dfe.PlanTech.Domain\Dfe.PlanTech.Domain.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Dfe.PlanTech.Domain\Dfe.PlanTech.Domain.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/tests/Dfe.PlanTech.Domain.UnitTests/Helpers/DateTimeFormatterTests.cs
+++ b/tests/Dfe.PlanTech.Domain.UnitTests/Helpers/DateTimeFormatterTests.cs
@@ -25,7 +25,7 @@ public class DateTimeFormatterTests
     }
 
     [Theory]
-    [InlineData("2015/09/15", "15 Sept 2015")]
+    [InlineData("2015/09/15", "15 Sep 2015")]
     [InlineData("2020/01/09", "9 Jan 2020")]
     public void FormattedDateShort_Should_Display_Correctly(string inputDate, string expected)
     {

--- a/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests.csproj
+++ b/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests.csproj
@@ -17,10 +17,16 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Dfe.PlanTech.Infrastructure.Contentful\Dfe.PlanTech.Infrastructure.Contentful.csproj" />
-        <ProjectReference Include="..\..\src\Dfe.PlanTech.Application\Dfe.PlanTech.Application.csproj" />
+        <ProjectReference
+            Include="..\..\src\Dfe.PlanTech.Infrastructure.Contentful\Dfe.PlanTech.Infrastructure.Contentful.csproj" />
+        <ProjectReference
+            Include="..\..\src\Dfe.PlanTech.Application\Dfe.PlanTech.Application.csproj" />
     </ItemGroup>
 
 

--- a/tests/Dfe.PlanTech.Infrastructure.Data.UnitTests/Dfe.PlanTech.Infrastructure.Data.UnitTests.csproj
+++ b/tests/Dfe.PlanTech.Infrastructure.Data.UnitTests/Dfe.PlanTech.Infrastructure.Data.UnitTests.csproj
@@ -14,19 +14,26 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="MockQueryable.EntityFrameworkCore" Version="7.0.3" />
     <PackageReference Include="MockQueryable.NSubstitute" Version="7.0.3" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10" />
-      <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Dfe.PlanTech.Infrastructure.Data\Dfe.PlanTech.Infrastructure.Data.csproj" />
-    <ProjectReference Include="..\Dfe.PlanTech.UnitTests.Shared\Dfe.PlanTech.UnitTests.Shared.csproj" />
-    <ProjectReference Include="..\..\src\Dfe.PlanTech.DatabaseUpgrader\Dfe.PlanTech.DatabaseUpgrader.csproj" />
+    <ProjectReference
+      Include="..\..\src\Dfe.PlanTech.Infrastructure.Data\Dfe.PlanTech.Infrastructure.Data.csproj" />
+    <ProjectReference
+      Include="..\Dfe.PlanTech.UnitTests.Shared\Dfe.PlanTech.UnitTests.Shared.csproj" />
+    <ProjectReference
+      Include="..\..\src\Dfe.PlanTech.DatabaseUpgrader\Dfe.PlanTech.DatabaseUpgrader.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Dfe.PlanTech.Infrastructure.ServiceBus.UnitTests/Dfe.PlanTech.Infrastructure.ServiceBus.UnitTests.csproj
+++ b/tests/Dfe.PlanTech.Infrastructure.ServiceBus.UnitTests/Dfe.PlanTech.Infrastructure.ServiceBus.UnitTests.csproj
@@ -17,6 +17,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
@@ -24,8 +28,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Dfe.PlanTech.Infrastructure.ServiceBus\Dfe.PlanTech.Infrastructure.ServiceBus.csproj" />
-    <ProjectReference Include="..\Dfe.PlanTech.UnitTests.Shared\Dfe.PlanTech.UnitTests.Shared.csproj" />
+    <ProjectReference
+      Include="..\..\src\Dfe.PlanTech.Infrastructure.ServiceBus\Dfe.PlanTech.Infrastructure.ServiceBus.csproj" />
+    <ProjectReference
+      Include="..\Dfe.PlanTech.UnitTests.Shared\Dfe.PlanTech.UnitTests.Shared.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Dfe.PlanTech.Infrastructure.SignIn.UnitTests/Dfe.PlanTech.Infrastructure.SignIn.UnitTests.csproj
+++ b/tests/Dfe.PlanTech.Infrastructure.SignIn.UnitTests/Dfe.PlanTech.Infrastructure.SignIn.UnitTests.csproj
@@ -18,6 +18,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+          <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Dfe.PlanTech.Web.UnitTests/Dfe.PlanTech.Web.UnitTests.csproj
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Dfe.PlanTech.Web.UnitTests.csproj
@@ -7,13 +7,16 @@
   </ItemGroup>
 
   <ItemGroup>
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-
     <PackageReference Include="xunit" Version="2.9.2" />
   </ItemGroup>
 


### PR DESCRIPTION
## Overview

Recent package upgrade broke the test runners/detection. This fixes that.

## Changes

### Minor

- Add `xunit.runner.visualstudio` project to unit test projects

## Additional notes

We should amend our unit test pipelines to have some bare basic logic that goes something like "if unit tests have ran -> at least one unit test must have ran and succeeded"

## Checklist

Delete any rows that do not apply to the PR.

- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch
- [ ] Unit tests have been added/updated