### PR TITLE
fix: C&S print button

### DIFF
--- a/src/Dfe.ContentSupport.Web/Views/Shared/_Print.cshtml
+++ b/src/Dfe.ContentSupport.Web/Views/Shared/_Print.cshtml
@@ -1,3 +1,1 @@
-﻿<div class="js-only print-button govuk-!-display-none-print">
-    <button class="govuk-link print-link-button" data-module="print-link" id="print-link" >Print this page</button>
-</div>
+﻿<button class="govuk-link print-link-button js-only print-button govuk-!-display-none-print" data-module="print-link" id="print-link" >Print this page</button>

--- a/src/Dfe.ContentSupport.Web/Views/Shared/_Print.cshtml
+++ b/src/Dfe.ContentSupport.Web/Views/Shared/_Print.cshtml
@@ -1,1 +1,1 @@
-﻿<button class="govuk-link print-link-button js-only print-button govuk-!-display-none-print" data-module="print-link" id="print-link" >Print this page</button>
+<button class="govuk-link print-link-button js-only print-button govuk-!-display-none-print" data-module="print-link" id="print-link">Print this page</button>

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/contentsupport/pages/feedback.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/contentsupport/pages/feedback.cy.js
@@ -1,6 +1,6 @@
 describe('Feedback banner', () => {
   it("should be visible when tracking consented", () => {
-    cy.visit('content/hello-world',
+    cy.visit('content/digital-technology-asset-register',
       {
         headers: {
           'Cookie': 'user_cookies_preferences=%7B%22UserAcceptsCookies%22%3Atrue%2C%22IsVisible%22%3Afalse%7D'
@@ -15,7 +15,7 @@ describe('Feedback banner', () => {
   });
 
   it("should not exist when tracking consent not given", () => {
-    cy.visit('content/hello-world',
+    cy.visit('content/digital-technology-asset-register',
       {
         headers: {
           'Cookie': 'user_cookies_preferences=%7B%22UserAcceptsCookies%22%3Afalse%2C%22IsVisible%22%3Afalse%7D'

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/contentsupport/pages/print-button.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/contentsupport/pages/print-button.cy.js
@@ -1,6 +1,6 @@
 describe('Print button', () => {
   beforeEach(() => {
-    cy.visit('content/hello-world', {
+    cy.visit('content/digital-technology-asset-register', {
       onBeforeLoad(win) {
         //Stub the print functionality so we can see if it was called
         //Note: could spy instead, but I don't want the print dialog to actually show.
@@ -10,12 +10,10 @@ describe('Print button', () => {
   });
 
   it("should be visible", () => {
-    cy.get("div.print-button")
+    cy.get("button#print-link")
       .should('exist')
-      .not("govuk-visually-hidden")
-      .should('not.have.attr', 'aria-hidden');
-
-    cy.get("button#print-link").should("exist");
+      .and('be.visible')
+      .and('not.have.attr', 'aria-hidden');
   });
 
   it("should print on click", () => {


### PR DESCRIPTION
## Overview

Fix rendering of print button on C&S pages

## How to review the PR

- View a C&S page with print button enabled
- Verify print button renders correctly
- Verify print button is not displayed with js disabled or when printing page


## Checklist

- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch
