### PR TITLE
chore: Remove all Contentful schema dependencies

### DIFF
--- a/src/Dfe.PlanTech.Application/Persistence/Interfaces/IPlanTechDbContext.cs
+++ b/src/Dfe.PlanTech.Application/Persistence/Interfaces/IPlanTechDbContext.cs
@@ -26,7 +26,7 @@ public interface IPlanTechDbContext
 
     Task<int> CallStoredProcedureWithReturnInt(string sprocName, IEnumerable<object> parameters, CancellationToken cancellationToken = default);
 
-    IQueryable<SectionStatusDto> GetSectionStatuses(string categoryId, int establishmentId);
+    IQueryable<SectionStatusDto> GetSectionStatuses(string sectionIds, int establishmentId);
 
     Task<User?> GetUserBy(Expression<Func<User, bool>> predicate);
 

--- a/src/Dfe.PlanTech.Application/Submissions/Queries/GetSubmissionStatusesQuery.cs
+++ b/src/Dfe.PlanTech.Application/Submissions/Queries/GetSubmissionStatusesQuery.cs
@@ -1,5 +1,6 @@
 using Dfe.PlanTech.Application.Persistence.Interfaces;
 using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
+using Dfe.PlanTech.Domain.Questionnaire.Models;
 using Dfe.PlanTech.Domain.Submissions.Enums;
 using Dfe.PlanTech.Domain.Submissions.Interfaces;
 using Dfe.PlanTech.Domain.Submissions.Models;
@@ -10,11 +11,13 @@ namespace Dfe.PlanTech.Application.Submissions.Queries;
 public class GetSubmissionStatusesQuery(IPlanTechDbContext db, IUser userHelper) : IGetSubmissionStatusesQuery
 {
 
-    public async Task<List<SectionStatusDto>> GetSectionSubmissionStatuses(string categoryId)
+    public async Task<List<SectionStatusDto>> GetSectionSubmissionStatuses(IEnumerable<Section> sections)
     {
         int establishmentId = await userHelper.GetEstablishmentId();
 
-        return await db.ToListAsync(db.GetSectionStatuses(categoryId, establishmentId));
+        var sectionIds = String.Join(',', sections.Select(section => section.Sys.Id));
+
+        return await db.ToListAsync(db.GetSectionStatuses(sectionIds, establishmentId));
     }
 
     public async Task<SectionStatus> GetSectionSubmissionStatusAsync(int establishmentId,
@@ -39,8 +42,8 @@ public class GetSubmissionStatusesQuery(IPlanTechDbContext db, IUser userHelper)
     }
 
     /// <summary>
-    /// For each submission, convert to SectionStatus, 
-    /// group by Section, 
+    /// For each submission, convert to SectionStatus,
+    /// group by Section,
     /// then return latest for each grouping
     /// optionally choosing from completed submissions first
     /// </summary>

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20241104_1200_RemoveContentfulDependencies.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20241104_1200_RemoveContentfulDependencies.sql
@@ -1,0 +1,46 @@
+ALTER PROCEDURE dbo.GetSectionStatuses @sectionIds NVARCHAR(MAX), @establishmentId INT
+AS
+
+SELECT
+    Value sectionId
+INTO #SectionIds
+FROM STRING_SPLIT(@sectionIds, ',')
+
+SELECT
+    CurrentSubmission.sectionId,
+    CurrentSubmission.completed,
+    LastCompleteSubmission.maturity   AS lastMaturity,
+    CurrentSubmission.dateCreated,
+    CurrentSubmission.dateLastUpdated AS dateUpdated
+FROM #SectionIds SI
+-- The current submission
+CROSS APPLY (
+    SELECT TOP 1
+        sectionId,
+        completed,
+        S.id,
+        dateCreated,
+        dateLastUpdated
+    FROM [dbo].submission S
+    WHERE
+          SI.sectionId = S.sectionId
+      AND S.establishmentId = @establishmentId
+      AND S.deleted = 0
+    ORDER BY S.dateCreated DESC
+) CurrentSubmission
+-- Use maturity from most recent complete submission (if there is one) so that user always sees recommendation
+OUTER APPLY (
+    SELECT TOP 1
+        maturity
+    FROM [dbo].submission S
+    WHERE
+          SI.sectionId = S.sectionId
+      AND S.establishmentId = @establishmentId
+      AND S.deleted = 0
+      AND s.completed = 1
+    ORDER BY S.dateCreated DESC
+) LastCompleteSubmission
+
+DROP TABLE #SectionIds
+
+GO

--- a/src/Dfe.PlanTech.Domain/Submissions/Interfaces/IGetSubmissionStatusesQuery.cs
+++ b/src/Dfe.PlanTech.Domain/Submissions/Interfaces/IGetSubmissionStatusesQuery.cs
@@ -1,11 +1,12 @@
 ﻿using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
+using Dfe.PlanTech.Domain.Questionnaire.Models;
 using Dfe.PlanTech.Domain.Submissions.Models;
 
 namespace Dfe.PlanTech.Domain.Submissions.Interfaces;
 
 public interface IGetSubmissionStatusesQuery
 {
-    Task<List<SectionStatusDto>> GetSectionSubmissionStatuses(string categoryId);
+    Task<List<SectionStatusDto>> GetSectionSubmissionStatuses(IEnumerable<Section> sections);
 
     Task<SectionStatus> GetSectionSubmissionStatusAsync(int establishmentId,
                                                            ISectionComponent section,

--- a/src/Dfe.PlanTech.Infrastructure.Data/PlanTechDbContext.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Data/PlanTechDbContext.cs
@@ -111,7 +111,7 @@ public class PlanTechDbContext : DbContext, IPlanTechDbContext
         });
     }
 
-    public IQueryable<SectionStatusDto> GetSectionStatuses(string categoryId, int establishmentId) => SectionStatusesSp.FromSqlInterpolated($"{DatabaseConstants.GetSectionStatuses} {categoryId} , {establishmentId}");
+    public IQueryable<SectionStatusDto> GetSectionStatuses(string sectionIds, int establishmentId) => SectionStatusesSp.FromSqlInterpolated($"{DatabaseConstants.GetSectionStatuses} {sectionIds} , {establishmentId}");
 
     public void AddUser(User user) => Users.Add(user);
 

--- a/src/Dfe.PlanTech.Web/ViewComponents/CategorySectionViewComponent.cs
+++ b/src/Dfe.PlanTech.Web/ViewComponents/CategorySectionViewComponent.cs
@@ -76,7 +76,7 @@ public class CategorySectionViewComponent(
     {
         try
         {
-            category.SectionStatuses = await _query.GetSectionSubmissionStatuses(category.Sys.Id);
+            category.SectionStatuses = await _query.GetSectionSubmissionStatuses(category.Sections);
             category.Completed = category.SectionStatuses.Count(x => x.Completed);
             category.RetrievalError = false;
             return category;

--- a/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/GetSubmissionStatusesQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/GetSubmissionStatusesQueryTests.cs
@@ -25,7 +25,7 @@ public class GetSubmissionStatusesQueryTests
     private const int establishmentId = 1;
     private const string maturity = "High";
 
-    private readonly static Section completeSection = new()
+    private static readonly Section completeSection = new()
     {
         Sys = new SystemDetails()
         {
@@ -34,7 +34,7 @@ public class GetSubmissionStatusesQueryTests
         Name = "section one"
     };
 
-    private readonly static Section inprogressSection = new()
+    private static readonly Section inprogressSection = new()
     {
         Sys = new SystemDetails()
         {
@@ -43,7 +43,7 @@ public class GetSubmissionStatusesQueryTests
         Name = "section two"
     };
 
-    private readonly static Section notstartedSection = new()
+    private static readonly Section notstartedSection = new()
     {
         Sys = new SystemDetails()
         {
@@ -106,7 +106,6 @@ public class GetSubmissionStatusesQueryTests
         }
     };
 
-
     private GetSubmissionStatusesQuery CreateStrut() => new GetSubmissionStatusesQuery(Db, user);
 
     public GetSubmissionStatusesQueryTests()
@@ -114,10 +113,8 @@ public class GetSubmissionStatusesQueryTests
         Db.GetSectionStatuses(Arg.Any<string>(), Arg.Any<int>())
         .Returns((callinfo) =>
         {
-            var categoryId = callinfo.ArgAt<string>(0);
-            var category = categories.FirstOrDefault(category => category.Sys.Id == categoryId);
-            Assert.NotNull(category);
-            return SectionStatuses.Where(sectionStatus => category.Sections.Select(section => section.Sys.Id).Any(id => id == sectionStatus.SectionId)).AsQueryable();
+            var sectionIds = callinfo.ArgAt<string>(0).Split(",");
+            return SectionStatuses.Where(sectionStatus => sectionIds.Contains(sectionStatus.SectionId)).AsQueryable();
         });
 
 
@@ -146,7 +143,7 @@ public class GetSubmissionStatusesQueryTests
     {
         var category = categories[0];
         var sections = category.Sections;
-        var result = await CreateStrut().GetSectionSubmissionStatuses(category.Sys.Id);
+        var result = await CreateStrut().GetSectionSubmissionStatuses(category.Sections);
 
         Assert.Equal(result.Count, sections.Count);
 

--- a/tests/Dfe.PlanTech.Web.UnitTests/ViewComponents/CategorySectionViewComponentTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/ViewComponents/CategorySectionViewComponentTests.cs
@@ -222,7 +222,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
                 DateUpdated = DateTime.Parse(utcTime),
             });
 
-            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sys.Id).Returns([.. _category.SectionStatuses]);
+            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sections).Returns([.. _category.SectionStatuses]);
 
             var result = await _categorySectionViewComponent.InvokeAsync(_category) as ViewViewComponentResult;
 
@@ -271,7 +271,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
                 DateUpdated = DateTime.Parse(utcTime)
             });
 
-            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sys.Id).Returns([.. _category.SectionStatuses]);
+            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sections).Returns([.. _category.SectionStatuses]);
 
             var result = await _categorySectionViewComponent.InvokeAsync(_category) as ViewViewComponentResult;
 
@@ -310,7 +310,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
         {
             _category.Completed = 0;
 
-            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sys.Id).Returns([.. _category.SectionStatuses]);
+            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sections).Returns([.. _category.SectionStatuses]);
 
             var result = await _categorySectionViewComponent.InvokeAsync(_category) as ViewViewComponentResult;
 
@@ -363,7 +363,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
                 Completed = true
             });
 
-            _ = _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sys.Id).Returns([.. _category.SectionStatuses]);
+            _ = _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sections).Returns([.. _category.SectionStatuses]);
 
             var result = await _categorySectionViewComponent.InvokeAsync(_category) as ViewViewComponentResult;
 
@@ -401,7 +401,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
         [Fact]
         public async Task Returns_ProgressRetrievalError_When_ProgressCanNotBeRetrieved()
         {
-            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(Arg.Any<string>())
+            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(Arg.Any<IEnumerable<Section>>())
                                         .ThrowsAsync(new Exception("Error occurred fection sections"));
 
             var result = await _categorySectionViewComponent.InvokeAsync(_category) as ViewViewComponentResult;
@@ -447,7 +447,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
                 }
             };
 
-            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sys.Id).Returns([.. _category.SectionStatuses]);
+            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sections).Returns([.. _category.SectionStatuses]);
 
             var result = await _categorySectionViewComponent.InvokeAsync(_category) as ViewViewComponentResult;
 
@@ -479,7 +479,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
             });
 
             _getSubTopicRecommendationQuery.GetSubTopicRecommendation(Arg.Any<string>()).Returns(_subtopic);
-            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sys.Id).Returns(_category.SectionStatuses.ToList());
+            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sections).Returns(_category.SectionStatuses.ToList());
 
             var result = await _categorySectionViewComponent.InvokeAsync(_category) as ViewViewComponentResult;
 
@@ -509,7 +509,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
             });
 
             _getSubTopicRecommendationQuery.GetSubTopicRecommendation(Arg.Any<string>()).Returns(_subtopic);
-            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sys.Id).Throws(new Exception("test"));
+            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sections).Throws(new Exception("test"));
 
             var result = await _categorySectionViewComponent.InvokeAsync(_category) as ViewViewComponentResult;
 
@@ -541,7 +541,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
                 LastMaturity = "Low",
             });
 
-            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sys.Id).Returns(_category.SectionStatuses.ToList());
+            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sections).Returns(_category.SectionStatuses.ToList());
 
             var result = await _categorySectionViewComponent.InvokeAsync(_category) as ViewViewComponentResult;
 
@@ -572,7 +572,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
                 LastMaturity = null
             });
 
-            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sys.Id).Returns(_category.SectionStatuses.ToList());
+            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sections).Returns(_category.SectionStatuses.ToList());
 
             var result = await _categorySectionViewComponent.InvokeAsync(_category) as ViewViewComponentResult;
 
@@ -602,7 +602,7 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
             });
 
             _getSubTopicRecommendationQuery.GetSubTopicRecommendation(Arg.Any<string>()).Returns(_subtopic);
-            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sys.Id).Returns(_category.SectionStatuses.ToList());
+            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sections).Returns(_category.SectionStatuses.ToList());
 
             var result = await _categorySectionViewComponent.InvokeAsync(_category) as ViewViewComponentResult;
 


### PR DESCRIPTION
## Overview

Addresses ticket [#235157](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/235157)

Removes any dependencies on the Contentful schema

Ignore the E2E failures - this will be another one that I'll have to run the script on manually before merge, its incompatible with the current DB

## Changes

- Amends the `GetSectionStatuses` procedure to use a list of sectionIds instead of the categoryId
  - This way it doesn't need to access any contentful tables to look up the relevant submissions

## How to review the PR

If you're using a tool like rider, datagrip or any other database IDE which supports scripting to file/clipboard you can script the dbo schema to file and verify that there are no longer any dependencies on the `Contentful` schema. Or we don't have that many stored procedures so you can skim through them in the portal

### Testing the sproc
- I created a duplicate `GetSectionStatusesTest` in dev, so you can just change the database constants to use that and test in dev
- Or alternatively restoring the seeded test database is another way to see that the updated `GetSectionStatuses` procedure works

## Checklist

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [x] Unit tests have been added/updated
