### PR TITLE
feat: recommendation sidebar accessibility changes

### DIFF
--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IHeaderWithContent.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IHeaderWithContent.cs
@@ -9,4 +9,8 @@ public interface IHeaderWithContent
     public string HeaderText { get; }
 
     public List<ContentComponent> Content { get; }
+
+    public string LinkText { get; }
+
+    public string SlugifiedLinkText { get; }
 }

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IHeaderWithContent.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IHeaderWithContent.cs
@@ -4,8 +4,6 @@ namespace Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 
 public interface IHeaderWithContent
 {
-    public string SlugifiedHeader { get; }
-
     public string HeaderText { get; }
 
     public List<ContentComponent> Content { get; }

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationChunk.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationChunk.cs
@@ -18,4 +18,10 @@ public class RecommendationChunk : ContentComponent, IRecommendationChunk<Answer
     public CSLink? CSLink { get; init; }
 
     public string HeaderText => Header;
+
+    public string LinkText => HeaderText;
+
+    private string? _slugifiedLinkText;
+
+    public string SlugifiedLinkText => _slugifiedLinkText ??= LinkText.Slugify();
 }

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationChunk.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationChunk.cs
@@ -5,15 +5,11 @@ namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
 public class RecommendationChunk : ContentComponent, IRecommendationChunk<Answer, ContentComponent>, IHeaderWithContent
 {
-    private string? _slugifiedHeader;
-
     public string Header { get; init; } = null!;
 
     public List<ContentComponent> Content { get; init; } = [];
 
     public List<Answer> Answers { get; init; } = [];
-
-    public string SlugifiedHeader => _slugifiedHeader ??= Header.Slugify();
 
     public CSLink? CSLink { get; init; }
 

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationIntro.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationIntro.cs
@@ -6,8 +6,6 @@ namespace Dfe.PlanTech.Domain.Questionnaire.Models;
 
 public class RecommendationIntro : ContentComponent, IRecommendationIntro<Header, ContentComponent>, IHeaderWithContent
 {
-    private string? _slugifiedHeader;
-
     public string Slug { get; init; } = null!;
 
     public Header Header { get; init; } = null!;
@@ -16,8 +14,6 @@ public class RecommendationIntro : ContentComponent, IRecommendationIntro<Header
 
     [NotMapped]
     public List<ContentComponent> Content { get; init; } = [];
-
-    public string SlugifiedHeader => _slugifiedHeader ??= Header.Text.Slugify();
 
     public string HeaderText => Header.Text;
 

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationIntro.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/RecommendationIntro.cs
@@ -20,4 +20,10 @@ public class RecommendationIntro : ContentComponent, IRecommendationIntro<Header
     public string SlugifiedHeader => _slugifiedHeader ??= Header.Text.Slugify();
 
     public string HeaderText => Header.Text;
+
+    public string LinkText => "Overview";
+
+    private string? _slugifiedLinkText;
+
+    public string SlugifiedLinkText => _slugifiedLinkText ??= LinkText.Slugify();
 }

--- a/src/Dfe.PlanTech.Web/Views/Recommendations/RecommendationContent.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/RecommendationContent.cshtml
@@ -11,7 +11,7 @@
 
     var nextContent = x + 1 < allContent.Length ? allContent[x+1] : null;
 
-    <div class="recommendation-piece-container" id="@headerWithContent.SlugifiedHeader">
+    <div class="recommendation-piece-container" id="@headerWithContent.SlugifiedLinkText">
     <div class="recommendation-piece-header">
         <div class="recommendation-piece-header">
             <h1 class="govuk-heading-xl">@headerWithContent.HeaderText</h1>
@@ -20,7 +20,7 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-quarter">
             @{
-                    ViewData["VerticalNavigationSection"] = headerWithContent.SlugifiedHeader;
+                    ViewData["VerticalNavigationSection"] = headerWithContent.SlugifiedLinkText;
                 }
                 <partial name="Components/VerticalNavigation/Default" model="@Model.AllContent" />
             </div>
@@ -44,11 +44,11 @@
                 <div>
                     <govuk-pagination>
                     @if(previousContent != null){
-                        <govuk-pagination-previous href="#@previousContent.SlugifiedHeader" label-text="@previousContent.HeaderText" />
+                        <govuk-pagination-previous href="#@previousContent.SlugifiedLinkText" label-text="@previousContent.LinkText" />
                     }
 
                     @if(nextContent != null){
-                        <govuk-pagination-next href="#@nextContent.SlugifiedHeader" label-text="@nextContent.HeaderText" />
+                        <govuk-pagination-next href="#@nextContent.SlugifiedLinkText" label-text="@nextContent.LinkText" />
                         }
                     </govuk-pagination>
                 </div>

--- a/src/Dfe.PlanTech.Web/Views/Recommendations/RecommendationPrintContent.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/RecommendationPrintContent.cshtml
@@ -13,7 +13,7 @@
             {
                 await Html.RenderPartialAsync("Components/PageComponentFactory", content);
             }
-            @{ ViewData["RecommendationsActionsHeader"] = headerWithContent.SlugifiedHeader; }
+            @{ ViewData["RecommendationsActionsHeader"] = headerWithContent.SlugifiedLinkText; }
         </div>
     }
 }

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/HeaderWithContent.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/HeaderWithContent.cshtml
@@ -6,7 +6,7 @@
     var contentClass = ViewData["ContentClass"] ?? "header-with-content-content";
 }
 
-<div class="@parentContainerClass" id="@Model.SlugifiedHeader">
+<div class="@parentContainerClass" id="@Model.SlugifiedLinkText">
     <div class="@headerClass">
         <div class="recommendation-piece-header">
             <h1 class="govuk-heading-xl">@Model.HeaderText</h1>

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/VerticalNavigation/Default.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/VerticalNavigation/Default.cshtml
@@ -1,16 +1,16 @@
 @model IEnumerable<Dfe.PlanTech.Domain.Questionnaire.Interfaces.IHeaderWithContent>
 
 <nav class="dfe-vertical-nav">
-    <h2 class="dfe-vertical-nav__theme govuk-heading-m">List of actions</h2>
+    <h2 class="dfe-vertical-nav__theme govuk-heading-m">Recommendations</h2>
     <ul class="dfe-vertical-nav__section govuk-!-padding-left-0">
-        @foreach (var chunk in Model)
+        @foreach (var content in Model)
         {
-            var classes = chunk.SlugifiedHeader == ViewData["VerticalNavigationSection"]?.ToString()
+            var classes = content.SlugifiedHeader == ViewData["VerticalNavigationSection"]?.ToString()
                 ? "dfe-vertical-nav__link--selected"
                 : "";
 
             <li class="dfe-vertical-nav__section-item">
-                <a class="dfe-vertical-nav__link @classes" href="#@chunk.SlugifiedHeader">@chunk.HeaderText</a>
+                <a class="dfe-vertical-nav__link @classes" href="#@content.SlugifiedLinkText">@content.LinkText</a>
             </li>
         }
     </ul>

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/VerticalNavigation/Default.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/VerticalNavigation/Default.cshtml
@@ -5,7 +5,7 @@
     <ul class="dfe-vertical-nav__section govuk-!-padding-left-0">
         @foreach (var content in Model)
         {
-            var classes = content.SlugifiedHeader == ViewData["VerticalNavigationSection"]?.ToString()
+            var classes = content.SlugifiedLinkText == ViewData["VerticalNavigationSection"]?.ToString()
                 ? "dfe-vertical-nav__link--selected"
                 : "";
 

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/dynamic-page-validator/validators/completion-tags.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/dynamic-page-validator/validators/completion-tags.js
@@ -30,7 +30,7 @@ export const validateCompletionTags = (section, introPage) => {
         .parent().next().next()
         .within(() => {
             cy.get("strong.app-task-list__tag").should("include.text", "New").and("have.class", "govuk-tag--yellow");
-            cy.get("a.govuk-button").contains("View Recommendation")
+            cy.get("a.govuk-button").contains("View recommendation")
                 .should("have.attr", "href")
                 .and("include", expectedPath);
         })

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/dynamic-page-validator/validators/recommendation-chunks.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/dynamic-page-validator/validators/recommendation-chunks.js
@@ -3,12 +3,10 @@ import { CleanText, ValidateContent, slugifyChunks } from "../helpers/index.js";
 
 export const validateRecommendationChunks = (introPage, chunks) => {
 
-    cy.get("h2.dfe-vertical-nav__theme").contains("List of actions").should("exist");
-
     chunks.forEach((chunk, i) => {
         const chunkSlug = `${slugifyChunks(chunk.header)}`;
 
-        cy.get("ul.dfe-vertical-nav__section > li").eq(i).within(() => {
+        cy.get("ul.dfe-vertical-nav__section > li").eq(i + 1).within(() => {
             cy.get(`a.dfe-vertical-nav__link:contains(${CleanText(chunk.header)})`).each($link => {
                 expect($link).to.have.attr("href").contains(`#${chunkSlug}`);
             })

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/dynamic-page-validator/validators/recommendation-intro.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/dynamic-page-validator/validators/recommendation-intro.js
@@ -6,7 +6,15 @@ export const validateRecommendationIntro = (introPage, recommendationUrl) => {
     cy.url().should("include", `${recommendationUrl}/${slug}`);
 
     cy.get("h1.govuk-heading-xl").contains(header);
- 
+
+    cy.get("h2.dfe-vertical-nav__theme").contains("Recommendations").should("exist");
+
+    cy.get("ul.dfe-vertical-nav__section > li").eq(0).within(() => {
+        cy.get("a.dfe-vertical-nav__link")
+            .contains("Overview")
+            .should("have.attr", "href", "#overview")
+    });
+
     if (content) {
         for (const component of content) {
             if (!component) {

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/dynamic-page-validator/validators/validate-recommendations.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/dynamic-page-validator/validators/validate-recommendations.js
@@ -35,7 +35,7 @@ export const validateAndTestRecommendations = (section, maturity, path) => {
             .contains(section.name.trim())
             .parent().next().next()
             .within(() => {
-                cy.get("a.govuk-button").contains("View Recommendation").click();
+                cy.get("a.govuk-button").contains("View recommendation").click();
             })
         validateRecommendationIntro(introPage, recommendationUrl);
     });

--- a/tests/Dfe.PlanTech.Web.UnitTests/Models/ComponentModelTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Models/ComponentModelTests.cs
@@ -1,119 +1,13 @@
-﻿using Xunit;
+﻿using Xunit;namespace Dfe.PlanTech.Web.UnitTests.Models{    public class ComponentModelTests    {        private readonly ComponentBuilder _componentBuilder;        public ComponentModelTests()        {            _componentBuilder = new ComponentBuilder();        }        [Fact]        public void Should_Render_Button_Component()        {            var actual = _componentBuilder.BuildButtonWithLink();            Assert.NotNull(actual);            Assert.Equal("Submit", actual.Button.Value);            Assert.False(actual.Button.IsStartButton);            Assert.Equal("/FakeLink", actual.Href);        }        [Fact]        public void Should_Render_Dropdown_Component()        {            var actual = _componentBuilder.BuildDropDownComponent();            Assert.NotNull(actual);            Assert.Equal("Dropdown", actual.Title);            Assert.NotNull(actual.Content);            Assert.Equal("Content", actual.Content.Value);        }        [Fact]        public void Should_Render_TextBody_Component()        {            var actual = _componentBuilder.BuildTextBody();            Assert.NotNull(actual);            Assert.Equal("Content", actual.RichText.Value);        }        [Fact]        public void Should_Render_Category_Component()        {            var actual = _componentBuilder.BuildCategory();            Assert.NotNull(actual);            Assert.Equal("Category", actual.Header.Text);            Assert.Equal("Section", actual.Sections[0].Name);            Assert.NotNull(actual.Sections[0].Questions);            Assert.Equal("Question Text", actual.Sections[0].Questions[0].Text);            Assert.Equal("Help Text", actual.Sections[0].Questions[0].HelpText);            Assert.NotNull(actual.Sections[0].Questions[0].Answers[0]);            Assert.Equal("Answer", actual.Sections[0].Questions[0].Answers[0].Text);            Assert.Equal(0, actual.Completed);        }        [Fact]        public void Should_Render_ButtonWithEntryReference()        {            var actual = _componentBuilder.BuildButtonWithEntryReference();            Assert.NotNull(actual);            Assert.Equal("Submit", actual.Button.Value);            Assert.False(actual.Button.IsStartButton);            Assert.NotNull(actual.LinkToEntry);        }        [Fact]        public void Should_Render_InsetText()        {            var actual = _componentBuilder.BuildInsetText();            Assert.NotNull(actual);            Assert.Equal("Inset Text", actual.Text);        }        [Theory]        [InlineData("Random test Topic", "random-test-topic")]        [InlineData("Y867as ()&ycj Cool Thing", "y867as-ycj-cool-thing")]        [InlineData("Save a back-up...", "save-a-back-up")]        [InlineData("This is a string with loads of spaces at the end        ", "this-is-a-string-with-loads-of-spaces-at-the-end")]        [InlineData("This is a string with loads of spaces at the end        and-this", "this-is-a-string-with-loads-of-spaces-at-the-end--------and-this")]        [InlineData(" spaces either side     ", "spaces-either-side")]        [InlineData(@"Lineseparatorcharacter", "line-separator-character")]        public void Slugify_Should_Slugify_Strings(string linkText, string expectedResult)        {            var recommendationChunk = ComponentBuilder.BuildRecommendationChunk(linkText);            Assert.Equal(expectedResult, recommendationChunk.SlugifiedLinkText);        }        [Theory]        [InlineData("Random test Topic")]        [InlineData("Y867as ()&ycj Cool Thing")]        public void RecommendationIntro_Should_Return_Correct_Header_And_Title(string header)        {            var recommendationIntro = ComponentBuilder.BuildRecommendationIntro(header);            Assert.Equal(header, recommendationIntro.Header.Text);            Assert.Equal(header, recommendationIntro.HeaderText);        }
 
-namespace Dfe.PlanTech.Web.UnitTests.Models
-{
-    public class ComponentModelTests
-    {
-        private readonly ComponentBuilder _componentBuilder;
-
-        public ComponentModelTests()
-        {
-            _componentBuilder = new ComponentBuilder();
-        }
-
-        [Fact]
-        public void Should_Render_Button_Component()
-        {
-            var actual = _componentBuilder.BuildButtonWithLink();
-            Assert.NotNull(actual);
-            Assert.Equal("Submit", actual.Button.Value);
-            Assert.False(actual.Button.IsStartButton);
-            Assert.Equal("/FakeLink", actual.Href);
-        }
-
-        [Fact]
-        public void Should_Render_Dropdown_Component()
-        {
-            var actual = _componentBuilder.BuildDropDownComponent();
-            Assert.NotNull(actual);
-            Assert.Equal("Dropdown", actual.Title);
-            Assert.NotNull(actual.Content);
-            Assert.Equal("Content", actual.Content.Value);
-        }
-
-        [Fact]
-        public void Should_Render_TextBody_Component()
-        {
-            var actual = _componentBuilder.BuildTextBody();
-            Assert.NotNull(actual);
-            Assert.Equal("Content", actual.RichText.Value);
-        }
-
-        [Fact]
-        public void Should_Render_Category_Component()
-        {
-            var actual = _componentBuilder.BuildCategory();
-            Assert.NotNull(actual);
-            Assert.Equal("Category", actual.Header.Text);
-            Assert.Equal("Section", actual.Sections[0].Name);
-            Assert.NotNull(actual.Sections[0].Questions);
-            Assert.Equal("Question Text", actual.Sections[0].Questions[0].Text);
-            Assert.Equal("Help Text", actual.Sections[0].Questions[0].HelpText);
-            Assert.NotNull(actual.Sections[0].Questions[0].Answers[0]);
-            Assert.Equal("Answer", actual.Sections[0].Questions[0].Answers[0].Text);
-            Assert.Equal(0, actual.Completed);
-        }
-
-
-        [Fact]
-        public void Should_Render_ButtonWithEntryReference()
-        {
-            var actual = _componentBuilder.BuildButtonWithEntryReference();
-            Assert.NotNull(actual);
-            Assert.Equal("Submit", actual.Button.Value);
-            Assert.False(actual.Button.IsStartButton);
-            Assert.NotNull(actual.LinkToEntry);
-        }
-
-        [Fact]
-        public void Should_Render_InsetText()
-        {
-            var actual = _componentBuilder.BuildInsetText();
-
-            Assert.NotNull(actual);
-            Assert.Equal("Inset Text", actual.Text);
-        }
-
-        [Theory]
-        [InlineData("Random test Topic", "random-test-topic")]
-        [InlineData("Y867as ()&ycj Cool Thing", "y867as-ycj-cool-thing")]
-        [InlineData("Save a back-up...", "save-a-back-up")]
-        [InlineData("This is a string with loads of spaces at the end        ", "this-is-a-string-with-loads-of-spaces-at-the-end")]
-        [InlineData("This is a string with loads of spaces at the end        and-this", "this-is-a-string-with-loads-of-spaces-at-the-end--------and-this")]
-        [InlineData(" spaces either side     ", "spaces-either-side")]
-        [InlineData(@"Line separator character ", "line-separator-character")]
-        public void Slugify_Should_Slugify_Strings(string header, string expectedResult)
+        [Theory]        [InlineData("Random test Topic", "overview")]        [InlineData("Pasdw!345      dsdoiu()=2 Yo ", "overview")]        public void RecommendationIntro_Should_Return_Correct_LinkText(string header, string expectedResult)        {            var recommendationIntro = ComponentBuilder.BuildRecommendationIntro(header);            Assert.Equal("Overview", recommendationIntro.LinkText);            Assert.Equal(expectedResult, recommendationIntro.SlugifiedLinkText);        }
+        [Theory]        [InlineData("Random test Topic", "random-test-topic")]        [InlineData("Y867as ()&ycj Cool Thing", "y867as-ycj-cool-thing")]
+        public void RecommendationChunk_Should_Return_Correct_Header_Title_And_LinkText(string header, string expectedResult)
         {
             var recommendationChunk = ComponentBuilder.BuildRecommendationChunk(header);
 
-            Assert.Equal(expectedResult, recommendationChunk.SlugifiedHeader);
+            Assert.Equal(header, recommendationChunk.HeaderText);
+            Assert.Equal(header, recommendationChunk.LinkText);
+            Assert.Equal(expectedResult, recommendationChunk.SlugifiedLinkText);
         }
-
-        [Theory]
-        [InlineData("Random test Topic", "random-test-topic")]
-        [InlineData("Y867as ()&ycj Cool Thing", "y867as-ycj-cool-thing")]
-        public void RecommendationIntro_Should_Return_Correct_Header_And_Title(string header, string expectedResult)
-        {
-            var recommendationIntro = ComponentBuilder.BuildRecommendationIntro(header);
-
-            Assert.Equal(header, recommendationIntro.Header.Text);
-            Assert.Equal(header, recommendationIntro.HeaderText);
-            Assert.Equal(expectedResult, recommendationIntro.SlugifiedHeader);
-        }
-
-        [Fact]
-        public void RecommendationViewModel_Should_Return_All_Content()
-        {
-            var recommendationViewModel = ComponentBuilder.BuildRecommendationViewModel();
-
-            var allContent = recommendationViewModel.AllContent.ToList();
-
-            Assert.Contains(recommendationViewModel.Intro, allContent);
-
-            foreach (var chunk in recommendationViewModel.Chunks)
-            {
-                Assert.Contains(chunk, allContent);
-            }
-        }
-    }
-}
+        [Fact]        public void RecommendationViewModel_Should_Return_All_Content()        {            var recommendationViewModel = ComponentBuilder.BuildRecommendationViewModel();            var allContent = recommendationViewModel.AllContent.ToList();            Assert.Contains(recommendationViewModel.Intro, allContent);            foreach (var chunk in recommendationViewModel.Chunks)            {                Assert.Contains(chunk, allContent);            }        }    }}

--- a/tests/Dfe.PlanTech.Web.UnitTests/Models/ComponentModelTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Models/ComponentModelTests.cs
@@ -1,7 +1,122 @@
-﻿using Xunit;namespace Dfe.PlanTech.Web.UnitTests.Models{    public class ComponentModelTests    {        private readonly ComponentBuilder _componentBuilder;        public ComponentModelTests()        {            _componentBuilder = new ComponentBuilder();        }        [Fact]        public void Should_Render_Button_Component()        {            var actual = _componentBuilder.BuildButtonWithLink();            Assert.NotNull(actual);            Assert.Equal("Submit", actual.Button.Value);            Assert.False(actual.Button.IsStartButton);            Assert.Equal("/FakeLink", actual.Href);        }        [Fact]        public void Should_Render_Dropdown_Component()        {            var actual = _componentBuilder.BuildDropDownComponent();            Assert.NotNull(actual);            Assert.Equal("Dropdown", actual.Title);            Assert.NotNull(actual.Content);            Assert.Equal("Content", actual.Content.Value);        }        [Fact]        public void Should_Render_TextBody_Component()        {            var actual = _componentBuilder.BuildTextBody();            Assert.NotNull(actual);            Assert.Equal("Content", actual.RichText.Value);        }        [Fact]        public void Should_Render_Category_Component()        {            var actual = _componentBuilder.BuildCategory();            Assert.NotNull(actual);            Assert.Equal("Category", actual.Header.Text);            Assert.Equal("Section", actual.Sections[0].Name);            Assert.NotNull(actual.Sections[0].Questions);            Assert.Equal("Question Text", actual.Sections[0].Questions[0].Text);            Assert.Equal("Help Text", actual.Sections[0].Questions[0].HelpText);            Assert.NotNull(actual.Sections[0].Questions[0].Answers[0]);            Assert.Equal("Answer", actual.Sections[0].Questions[0].Answers[0].Text);            Assert.Equal(0, actual.Completed);        }        [Fact]        public void Should_Render_ButtonWithEntryReference()        {            var actual = _componentBuilder.BuildButtonWithEntryReference();            Assert.NotNull(actual);            Assert.Equal("Submit", actual.Button.Value);            Assert.False(actual.Button.IsStartButton);            Assert.NotNull(actual.LinkToEntry);        }        [Fact]        public void Should_Render_InsetText()        {            var actual = _componentBuilder.BuildInsetText();            Assert.NotNull(actual);            Assert.Equal("Inset Text", actual.Text);        }        [Theory]        [InlineData("Random test Topic", "random-test-topic")]        [InlineData("Y867as ()&ycj Cool Thing", "y867as-ycj-cool-thing")]        [InlineData("Save a back-up...", "save-a-back-up")]        [InlineData("This is a string with loads of spaces at the end        ", "this-is-a-string-with-loads-of-spaces-at-the-end")]        [InlineData("This is a string with loads of spaces at the end        and-this", "this-is-a-string-with-loads-of-spaces-at-the-end--------and-this")]        [InlineData(" spaces either side     ", "spaces-either-side")]        [InlineData(@"Lineseparatorcharacter", "line-separator-character")]        public void Slugify_Should_Slugify_Strings(string linkText, string expectedResult)        {            var recommendationChunk = ComponentBuilder.BuildRecommendationChunk(linkText);            Assert.Equal(expectedResult, recommendationChunk.SlugifiedLinkText);        }        [Theory]        [InlineData("Random test Topic")]        [InlineData("Y867as ()&ycj Cool Thing")]        public void RecommendationIntro_Should_Return_Correct_Header_And_Title(string header)        {            var recommendationIntro = ComponentBuilder.BuildRecommendationIntro(header);            Assert.Equal(header, recommendationIntro.Header.Text);            Assert.Equal(header, recommendationIntro.HeaderText);        }
+﻿using Xunit;
 
-        [Theory]        [InlineData("Random test Topic", "overview")]        [InlineData("Pasdw!345      dsdoiu()=2 Yo ", "overview")]        public void RecommendationIntro_Should_Return_Correct_LinkText(string header, string expectedResult)        {            var recommendationIntro = ComponentBuilder.BuildRecommendationIntro(header);            Assert.Equal("Overview", recommendationIntro.LinkText);            Assert.Equal(expectedResult, recommendationIntro.SlugifiedLinkText);        }
-        [Theory]        [InlineData("Random test Topic", "random-test-topic")]        [InlineData("Y867as ()&ycj Cool Thing", "y867as-ycj-cool-thing")]
+namespace Dfe.PlanTech.Web.UnitTests.Models
+{
+    public class ComponentModelTests
+    {
+        private readonly ComponentBuilder _componentBuilder;
+
+        public ComponentModelTests()
+        {
+            _componentBuilder = new ComponentBuilder();
+        }
+
+        [Fact]
+        public void Should_Render_Button_Component()
+        {
+            var actual = _componentBuilder.BuildButtonWithLink();
+            Assert.NotNull(actual);
+            Assert.Equal("Submit", actual.Button.Value);
+            Assert.False(actual.Button.IsStartButton);
+            Assert.Equal("/FakeLink", actual.Href);
+        }
+
+        [Fact]
+        public void Should_Render_Dropdown_Component()
+        {
+            var actual = _componentBuilder.BuildDropDownComponent();
+            Assert.NotNull(actual);
+            Assert.Equal("Dropdown", actual.Title);
+            Assert.NotNull(actual.Content);
+            Assert.Equal("Content", actual.Content.Value);
+        }
+
+        [Fact]
+        public void Should_Render_TextBody_Component()
+        {
+            var actual = _componentBuilder.BuildTextBody();
+            Assert.NotNull(actual);
+            Assert.Equal("Content", actual.RichText.Value);
+        }
+
+        [Fact]
+        public void Should_Render_Category_Component()
+        {
+            var actual = _componentBuilder.BuildCategory();
+            Assert.NotNull(actual);
+            Assert.Equal("Category", actual.Header.Text);
+            Assert.Equal("Section", actual.Sections[0].Name);
+            Assert.NotNull(actual.Sections[0].Questions);
+            Assert.Equal("Question Text", actual.Sections[0].Questions[0].Text);
+            Assert.Equal("Help Text", actual.Sections[0].Questions[0].HelpText);
+            Assert.NotNull(actual.Sections[0].Questions[0].Answers[0]);
+            Assert.Equal("Answer", actual.Sections[0].Questions[0].Answers[0].Text);
+            Assert.Equal(0, actual.Completed);
+        }
+
+
+        [Fact]
+        public void Should_Render_ButtonWithEntryReference()
+        {
+            var actual = _componentBuilder.BuildButtonWithEntryReference();
+            Assert.NotNull(actual);
+            Assert.Equal("Submit", actual.Button.Value);
+            Assert.False(actual.Button.IsStartButton);
+            Assert.NotNull(actual.LinkToEntry);
+        }
+
+        [Fact]
+        public void Should_Render_InsetText()
+        {
+            var actual = _componentBuilder.BuildInsetText();
+
+            Assert.NotNull(actual);
+            Assert.Equal("Inset Text", actual.Text);
+        }
+
+        [Theory]
+        [InlineData("Random test Topic", "random-test-topic")]
+        [InlineData("Y867as ()&ycj Cool Thing", "y867as-ycj-cool-thing")]
+        [InlineData("Save a back-up...", "save-a-back-up")]
+        [InlineData("This is a string with loads of spaces at the end        ", "this-is-a-string-with-loads-of-spaces-at-the-end")]
+        [InlineData("This is a string with loads of spaces at the end        and-this", "this-is-a-string-with-loads-of-spaces-at-the-end--------and-this")]
+        [InlineData(" spaces either side     ", "spaces-either-side")]
+        [InlineData(@"Line
+separator
+character
+", "line-separator-character")]
+        public void Slugify_Should_Slugify_Strings(string linkText, string expectedResult)
+        {
+            var recommendationChunk = ComponentBuilder.BuildRecommendationChunk(linkText);
+
+            Assert.Equal(expectedResult, recommendationChunk.SlugifiedLinkText);
+        }
+
+        [Theory]
+        [InlineData("Random test Topic")]
+        [InlineData("Y867as ()&ycj Cool Thing")]
+        public void RecommendationIntro_Should_Return_Correct_Header_And_Title(string header)
+        {
+            var recommendationIntro = ComponentBuilder.BuildRecommendationIntro(header);
+
+            Assert.Equal(header, recommendationIntro.Header.Text);
+            Assert.Equal(header, recommendationIntro.HeaderText);
+        }
+
+        [Theory]
+        [InlineData("Random test Topic", "overview")]
+        [InlineData("Pasdw!345      dsdoiu()=2 Yo ", "overview")]
+        public void RecommendationIntro_Should_Return_Correct_LinkText(string header, string expectedResult)
+        {
+            var recommendationIntro = ComponentBuilder.BuildRecommendationIntro(header);
+
+            Assert.Equal("Overview", recommendationIntro.LinkText);
+            Assert.Equal(expectedResult, recommendationIntro.SlugifiedLinkText);
+        }
+
+        [Theory]
+        [InlineData("Random test Topic", "random-test-topic")]
+        [InlineData("Y867as ()&ycj Cool Thing", "y867as-ycj-cool-thing")]
         public void RecommendationChunk_Should_Return_Correct_Header_Title_And_LinkText(string header, string expectedResult)
         {
             var recommendationChunk = ComponentBuilder.BuildRecommendationChunk(header);
@@ -10,4 +125,20 @@
             Assert.Equal(header, recommendationChunk.LinkText);
             Assert.Equal(expectedResult, recommendationChunk.SlugifiedLinkText);
         }
-        [Fact]        public void RecommendationViewModel_Should_Return_All_Content()        {            var recommendationViewModel = ComponentBuilder.BuildRecommendationViewModel();            var allContent = recommendationViewModel.AllContent.ToList();            Assert.Contains(recommendationViewModel.Intro, allContent);            foreach (var chunk in recommendationViewModel.Chunks)            {                Assert.Contains(chunk, allContent);            }        }    }}
+
+        [Fact]
+        public void RecommendationViewModel_Should_Return_All_Content()
+        {
+            var recommendationViewModel = ComponentBuilder.BuildRecommendationViewModel();
+
+            var allContent = recommendationViewModel.AllContent.ToList();
+
+            Assert.Contains(recommendationViewModel.Intro, allContent);
+
+            foreach (var chunk in recommendationViewModel.Chunks)
+            {
+                Assert.Contains(chunk, allContent);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Overview

Addresses ticket [#234960](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/234960)

Changes to display of Recommendations sidebar.

The design for the ticket is based on [this prototype](https://content-and-support-3394b320ea96.herokuapp.com/sandbox/pt-recomendation-c1/prototype-a/recomendations#)

## Changes

### Major

- Recommendation Intro header is displayed in the sidebar, pagination and slug as 'Overview' (main header and print view unchanged)

### Minor

- Sidebar header changed to 'Recommendations' from 'List of actions'

### Non-functional changes (e.g. documentation)

- Added and amended unit tests and amended E2E tests.

## How to review the PR

Test against a recommendations page as per normal.

To run E2E tests while running locally, change the url in `cypress.env.json` to localhost, and open cypress using localhost as the baseUrl (see cypress E2E readme for further details if needed). Once loaded, run the `rec-maturity-paths.cy.js` file to test DPV changes and the `recommendation-page.cy.js` file. There will be failures in the DPV file when running in dev, particularly if you have unfinished paths, but the recommendation intro and chunks tests should pass/pass these bits.

## Release requirements

Nothing unusual.

## Checklist

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [x] Unit tests have been added/updated
- [x] E2E tests have been added/updated