### PR TITLE
fix(redis): Preserve references in serialisation

### DIFF
--- a/src/Dfe.PlanTech.Infrastructure.Redis/JsonSerialiser.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Redis/JsonSerialiser.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using Dfe.PlanTech.Domain.Content.Models;
 using StackExchange.Redis;
@@ -11,11 +12,14 @@ namespace Dfe.PlanTech.Infrastructure.Redis;
 public static class JsonSerialiser
 {
     /// <summary>
-    /// Default JSON options to use; adds base class type info resolver from <see cref="ContentComponentJsonExtensions.AddContentComponentPolymorphicInfo"/> 
+    /// Default JSON options to use; adds base class type info resolver from <see cref="ContentComponentJsonExtensions.AddContentComponentPolymorphicInfo"/>
     /// </summary>
     private static readonly JsonSerializerOptions JsonSerialiserOptions = new()
     {
-        TypeInfoResolver = new DefaultJsonTypeInfoResolver().WithAddedModifier(ContentComponentJsonExtensions.AddContentComponentPolymorphicInfo),
+        TypeInfoResolver =
+            new DefaultJsonTypeInfoResolver().WithAddedModifier(ContentComponentJsonExtensions
+                .AddContentComponentPolymorphicInfo),
+        ReferenceHandler = ReferenceHandler.Preserve
     };
 
     /// <summary>


### PR DESCRIPTION
## Overview

Fixes issue with serialisation where the parent has a lot of objects with references

## Changes

### Minor

- Set [reference handler to preserve](https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/preserve-references)

## How to review the PR

## Checklist

- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch
