### PR TITLE
feat: Add support for notification banners

### DIFF
--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/INotificationBanner.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/INotificationBanner.cs
@@ -1,0 +1,13 @@
+namespace Dfe.PlanTech.Domain.Content.Interfaces;
+
+/// <summary>
+/// Model for Notification Banner Component content type
+/// </summary>
+public interface INotificationBanner<out TTextBody>
+where TTextBody : ITextBody
+{
+    /// <summary>
+    /// Notification text
+    /// </summary>
+    public TTextBody Text { get; }
+}

--- a/src/Dfe.PlanTech.Domain/Content/Models/NotificationBanner.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/NotificationBanner.cs
@@ -1,0 +1,8 @@
+using Dfe.PlanTech.Domain.Content.Interfaces;
+
+namespace Dfe.PlanTech.Domain.Content.Models;
+
+public class NotificationBanner : ContentComponent, INotificationBanner<TextBody>
+{
+    public TextBody Text { get; init; } = null!;
+}

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/NotificationBanner.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/NotificationBanner.cshtml
@@ -1,0 +1,7 @@
+@model Dfe.PlanTech.Domain.Content.Models.NotificationBanner;
+
+<govuk-notification-banner>
+  @{
+    await Html.RenderPartialAsync("Components/PageComponentFactory", Model.Text);
+  }
+</govuk-notification-banner>

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/dynamic-page-validator/dynamic-page-validator-readme.md
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/dynamic-page-validator/dynamic-page-validator-readme.md
@@ -2,7 +2,7 @@
 
 ## Instructions
 
-1. When branching from development, a dummy version of `contentful-data.json` will be in the `\fixtures` folder. This file exists to ensure that pipeline tests will be skipped. 
+1. When branching from development, a dummy version of `contentful-data.json` will be in the `\fixtures` folder. This file exists to ensure that pipeline tests will be skipped.
 2. Delete `contentful-data.json` to enable a fresh data file to be created when the DPV is run.
 3. Before running Cypress, run `npm install` from `\Dfe.PlanTech.Web.E2ETests` to install the Contentful export processor.
 4. Run Cypress as normal (using `npx cypress open --config "baseUrl=URL"` where URL is that listed in your `cypress.env.json` file) and select each of the dynamic page validator files from the Specs when in Cypress (NB: test files do not need to be run in order, but running recommendation-focused files in isolation will skip validation of questions, answers, etc. Run all files in the dynamic page validator section to ensure coverage).
@@ -19,13 +19,14 @@
 - [x] InsetText
 - [x] NavigationLink
 - [x] Question
-- [x] RecommendationIntro 
+- [x] RecommendationIntro
 - [x] RecommendationChunk
 - [x] RecommendationSection
 - [x] Section *
 - [x] TextBody *
 - [x] Titles
 - [x] WarningComponent
+- [x] NotificationBanner
 
 * Not fully complete. See below for notes.
 

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/helpers/content-validators/content-validator.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/helpers/content-validators/content-validator.js
@@ -8,6 +8,7 @@ import ValidateInsetTextContent from "./inset-text-validator.js";
 import ValidateNavigationLink from "./nav-link-validator.js";
 import ValidateRichTextContent from "./rich-text-content-validator.js";
 import ValidateWarningComponent from "./warning-validator.js";
+import ValidateNotificationBanner from "./notification-banner-validator.js";
 
 export const ValidateContent = (content) => {
     if (!content.sys || !content.fields) {
@@ -32,6 +33,10 @@ export const ValidateContent = (content) => {
         }
         case "warningComponent": {
             ValidateWarningComponent(content);
+            break;
+        }
+        case "notificationBanner": {
+            ValidateNotificationBanner(content);
             break;
         }
         case "buttonWithEntryReference": {

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/helpers/content-validators/notification-banner-validator.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/helpers/content-validators/notification-banner-validator.js
@@ -1,0 +1,5 @@
+import ValidateRichTextContent from "./rich-text-content-validator.js";
+
+export default function ValidateNotificationBanner({ fields }) {
+  ValidateRichTextContent(fields.text.fields.richText);
+}

--- a/tests/Dfe.PlanTech.Web.UnitTests/Models/ComponentBuilder.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Models/ComponentBuilder.cs
@@ -144,5 +144,16 @@ namespace Dfe.PlanTech.Web.UnitTests.Models
                 }
             };
         }
+
+        public static NotificationBanner BuildNotificationBanner(string text)
+        {
+            return new NotificationBanner()
+            {
+                Text = new TextBody
+                {
+                    RichText = BuildRichContent(text)
+                }
+            };
+        }
     }
 }

--- a/tests/Dfe.PlanTech.Web.UnitTests/ViewComponents/NotificationBannerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/ViewComponents/NotificationBannerTests.cs
@@ -1,0 +1,18 @@
+﻿using Dfe.PlanTech.Web.UnitTests.Models;
+using Xunit;
+
+namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
+{
+    public class NotificationBannerTests
+    {
+        [Theory]
+        [InlineData("text")]
+        [InlineData("longer text with spaces")]
+        [InlineData("")]
+        public void NotificationBanner_Text_Test(string text)
+        {
+            var banner = ComponentBuilder.BuildNotificationBanner(text);
+            Assert.Equal(text, banner.Text.RichText.Value);
+        }
+    }
+}


### PR DESCRIPTION
## Overview

Addresses ticket [#236011](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/236011)

Adds support for displaying a Notification banner as a piece of Content for a page

## Changes

### Minor
- Adds another content model similar to warning component for a notification banner
- This content type has been created in Contentful under the api name `notificationBanner`

## How to review the PR
- Try making one yourself in Contentful added to any page and see that it renders as expected, and that you can toggle it on and off, add links, etc, as the ticket requests.

## Release requirements

1. Create the `NotificationBanner` content type in staging/prod contentful
2. Alter the `Page` content type to accept notification banners within the list of content

## Checklist

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [x] Unit tests have been added/updated
- [x] E2E tests have been added/updated
- [x] Documentation has been updated where relevant
