### PR TITLE
fix: Fix bug where dep collection fails if sys details are missing

### DIFF
--- a/src/Dfe.PlanTech.Infrastructure.Redis/RedisCache.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Redis/RedisCache.cs
@@ -259,13 +259,17 @@ public class RedisCache : ICmsCache
     /// <param name="value"></param>
     private async Task<IEnumerable<string>> GetContentDependenciesAsync(ContentComponent value)
     {
+        // RichText is a sub-component that doesn't have SystemDetails, exit for such types
+        if (value.Sys is null)
+            return [];
+
         // add the item itself as a dependency
         var results = new List<string> { value.Sys.Id };
 
         var properties = value.GetType().GetProperties();
         foreach (var property in properties)
         {
-            if (property.PropertyType == typeof(ContentComponent) || typeof(IEnumerable<ContentComponent>).IsAssignableFrom(property.PropertyType))
+            if (typeof(ContentComponent).IsAssignableFrom(property.PropertyType) || typeof(IEnumerable<ContentComponent>).IsAssignableFrom(property.PropertyType))
             {
                 var nestedDependencies = await GetDependenciesAsync(property.GetValue(value));
                 results.AddRange(nestedDependencies);


### PR DESCRIPTION
## Overview

Relates to [#234426](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/234426)

Fixes a bug where some models like `RichText` which are `ContentComponent` types, don't actually have `SystemDetails` as sub-content of something else and therefore caused the dependency loop to fail

Also ensures the typeofs work with inheritance

## How to review the PR
- Test making changes to various different bits of content on a page and ensure the page is correctly invalidated and refreshes with the new up to date content

I chose not to change `RichText` to not inherit because it seems risky - but might be something we look into 

## Checklist

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
