### PR TITLE
fix: Use 404 page for missing C&S pages

### DIFF
--- a/src/Dfe.PlanTech.Web/Controllers/ContentController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/ContentController.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics;
-using Dfe.PlanTech.Web.Content;
-using Dfe.PlanTech.Web.Models;
+﻿using Dfe.PlanTech.Web.Content;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -27,14 +25,14 @@ public class ContentController(
             logger.LogError(
                 "Invalid model state received for {Controller} {Action} with slug {Slug}",
                 nameof(ContentController), nameof(Index), slug);
-            return RedirectToAction(ErrorActionName);
+            return RedirectToAction(ErrorActionName, PagesController.ControllerName);
         }
 
         if (string.IsNullOrEmpty(slug))
         {
             logger.LogError("No slug received for C&S {Controller} {Action}",
                 nameof(ContentController), nameof(Index));
-            return RedirectToAction(ErrorActionName);
+            return RedirectToAction(PagesController.NotFoundPage, PagesController.ControllerName);
         }
 
         try
@@ -44,7 +42,7 @@ public class ContentController(
             {
                 logger.LogError("Failed to load content for C&S page {Slug}; no content received.",
                     slug);
-                return RedirectToAction(ErrorActionName);
+                return RedirectToAction(PagesController.NotFoundPage, PagesController.ControllerName);
             }
 
             resp = layoutService.GenerateLayout(resp, Request, page);
@@ -55,14 +53,7 @@ public class ContentController(
         catch (Exception ex)
         {
             logger.LogError(ex, "Error loading C&S content page {Slug}", slug);
-            return RedirectToAction(ErrorActionName);
+            return RedirectToAction(ErrorActionName, PagesController.ControllerName);
         }
-    }
-
-    [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
-    public IActionResult Error()
-    {
-        return View(new ErrorViewModel
-        { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });
     }
 }

--- a/src/Dfe.PlanTech.Web/Controllers/PagesController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/PagesController.cs
@@ -14,18 +14,13 @@ namespace Dfe.PlanTech.Web.Controllers;
 
 [LogInvalidModelState]
 [Route("/")]
-public class PagesController : BaseController<PagesController>
+public class PagesController(ILogger<PagesController> logger, IGetEntityFromContentfulQuery getEntityByIdQuery) : BaseController<PagesController>(logger)
 {
-    private readonly ILogger _logger;
-    private readonly IGetEntityFromContentfulQuery _getEntityFromContentfulQuery;
+    private readonly ILogger _logger = logger;
+    private readonly IGetEntityFromContentfulQuery _getEntityFromContentfulQuery = getEntityByIdQuery;
     public const string ControllerName = "Pages";
     public const string GetPageByRouteAction = nameof(GetByRoute);
-
-    public PagesController(ILogger<PagesController> logger, IGetEntityFromContentfulQuery getEntityByIdQuery) : base(logger)
-    {
-        _logger = logger;
-        _getEntityFromContentfulQuery = getEntityByIdQuery;
-    }
+    public const string NotFoundPage = "NotFoundError";
 
     [Authorize(Policy = PageModelAuthorisationPolicy.PolicyName)]
     [HttpGet("{route?}", Name = "GetPage")]
@@ -34,7 +29,7 @@ public class PagesController : BaseController<PagesController>
         if (page == null)
         {
             _logger.LogInformation("Could not find page at {Path}", Request.Path.Value);
-            return RedirectToAction("NotFoundError");
+            return RedirectToAction(NotFoundPage);
         }
         var viewModel = new PageViewModel(page, this, user, Logger);
 

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/contentsupport/pages/not-found.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/contentsupport/pages/not-found.cy.js
@@ -1,6 +1,6 @@
 describe("not found", () => {
     beforeEach(() => {
-        cy.visit("/some-slug-that-doesnt-exist");
+        cy.visit("/content/some-slug-that-doesnt-exist");
         cy.injectAxe();
     });
 

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/ContentControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/ContentControllerTests.cs
@@ -1,9 +1,7 @@
 ﻿using Dfe.PlanTech.Web.Content;
 using Dfe.PlanTech.Web.Controllers;
-using Dfe.PlanTech.Web.Models;
 using Dfe.PlanTech.Web.Models.Content.Mapped;
 using FluentAssertions;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -29,7 +27,7 @@ public class ContentControllerTests
         var result = await sut.Index(string.Empty);
 
         result.Should().BeOfType<RedirectToActionResult>();
-        (result as RedirectToActionResult)!.ActionName.Should().BeEquivalentTo("error");
+        (result as RedirectToActionResult)!.ActionName.Should().BeEquivalentTo(PagesController.NotFoundPage);
 
         _loggerMock.Verify(
                x => x.Log(
@@ -65,7 +63,7 @@ public class ContentControllerTests
         var result = await sut.Index(slug);
 
         result.Should().BeOfType<RedirectToActionResult>();
-        (result as RedirectToActionResult)!.ActionName.Should().BeEquivalentTo("error");
+        (result as RedirectToActionResult)!.ActionName.Should().BeEquivalentTo(PagesController.NotFoundPage);
 
         _loggerMock.Verify(x => x.Log(
            LogLevel.Error,
@@ -110,16 +108,5 @@ public class ContentControllerTests
 
         result.Should().BeOfType<ViewResult>();
         (result as ViewResult)!.Model.Should().BeOfType<CsPage>();
-    }
-
-    [Fact]
-    public void Error_Returns_ErrorView()
-    {
-        var sut = GetController();
-        sut.ControllerContext.HttpContext = new DefaultHttpContext();
-        var result = sut.Error();
-
-        result.Should().BeOfType<ViewResult>();
-        (result as ViewResult)!.Model.Should().BeOfType<ErrorViewModel>();
     }
 }

--- a/tests/Dfe.PlanTech.Web.UnitTests/Dfe.PlanTech.Web.UnitTests.csproj
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Dfe.PlanTech.Web.UnitTests.csproj
@@ -15,18 +15,6 @@
         <PackageReference Include="Moq" Version="4.20.70"/>
         <PackageReference Include="FluentAssertions" Version="7.0.0-alpha.3"/>
         <PackageReference Include="NSubstitute" Version="5.3.0"/>
-        <PackageReference Include="NSubstitute" Version="5.3.0"/>
-        <PackageReference Include="xunit" Version="2.9.2"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <None Update="StubData\ContentfulCollection.json">
-            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-        </None>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0"/>
-        <PackageReference Include="Moq" Version="4.20.70"/>
-        <PackageReference Include="FluentAssertions" Version="7.0.0-alpha.3"/>
-        <PackageReference Include="NSubstitute" Version="5.1.0"/>
         <PackageReference Include="xunit" Version="2.9.2"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Overview

Addresses ticket 2335547

If a C&S page is not found, redirect user to 404 page.

## Changes

### Minor

- Use 404 page for missing C&S pages

## How to review the PR

Try slugs like `/content` or `/content/this-definitely-does-not-exist`, and make sure you get the 404 page.

## Checklist

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [x] Unit tests have been added/updated
- [x] E2E tests have been added/updated