### PR TITLE
chore: remove email address from error message

### DIFF
--- a/src/Dfe.PlanTech.Web/appsettings.json
+++ b/src/Dfe.PlanTech.Web/appsettings.json
@@ -64,6 +64,6 @@
         "LinkId": "7ezhOgrTAdhP4NeGiNj8VY"
     },
     "ErrorMessages": {
-        "ConcurrentUsersOrContentChange": "Your answers have not been saved. Try again later. If the problem continues, check that no one else from your organisation is using the service, or contact us at technology.planning@education.gov.uk"
+        "ConcurrentUsersOrContentChange": "Your answers have not been saved. Try again later. If the problem continues, check that no one else from your organisation is using the service, or contact us."
     }
 }


### PR DESCRIPTION
## Overview

Removes the contact email address from concurrent user error message ahead of Zendesk integration

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
