### PR TITLE
feat(235545): Add link to content from navigation links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -501,3 +501,5 @@ build/
 
 contentful/migration-scripts/config.json
 contentful/migration-scripts/contentful-export-*.json
+
+.sonarqube/

--- a/contentful/content-migrations/migrations/20241118-1239-add-content-reference-to-nav-link.js
+++ b/contentful/content-migrations/migrations/20241118-1239-add-content-reference-to-nav-link.js
@@ -1,0 +1,35 @@
+const Migration = require("contentful-migration");
+
+/**
+ * 
+ * @param {Migration} migration 
+ */
+module.exports = function (migration) {
+  const fieldName = "Content to link to";
+  const navLinkContentType = migration.editContentType("navigationLink");
+
+  navLinkContentType.createField("contentToLinkTo", {
+    "name": fieldName,
+    "type": "Link",
+    "linkType": "Entry",
+    "validations": [{
+      "linkContentType": ["page", "ContentSupportPage"]
+    }],
+  });
+
+  navLinkContentType.moveField("contentToLinkTo").beforeField("openInNewTab");
+
+  navLinkContentType.changeFieldControl("contentToLinkTo", "builtin", "entryCardEditor", {
+    "showLinkEntityAction": true,
+    "showCreateEntityAction": false,
+    "helpText": "The page or content support page that this navigation link should link to. This will take precedence over the HREF field."
+  });
+
+  navLinkContentType.changeFieldControl("href", "builtin", "urlEditor", {
+    "helpText": `URL to link to. Only use this for external links - if you want to link to internal content then please use the "${fieldName}" to field.`
+  });
+
+  navLinkContentType.editField("href", {
+    required: false
+  });
+};

--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/IHasSlug.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/IHasSlug.cs
@@ -2,5 +2,5 @@ namespace Dfe.PlanTech.Domain.Content.Interfaces;
 
 public interface IHasSlug
 {
-    public string Slug { get; set; }
+    public string Slug { get; }
 }

--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/INavigationLink.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/INavigationLink.cs
@@ -16,7 +16,7 @@ public interface INavigationLink
     /// <summary>
     /// Href value (i.e. <a href="{Href}"></a>)
     /// </summary>
-    public string Href { get; set; }
+    public string? Href { get; set; }
 
     /// <summary>
     /// Should this link open in a new tab?
@@ -27,4 +27,9 @@ public interface INavigationLink
     /// Does this link contain all necessary information (Href + DisplayText)?
     /// </summary>
     public bool IsValid => !string.IsNullOrEmpty(DisplayText) && !string.IsNullOrEmpty(Href);
+
+    /// <summary>
+    /// The content to link to.
+    /// </summary>
+    public IContentComponent? ContentToLinkTo { get; set; }
 }

--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/INavigationLink.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/INavigationLink.cs
@@ -26,7 +26,7 @@ public interface INavigationLink
     /// <summary>
     /// Does this link contain all necessary information (Href + DisplayText)?
     /// </summary>
-    public bool IsValid => !string.IsNullOrEmpty(DisplayText) && !string.IsNullOrEmpty(Href);
+    public bool IsValid => !string.IsNullOrEmpty(DisplayText) && !(string.IsNullOrEmpty(Href) && ContentToLinkTo == null);
 
     /// <summary>
     /// The content to link to.

--- a/src/Dfe.PlanTech.Domain/Content/Interfaces/IPage.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Interfaces/IPage.cs
@@ -2,11 +2,9 @@ using Dfe.PlanTech.Domain.Content.Models;
 
 namespace Dfe.PlanTech.Domain.Content.Interfaces;
 
-public interface IPage
+public interface IPage : IHasSlug
 {
     public string InternalName { get; }
-
-    public string Slug { get; }
 
     public bool DisplayBackButton { get; }
 

--- a/src/Dfe.PlanTech.Domain/Content/Models/NavigationLink.cs
+++ b/src/Dfe.PlanTech.Domain/Content/Models/NavigationLink.cs
@@ -18,10 +18,15 @@ public class NavigationLink : ContentComponent, INavigationLink
     /// <summary>
     /// Href value (i.e. <a href="{Href}"></a>)
     /// </summary>
-    public string Href { get; set; } = null!;
+    public string? Href { get; set; } = null;
 
     /// <summary>
     /// Should this link open in a new tab?
     /// </summary>
     public bool OpenInNewTab { get; set; } = false;
+
+    /// <summary>
+    /// The content to link to.
+    /// </summary>
+    public IContentComponent? ContentToLinkTo { get; set; }
 }

--- a/src/Dfe.PlanTech.Infrastructure.Contentful/Persistence/EntityResolver.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Contentful/Persistence/EntityResolver.cs
@@ -1,6 +1,7 @@
 using Contentful.Core.Configuration;
 using Dfe.PlanTech.Domain.Content.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Domain.Helpers;
 using Microsoft.Extensions.Logging;
 
 namespace Dfe.PlanTech.Infrastructure.Contentful;
@@ -15,8 +16,7 @@ public class EntityResolver(ILogger<EntityResolver> logger) : IContentTypeResolv
 
     private readonly ILogger<EntityResolver> _logger = logger;
 
-    private readonly Dictionary<string, Type> _types = typeof(IContentComponent).Assembly.GetTypes()
-                                                                        .Where(type => type.IsAssignableTo(typeof(IContentComponent)))
+    private readonly Dictionary<string, Type> _types = ReflectionHelpers.GetTypesInheritingFrom<IContentComponent>()
                                                                         .ToDictionary(type => type.Name.ToLower());
 
     /// <summary>

--- a/src/Dfe.PlanTech.Web/Content/ContentService.cs
+++ b/src/Dfe.PlanTech.Web/Content/ContentService.cs
@@ -47,8 +47,7 @@ public class ContentService(
         return pages.ToList();
     }
 
-    public async Task<List<CsPage>> GetContentSupportPages(
-        string field, string value, bool isPreview)
+    public async Task<List<CsPage>> GetContentSupportPages(string field, string value, bool isPreview)
     {
         var key = $"{field}_{value}";
         if (!isPreview)
@@ -57,7 +56,6 @@ public class ContentService(
             if (fromCache is not null)
                 return fromCache;
         }
-
 
         var result = await contentfulService.GetContentSupportPages(field, value);
         var pages = modelMapper.MapToCsPages(result);

--- a/src/Dfe.PlanTech.Web/Models/Content/ContentBase.cs
+++ b/src/Dfe.PlanTech.Web/Models/Content/ContentBase.cs
@@ -1,12 +1,15 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using Dfe.PlanTech.Domain.Content.Interfaces;
+using Dfe.PlanTech.Domain.Content.Models;
 
 namespace Dfe.PlanTech.Web.Models.Content;
 
 [ExcludeFromCodeCoverage]
-public class ContentBase : Contentful.Core.Models.Entry<ContentBase>
+public class ContentBase : Contentful.Core.Models.Entry<ContentBase>, IContentComponent, IHasSlug
 {
     public string InternalName { get; set; } = null!;
     public string Slug { get; set; } = null!;
     public string? Title { get; set; }
     public string? Subtitle { get; set; }
+    public SystemDetails Sys { get; set; } = null!;
 }

--- a/src/Dfe.PlanTech.Web/Models/Content/ContentSupportPage.cs
+++ b/src/Dfe.PlanTech.Web/Models/Content/ContentSupportPage.cs
@@ -3,7 +3,7 @@
 namespace Dfe.PlanTech.Web.Models.Content;
 
 [ExcludeFromCodeCoverage]
-public class ContentSupportPage : ContentBase
+public class ContentSupportPage : ContentBase, IContentSupportPage<Entry>
 {
     public Heading Heading { get; init; } = null!;
     public List<Entry> Content { get; init; } = [];
@@ -13,5 +13,4 @@ public class ContentSupportPage : ContentBase
     public bool HasFeedbackBanner { get; init; }
     public bool HasPrint { get; init; }
     public bool ShowVerticalNavigation { get; init; }
-
 }

--- a/src/Dfe.PlanTech.Web/Models/Content/IContentSupportPage.cs
+++ b/src/Dfe.PlanTech.Web/Models/Content/IContentSupportPage.cs
@@ -1,0 +1,20 @@
+using Dfe.PlanTech.Domain.Content.Interfaces;
+
+namespace Dfe.PlanTech.Web.Models.Content;
+
+public interface IContentSupportPage<TContent> : IContentSupportPage
+where TContent : class
+{
+    List<TContent> Content { get; }
+}
+
+public interface IContentSupportPage : IContentComponent, IHasSlug
+{
+    Heading Heading { get; }
+    bool IsSitemap { get; }
+    bool HasCitation { get; }
+    bool HasBackToTop { get; }
+    bool HasFeedbackBanner { get; }
+    bool HasPrint { get; }
+    bool ShowVerticalNavigation { get; }
+}

--- a/src/Dfe.PlanTech.Web/Models/Content/Mapped/CsPage.cs
+++ b/src/Dfe.PlanTech.Web/Models/Content/Mapped/CsPage.cs
@@ -1,10 +1,12 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using Dfe.PlanTech.Domain.Content.Models;
 
 namespace Dfe.PlanTech.Web.Models.Content.Mapped;
 
 [ExcludeFromCodeCoverage]
-public class CsPage
+public class CsPage : IContentSupportPage<CsContentItem>
 {
+    public SystemDetails Sys { get; set; } = null!;
     public Heading Heading { get; set; } = null!;
     public string Slug { get; set; } = null!;
     public bool IsSitemap { get; set; }

--- a/src/Dfe.PlanTech.Web/TagHelpers/FooterLinkTagHelper.cs
+++ b/src/Dfe.PlanTech.Web/TagHelpers/FooterLinkTagHelper.cs
@@ -1,6 +1,8 @@
 using System.Text;
 using Dfe.PlanTech.Domain.Content.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Web.Models.Content;
+using Dfe.PlanTech.Web.Models.Content.Mapped;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace Dfe.PlanTech.Web.TagHelpers;
@@ -9,23 +11,15 @@ namespace Dfe.PlanTech.Web.TagHelpers;
 /// Renders a single navigation link in the footer.
 /// </summary>
 /// <remarks>Should be refactored in future to be any <see cref="NavigationLink"/>, and pass in HTML class used</remarks>
-public class FooterLinkTagHelper : TagHelper
+public class FooterLinkTagHelper(ILogger<FooterLinkTagHelper> logger) : TagHelper
 {
-    public const string FOOTER_CLASS = "\"govuk-footer__link\"";
-    private readonly ILogger<FooterLinkTagHelper> _logger;
-
     public INavigationLink? Link { get; set; }
-
-    public FooterLinkTagHelper(ILogger<FooterLinkTagHelper> logger)
-    {
-        _logger = logger;
-    }
 
     public override void Process(TagHelperContext context, TagHelperOutput output)
     {
         if (Link == null || !Link.IsValid)
         {
-            _logger.LogWarning("Missing {link}", nameof(Link));
+            logger.LogWarning("Missing {link}", nameof(Link));
             return;
         }
 
@@ -53,14 +47,50 @@ public class FooterLinkTagHelper : TagHelper
 
     private void AppendOpenTag(StringBuilder stringBuilder)
     {
-        stringBuilder.Append("<a class=").Append(FOOTER_CLASS).Append(" href=\"");
-        stringBuilder.Append(Link!.Href);
+        stringBuilder.Append("""<a class="govuk-footer__link" """).Append(" href=\"");
+        stringBuilder.Append(GetHref());
         stringBuilder.Append('"');
 
-        if (Link.OpenInNewTab)
+        if (Link!.OpenInNewTab)
         {
             stringBuilder.Append(" target=\"_blank\"");
         }
+
         stringBuilder.Append('>');
+    }
+
+    private string GetHref()
+    {
+        if (Link!.ContentToLinkTo == null && string.IsNullOrEmpty(Link.Href))
+        {
+            logger.LogError("No href or content to link to for {LinkType}", nameof(NavigationLink));
+            return string.Empty;
+        }
+
+        return GetUrlForContent() ?? Link.Href ?? string.Empty;
+    }
+
+    private string? GetUrlForContent()
+    {
+        if (Link?.ContentToLinkTo == null)
+        {
+            return null;
+        }
+
+        return Link.ContentToLinkTo switch
+        {
+            IPage page => $"/{page.Slug}",
+            CsPage csPage  => $"/content/{csPage.Slug}", 
+            ContentSupportPage contentSupportPage => $"/content/{contentSupportPage.Slug}", 
+            _ => LogInvalidContentTypeAndReturnNull(Link.ContentToLinkTo)
+        };
+    }
+
+    private string? LogInvalidContentTypeAndReturnNull(object content)
+    {
+        logger.LogError("Unsupported content type {ContentType} in {TagHelper}", 
+            content.GetType().Name,
+            nameof(FooterLinkTagHelper));
+        return null;
     }
 }

--- a/src/Dfe.PlanTech.Web/ViewComponents/FooterLinksViewComponent.cs
+++ b/src/Dfe.PlanTech.Web/ViewComponents/FooterLinksViewComponent.cs
@@ -7,16 +7,10 @@ namespace Dfe.PlanTech.Web.ViewComponents;
 /// <summary>
 /// View component that retrieves and displays links in the layout's footer
 /// </summary>
-public class FooterLinksViewComponent : ViewComponent
+public class FooterLinksViewComponent(IGetNavigationQuery getNavQuery, ILogger<FooterLinksViewComponent> logger) : ViewComponent
 {
-    private readonly IGetNavigationQuery _getNavQuery;
-    private readonly ILogger<FooterLinksViewComponent> _logger;
-
-    public FooterLinksViewComponent(IGetNavigationQuery getNavQuery, ILogger<FooterLinksViewComponent> logger)
-    {
-        _getNavQuery = getNavQuery;
-        _logger = logger;
-    }
+    private readonly IGetNavigationQuery _getNavQuery = getNavQuery;
+    private readonly ILogger<FooterLinksViewComponent> _logger = logger;
 
     /// <summary>
     /// Retrieve the navigation links using <see cref="IGetNavigationQuery"/> then return the view

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/FooterLinks/Default.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/FooterLinks/Default.cshtml
@@ -2,10 +2,10 @@
 
 <ul class="govuk-footer__inline-list">
   @{
-    foreach (var link in Model)
+    foreach (var link in Model.Where(link => link.IsValid))
     {
       <li class="govuk-footer__inline-list-item">
-        <footer-link link=@link />
+        <footer-link link=@link>@link.DisplayText</footer-link>
       </li>
     }
   }


### PR DESCRIPTION
## Overview

Completes 235545.

Adds the ability for navigation links (footer links) to not only have "href" fields on Contentful, but also directly link to content. This should reduce the amount of changes needed if linking to an internal page.

## Changes

### Major

- Adds link to content field in navigation links

### Minor

- Amends a few C&S models to implement `IContentComponent` 

## How to review the PR

- Run app
- Test the footer links.
    - Test the existing links; no problems?
    - I've added two links to dev/test for testing.
        - `Link to accessibility page test`; links to accessibility page using the content field. Does this link to the accessibility page?
        - `Should be accessibility, might be cookies` links to accessibility page via content field, but also has href for cookies. Content link should take priority over href, so make sure this links to accessibility page.

## Release requirements

None, but updating content designers to let them know about the ability to use this now would be good.

## Additional notes

I spent pretty much a day trying to:
- Add validation so that one or the other of `href` + `linkToContentType` must have a value (i.e. both can't be null, and both can't have values). But doesn't look like you can do that.
- Group the two fields in the same row as a group in [the editor interface](https://www.contentful.com/developers/docs/extensibility/app-framework/editor-interfaces/), but whilst the API request worked (and the GET response validated it looked as expected), nothing seemed to have changed.

In the end this isn't ideal. I debated making a static page and hosting on one of the storage accounts (or something) and making a custom editor, but thought that would be outside the scope of this ticket. Will discuss with y'all this though to see if we want to raise it (not just for this but others as well).

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [x] Unit tests have been added/updated
- [x] E2E tests have been added/updated