### PR TITLE
fix: Move org title to support banner and make 2/3 width

### DIFF
--- a/src/Dfe.PlanTech.Web/Views/Pages/Page.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Pages/Page.cshtml
@@ -10,19 +10,24 @@
         await Html.RenderPartialAsync("HomeButton", Model);
     }
 }
+
 @{
     if (Model.Page.Slug == "self-assessment" && TempData.ContainsKey("SubtopicError"))
     {
         var error = TempData["SubtopicError"] as string;
-        <div class="govuk-error-summary" data-module="govuk-error-summary">
-            <div role="alert">
-                <h2 class="govuk-error-summary__title">
-                    There is a problem
-                </h2>
-                @if (!string.IsNullOrEmpty(error))
-                {
-                    <div class="govuk-error-summary__body whitespace-preline">@error</div>
-                }
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                <div class="govuk-error-summary" data-module="govuk-error-summary">
+                    <div role="alert">
+                        <h2 class="govuk-error-summary__title">
+                            There is a problem
+                        </h2>
+                        @if (!string.IsNullOrEmpty(error))
+                        {
+                            <div class="govuk-error-summary__body whitespace-preline">@error</div>
+                        }
+                    </div>
+                </div>
             </div>
         </div>
     }

--- a/src/Dfe.PlanTech.Web/Views/Pages/Page.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Pages/Page.cshtml
@@ -27,9 +27,5 @@
         </div>
     }
 
-    if (Model.Page.DisplayOrganisationName)
-    {
-        <span class="govuk-caption-xl">@Model.Page.OrganisationName</span>
-    }
     await Html.RenderPartialAsync("Components/Page", Model.Page);
 }

--- a/src/Dfe.PlanTech.Web/Views/Pages/Page.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Pages/Page.cshtml
@@ -10,24 +10,19 @@
         await Html.RenderPartialAsync("HomeButton", Model);
     }
 }
-
 @{
     if (Model.Page.Slug == "self-assessment" && TempData.ContainsKey("SubtopicError"))
     {
         var error = TempData["SubtopicError"] as string;
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
-                <div class="govuk-error-summary" data-module="govuk-error-summary">
-                    <div role="alert">
-                        <h2 class="govuk-error-summary__title">
-                            There is a problem
-                        </h2>
-                        @if (!string.IsNullOrEmpty(error))
-                        {
-                            <div class="govuk-error-summary__body whitespace-preline">@error</div>
-                        }
-                    </div>
-                </div>
+        <div class="govuk-error-summary" data-module="govuk-error-summary">
+            <div role="alert">
+                <h2 class="govuk-error-summary__title">
+                    There is a problem
+                </h2>
+                @if (!string.IsNullOrEmpty(error))
+                {
+                    <div class="govuk-error-summary__body whitespace-preline">@error</div>
+                }
             </div>
         </div>
     }

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/NotificationBanner.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/NotificationBanner.cshtml
@@ -1,11 +1,16 @@
 @model Dfe.PlanTech.Domain.Content.Models.NotificationBanner;
-
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        <govuk-notification-banner>
-            @{
-                await Html.RenderPartialAsync("Components/PageComponentFactory", Model.Text);
-            }
-        </govuk-notification-banner>
-    </div>
-</div>
+@{
+    var error = TempData["SubtopicError"] as string;
+    if (String.IsNullOrEmpty(error))
+    {
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                <govuk-notification-banner>
+                    @{
+                        await Html.RenderPartialAsync("Components/PageComponentFactory", Model.Text);
+                    }
+                </govuk-notification-banner>
+            </div>
+        </div>
+    }
+}

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/NotificationBanner.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/NotificationBanner.cshtml
@@ -1,7 +1,11 @@
 @model Dfe.PlanTech.Domain.Content.Models.NotificationBanner;
 
-<govuk-notification-banner>
-  @{
-    await Html.RenderPartialAsync("Components/PageComponentFactory", Model.Text);
-  }
-</govuk-notification-banner>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <govuk-notification-banner>
+            @{
+                await Html.RenderPartialAsync("Components/PageComponentFactory", Model.Text);
+            }
+        </govuk-notification-banner>
+    </div>
+</div>

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/NotificationBanner.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/NotificationBanner.cshtml
@@ -1,7 +1,6 @@
 @model Dfe.PlanTech.Domain.Content.Models.NotificationBanner;
 @{
-    var error = TempData["SubtopicError"] as string;
-    if (String.IsNullOrEmpty(error))
+    if (!TempData.ContainsKey("SubtopicError"))
     {
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/Page.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/Page.cshtml
@@ -6,6 +6,11 @@
         await Html.RenderPartialAsync("Components/PageComponentFactory", content);
     }
 
+    if (Model.DisplayOrganisationName)
+    {
+        <span class="govuk-caption-xl">@Model.OrganisationName</span>
+    }
+
     if (Model.DisplayTopicTitle)
     {
         <span class="govuk-caption-xl">@Model.SectionTitle</span>
@@ -15,7 +20,7 @@
     {
         await Html.RenderPartialAsync("Components/Title", Model.Title);
     }
-    
+
     foreach (var content in Model.Content)
     {
         await Html.RenderPartialAsync("Components/PageComponentFactory", content);

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/accessibility-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/accessibility-page.cy.js
@@ -16,8 +16,8 @@ describe("Accessibility Page - Unauthenticated", () => {
     cy.get("h1.govuk-heading-xl").should("exist");
   });
 
-  it("Should Have Home Button", () => {
-    cy.get('a:contains("Home")')
+  it("Should Have Back Button", () => {
+    cy.get('a:contains("Back")')
       .should("exist")
       .should("have.attr", "href")
       .and("include", "/");

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/accessibility-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/accessibility-page.cy.js
@@ -16,8 +16,8 @@ describe("Accessibility Page - Unauthenticated", () => {
     cy.get("h1.govuk-heading-xl").should("exist");
   });
 
-  it("Should Have Back Button", () => {
-    cy.get('a:contains("Back")')
+  it("Should Have Home Button", () => {
+    cy.get('a:contains("Home")')
       .should("exist")
       .should("have.attr", "href")
       .and("include", "/");


### PR DESCRIPTION
## Overview

Small changes to where the Organisation title renders so that we can put the banner before the title
Also makes the banner 2/3rd width

## Changes

- Moves org title into page rendering
- Makes banner 2/3 width
- Only renders the banner if the error banner is not showing
- Fixes accessibility page e2e tests to search for back button (it will fail in staging if we just fix the dev content)

## How to review the PR

Check it looks like new mockup from Sam using BeforeContent in contentful as place where banner goes

## Checklist

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
