### PR TITLE
feat(db): Add retry on failure to DB requests

### DIFF
--- a/src/Dfe.PlanTech.Domain/Database/DatabaseOptions.cs
+++ b/src/Dfe.PlanTech.Domain/Database/DatabaseOptions.cs
@@ -1,0 +1,25 @@
+namespace Dfe.PlanTech.Domain.Database;
+
+/// <summary>
+/// SQL database options; currently only used for retry options.
+/// </summary>
+public readonly record struct DatabaseOptions
+{
+    public DatabaseOptions(int maxRetryCount, int maxDelayInMilliseconds)
+    {
+        MaxRetryCount = maxRetryCount;
+        MaxDelayInMilliseconds = maxDelayInMilliseconds;
+    }
+
+    public DatabaseOptions() : this(5, 5000) { }
+
+    /// <summary>
+    /// Maximum number of retry attempts for transient failures.
+    /// </summary>
+    public int MaxRetryCount { get; init; }
+
+    /// <summary>
+    /// Maximum delay between retry attempts in milliseconds.
+    /// </summary>
+    public int MaxDelayInMilliseconds { get; init; }
+}

--- a/src/Dfe.PlanTech.Web/ProgramExtensions.cs
+++ b/src/Dfe.PlanTech.Web/ProgramExtensions.cs
@@ -20,6 +20,7 @@ using Dfe.PlanTech.Domain.Content.Models.Options;
 using Dfe.PlanTech.Domain.Content.Queries;
 using Dfe.PlanTech.Domain.Cookie;
 using Dfe.PlanTech.Domain.Cookie.Interfaces;
+using Dfe.PlanTech.Domain.Database;
 using Dfe.PlanTech.Domain.Persistence.Models;
 using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 using Dfe.PlanTech.Domain.Submissions.Interfaces;
@@ -136,7 +137,12 @@ public static class ProgramExtensions
 
     public static IServiceCollection AddDatabase(this IServiceCollection services, IConfiguration configuration)
     {
-        void databaseOptionsAction(DbContextOptionsBuilder options) => options.UseSqlServer(configuration.GetConnectionString("Database"));
+        void databaseOptionsAction(DbContextOptionsBuilder options) => options.UseSqlServer(configuration.GetConnectionString("Database"),
+        opts =>
+        {
+            var databaseRetryOptions = configuration.GetSection("Database").Get<DatabaseOptions>();
+            opts.EnableRetryOnFailure(databaseRetryOptions.MaxRetryCount, TimeSpan.FromMilliseconds(databaseRetryOptions.MaxDelayInMilliseconds), null);
+        });
 
         services.AddDbContext<IPlanTechDbContext, PlanTechDbContext>(databaseOptionsAction);
         ConfigureCookies(services, configuration);

--- a/src/Dfe.PlanTech.Web/appsettings.json
+++ b/src/Dfe.PlanTech.Web/appsettings.json
@@ -65,5 +65,11 @@
     },
     "ErrorMessages": {
         "ConcurrentUsersOrContentChange": "Your answers have not been saved. Try again later. If the problem continues, check that no one else from your organisation is using the service, or contact us."
+    },
+    "Database": {
+        "Retry": {
+            "MaxRetryCount": 5,
+            "MaxDelayInMilliseconds": 5000
+        }
     }
 }

--- a/tests/Dfe.PlanTech.Domain.UnitTests/Database/DatabaseOptionsTests.cs
+++ b/tests/Dfe.PlanTech.Domain.UnitTests/Database/DatabaseOptionsTests.cs
@@ -1,0 +1,19 @@
+using Dfe.PlanTech.Domain.Database;
+
+namespace Dfe.PlanTech.Domain.UnitTests.Database;
+
+public class DatabaseRetryOptionsTests
+{
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(5, 5000)]
+    [InlineData(10, 10000)]
+    [InlineData(15, 15000)]
+    public void DatabaseRetryOptions_Should_Set_Properties(int maxRetryCount, int maxDelayInMilliseconds)
+    {
+        var options = new DatabaseOptions(maxRetryCount, maxDelayInMilliseconds);
+
+        Assert.Equal(maxRetryCount, options.MaxRetryCount);
+        Assert.Equal(maxDelayInMilliseconds, options.MaxDelayInMilliseconds);
+    }
+}


### PR DESCRIPTION
## Overview

No ticket for this I just had time to fix it and didn't want to start another ticket at the end of the sprint with how little time I have to implement it today.

Adds retry on failure to DB requests

## Changes

### Minor

1. Enables retry on failure using EF Core's built in functionality.
2. Adds a `DatabaseOptions` record for configuring the options used above
3. Adds default settings to appsettings.json.

## Checklist

Delete any rows that do not apply to the PR.

- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch