### PR TITLE
fix: Handle IContentComponent serialisation + Redis errors better

### DIFF
--- a/src/Dfe.PlanTech.Domain/Helpers/ReflectionHelpers.cs
+++ b/src/Dfe.PlanTech.Domain/Helpers/ReflectionHelpers.cs
@@ -1,13 +1,24 @@
+using System.Reflection;
+
 namespace Dfe.PlanTech.Domain.Helpers;
 
 public static class ReflectionHelpers
 {
-    public static IEnumerable<Type> GetTypesInheritingFrom<TBase>()
-    {
-        var baseType = typeof(TBase);
+    public static IEnumerable<Type> GetTypesInheritingFrom<TBase>() => GetTypesInheritingFrom(typeof(TBase));
 
-        return AppDomain.CurrentDomain.GetAssemblies()
-            .SelectMany((assembley) => assembley.GetTypes())
-            .Where((type) => baseType.IsAssignableFrom(type) && type != baseType);
-    }
+    public static IEnumerable<Type> GetTypesInheritingFrom(Type baseType, bool internalProjectsOnly = true) => AppDomain.CurrentDomain.GetAssemblies()
+        .Where(assembly => IsNotTestProject(assembly, internalProjectsOnly))
+        .SelectMany(AssemblyTypes)
+        .Where(InheritsBaseType(baseType));
+
+    private static Func<Type, bool> InheritsBaseType(Type baseType) => (type) => baseType.IsAssignableFrom(type) && type != baseType;
+
+    private static Type[] AssemblyTypes(Assembly assembly) => assembly.GetTypes();
+
+    private static bool IsNotTestProject(Assembly assembly, bool internalProjectsOnly)
+    => assembly.FullName != null && !assembly.FullName.Contains("Test") && (!internalProjectsOnly || assembly.FullName.Contains("Dfe.PlanTech."));
+
+    public static bool HasParameterlessConstructor(this Type type) => type.GetConstructor(Type.EmptyTypes) != null || type.GetConstructors().Length == 0;
+
+    public static bool IsConcreteClass(this Type type) => !type.IsAbstract && !type.IsInterface;
 }

--- a/src/Dfe.PlanTech.Infrastructure.Redis/JsonSerialiser.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Redis/JsonSerialiser.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
+using Dfe.PlanTech.Domain.Content.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models;
 using StackExchange.Redis;
 
@@ -17,8 +18,8 @@ public static class JsonSerialiser
     private static readonly JsonSerializerOptions JsonSerialiserOptions = new()
     {
         TypeInfoResolver =
-            new DefaultJsonTypeInfoResolver().WithAddedModifier(ContentComponentJsonExtensions
-                .AddContentComponentPolymorphicInfo),
+            new DefaultJsonTypeInfoResolver().WithAddedModifier(ContentComponentJsonExtensions.AddContentComponentPolymorphicInfo<IContentComponent>)
+            .WithAddedModifier(ContentComponentJsonExtensions.AddContentComponentPolymorphicInfo<ContentComponent>),
         ReferenceHandler = ReferenceHandler.Preserve
     };
 

--- a/tests/Dfe.PlanTech.Infrastructure.Redis.UnitTests/ContentComponentJsonExtensionsTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Redis.UnitTests/ContentComponentJsonExtensionsTests.cs
@@ -1,24 +1,28 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
+using Dfe.PlanTech.Domain.Content.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models;
 
 namespace Dfe.PlanTech.Infrastructure.Redis.UnitTests;
 
 public class ContentComponentJsonExtensionsTests
 {
-    [Fact]
-    public void AddContentComponentPolymorphicInfo_ShouldSetPolymorphismOptions_WhenTypeIsContentComponent()
+    [Theory]
+    [InlineData(typeof(ContentComponent))]
+    [InlineData(typeof(IContentComponent))]
+    public void AddContentComponentPolymorphicInfo_ShouldSetPolymorphismOptions(Type type)
     {
         var options = new JsonSerializerOptions()
         {
-            TypeInfoResolver = new DefaultJsonTypeInfoResolver().WithAddedModifier(ContentComponentJsonExtensions.AddContentComponentPolymorphicInfo)
+            TypeInfoResolver = new DefaultJsonTypeInfoResolver().WithAddedModifier(ContentComponentJsonExtensions.AddContentComponentPolymorphicInfo<ContentComponent>)
+                                                                .WithAddedModifier(ContentComponentJsonExtensions.AddContentComponentPolymorphicInfo<IContentComponent>)
         };
 
-        var typeInfo = options.GetTypeInfo(typeof(ContentComponent));
+        var typeInfo = options.GetTypeInfo(type);
         Assert.NotNull(typeInfo);
         Assert.NotNull(typeInfo.PolymorphismOptions);
-        Assert.Equal("$contentcomponenttype", typeInfo.PolymorphismOptions.TypeDiscriminatorPropertyName);
+        Assert.Equal("$" + type.Name.ToLower(), typeInfo.PolymorphismOptions.TypeDiscriminatorPropertyName);
         Assert.True(typeInfo.PolymorphismOptions.IgnoreUnrecognizedTypeDiscriminators);
         Assert.Equal(JsonUnknownDerivedTypeHandling.FailSerialization, typeInfo.PolymorphismOptions.UnknownDerivedTypeHandling);
     }


### PR DESCRIPTION
## Overview

Fixes issue in #237764 where the navigation links were not being deserialised properly, as the content is of type `IContentComponent` by the polymorphic serialisation was of type `ContentComponent`.

Also fixes handling of Redis connection errors. Whilst errors in `Get` or `Create` were handled, there was no handling of the initial database connection in `GetOrCreate`. If there was an error connecting to the Redis server straight away then it would just fail. It should now return the result of what the `action` argument is.

## Changes

### Minor

- Fix navigation links deserialisation by handling `IContentComponent` polymorphic serialisation
- Handle database connection errors in Redis `GetOrCreate`

## How to review the PR

1. Change your redis connection string to a non-existent server; ensure that the pages (etc.) load from Contentful as expected
2. Test against a local redis instance + clear its cache. Load a page, check the terminal output. Are there any errors being thrown, or is it working ok? 

## Checklist

Delete any rows that do not apply to the PR.

- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch