### PR TITLE
feat: store if a recommendation is viewed for new tag

### DIFF
--- a/src/Dfe.PlanTech.Application/Responses/Queries/GetLatestResponsesQuery.cs
+++ b/src/Dfe.PlanTech.Application/Responses/Queries/GetLatestResponsesQuery.cs
@@ -56,7 +56,7 @@ public class GetLatestResponsesQuery(IPlanTechDbContext db) : IGetLatestResponse
 
     public async Task ViewLatestSubmission(int establishmentId, string sectionId)
     {
-        var currentSubmission = GetCurrentSubmission(establishmentId, sectionId, true).FirstOrDefault();
+        var currentSubmission = await db.FirstOrDefaultAsync(GetCurrentSubmission(establishmentId, sectionId, true));
         if (currentSubmission != null)
         {
             currentSubmission.Viewed = true;

--- a/src/Dfe.PlanTech.Application/Responses/Queries/GetLatestResponsesQuery.cs
+++ b/src/Dfe.PlanTech.Application/Responses/Queries/GetLatestResponsesQuery.cs
@@ -57,7 +57,7 @@ public class GetLatestResponsesQuery(IPlanTechDbContext db) : IGetLatestResponse
     public async Task ViewLatestSubmission(int establishmentId, string sectionId)
     {
         var currentSubmission = GetCurrentSubmission(establishmentId, sectionId, true).FirstOrDefault();
-        if (currentSubmission?.Viewed == false)
+        if (currentSubmission != null)
         {
             currentSubmission.Viewed = true;
             await db.SaveChangesAsync();

--- a/src/Dfe.PlanTech.Application/Responses/Queries/GetLatestResponsesQuery.cs
+++ b/src/Dfe.PlanTech.Application/Responses/Queries/GetLatestResponsesQuery.cs
@@ -54,6 +54,16 @@ public class GetLatestResponsesQuery(IPlanTechDbContext db) : IGetLatestResponse
             .Where(IsMatchingIncompleteSubmission(establishmentId, sectionId, completedSubmission))
             .OrderByDescending(submission => submission.DateCreated);
 
+    public async Task ViewLatestSubmission(int establishmentId, string sectionId)
+    {
+        var currentSubmission = GetCurrentSubmission(establishmentId, sectionId, true).FirstOrDefault();
+        if (currentSubmission?.Viewed == false)
+        {
+            currentSubmission.Viewed = true;
+            await db.SaveChangesAsync();
+        }
+    }
+
     private static Expression<Func<Submission, bool>> IsMatchingIncompleteSubmission(int establishmentId, string sectionId, bool completedSubmission)
     => submission => (submission.Completed == completedSubmission) &&
                      !submission.Deleted &&

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20241127_1700_AddSubmissionViewedColumn.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2024/20241127_1700_AddSubmissionViewedColumn.sql
@@ -1,0 +1,63 @@
+-- Add viewed column to submission table and set it to true for existing records
+
+ALTER TABLE dbo.submission
+ADD viewed BIT NOT NULL DEFAULT 0
+
+GO
+
+UPDATE dbo.submission
+SET viewed = 1
+WHERE viewed = 0
+
+GO
+
+-- Return viewed in the section statuses procedure
+
+ALTER PROCEDURE dbo.GetSectionStatuses @sectionIds NVARCHAR(MAX), @establishmentId INT
+AS
+
+SELECT
+    Value sectionId
+INTO #SectionIds
+FROM STRING_SPLIT(@sectionIds, ',')
+
+SELECT
+    CurrentSubmission.sectionId,
+    CurrentSubmission.completed,
+    LastCompleteSubmission.maturity   AS lastMaturity,
+    CurrentSubmission.dateCreated,
+    CurrentSubmission.dateLastUpdated AS dateUpdated,
+    LastCompleteSubmission.viewed
+FROM #SectionIds SI
+-- The current submission
+CROSS APPLY (
+    SELECT TOP 1
+        sectionId,
+        completed,
+        S.id,
+        dateCreated,
+        dateLastUpdated
+    FROM [dbo].submission S
+    WHERE
+          SI.sectionId = S.sectionId
+      AND S.establishmentId = @establishmentId
+      AND S.deleted = 0
+    ORDER BY S.dateCreated DESC
+) CurrentSubmission
+-- Use maturity from most recent complete submission (if there is one) so that user always sees recommendation
+OUTER APPLY (
+    SELECT TOP 1
+        maturity,
+        viewed
+    FROM [dbo].submission S
+    WHERE
+          SI.sectionId = S.sectionId
+      AND S.establishmentId = @establishmentId
+      AND S.deleted = 0
+      AND s.completed = 1
+    ORDER BY S.dateCreated DESC
+) LastCompleteSubmission
+
+DROP TABLE #SectionIds
+
+GO

--- a/src/Dfe.PlanTech.Domain/CategorySection/CategorySectionRecommendationDto.cs
+++ b/src/Dfe.PlanTech.Domain/CategorySection/CategorySectionRecommendationDto.cs
@@ -9,4 +9,6 @@ public class CategorySectionRecommendationDto
     public string? NoRecommendationFoundErrorMessage { get; init; }
 
     public string? SectionSlug { get; init; }
+
+    public bool Viewed { get; init; }
 }

--- a/src/Dfe.PlanTech.Domain/Submissions/Interfaces/IGetLatestResponsesQuery.cs
+++ b/src/Dfe.PlanTech.Domain/Submissions/Interfaces/IGetLatestResponsesQuery.cs
@@ -8,4 +8,6 @@ public interface IGetLatestResponsesQuery
     Task<QuestionWithAnswer?> GetLatestResponseForQuestion(int establishmentId, string sectionId, string questionId, CancellationToken cancellationToken = default);
 
     Task<SubmissionResponsesDto?> GetLatestResponses(int establishmentId, string sectionId, bool completedSubmission, CancellationToken cancellationToken = default);
+
+    Task ViewLatestSubmission(int establishmentId, string sectionId);
 }

--- a/src/Dfe.PlanTech.Domain/Submissions/Models/SectionStatusDto.cs
+++ b/src/Dfe.PlanTech.Domain/Submissions/Models/SectionStatusDto.cs
@@ -11,4 +11,6 @@ public class SectionStatusDto
     public DateTime DateCreated { get; set; }
 
     public DateTime DateUpdated { get; set; }
+
+    public bool Viewed { get; set; }
 }

--- a/src/Dfe.PlanTech.Domain/Submissions/Models/Submission.cs
+++ b/src/Dfe.PlanTech.Domain/Submissions/Models/Submission.cs
@@ -27,4 +27,6 @@ public class Submission
     public List<Response> Responses { get; set; } = new();
 
     public bool Deleted { get; set; }
+
+    public bool Viewed { get; set; }
 }

--- a/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
@@ -108,11 +108,14 @@ public class GetRecommendationRouter : IGetRecommendationRouter
     }
 
     /// <summary>
-    /// Render the recommendation page
+    /// Render the recommendation page and mark the recommendation as viewed in the database
     /// </summary>
     private async Task<IActionResult> HandleCompleteStatus(RecommendationsController controller, string recommendationSlug, CancellationToken cancellationToken)
     {
         var viewModel = await GetRecommendationViewModel(recommendationSlug, cancellationToken);
+
+        var establishmentId = await _router.User.GetEstablishmentId();
+        await _getLatestResponsesQuery.ViewLatestSubmission(establishmentId, _router.Section.Sys.Id);
 
         return controller.View("~/Views/Recommendations/Recommendations.cshtml", viewModel);
     }

--- a/src/Dfe.PlanTech.Web/ViewComponents/CategorySectionViewComponent.cs
+++ b/src/Dfe.PlanTech.Web/ViewComponents/CategorySectionViewComponent.cs
@@ -110,7 +110,8 @@ public class CategorySectionViewComponent(
             {
                 RecommendationSlug = recommendation.RecommendationSlug,
                 RecommendationDisplayName = recommendation.DisplayName,
-                SectionSlug = section.InterstitialPage?.Slug
+                SectionSlug = section.InterstitialPage?.Slug,
+                Viewed = sectionStatus.Viewed
             };
         }
         catch (Exception e)

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/CategorySection/SubtopicRecommendation.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/CategorySection/SubtopicRecommendation.cshtml
@@ -8,13 +8,9 @@
 }
 else if (Model.RecommendationSlug != null)
 {
-    if (TempData.ContainsKey("SectionSlug"))
+    if (!Model.Viewed)
     {
-        var sectionSlug = TempData["SectionSlug"] as string;
-        @if (!string.IsNullOrEmpty(sectionSlug) && sectionSlug == Model.SectionSlug)
-        {
-            <task-list-tag colour="@TagColour.Yellow">New</task-list-tag>
-        }
+        <task-list-tag colour="@TagColour.Yellow">New</task-list-tag>
     }
     <govuk-button-link
         asp-route="GetRecommendation"

--- a/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/GetLatestResponsesQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/GetLatestResponsesQueryTests.cs
@@ -151,6 +151,7 @@ public class GetLatestResponsesQueryTests
                 submission.Completed = true;
                 submission.DateCompleted = faker.Date.Future(1, submission.DateCreated);
                 submission.Maturity = faker.PickRandom(maturities);
+                submission.Viewed = false;
             }
 
             yield return submissions;
@@ -251,13 +252,18 @@ public class GetLatestResponsesQueryTests
     }
 
     [Fact]
-    public async Task ViewLatestSubmission_Should_Mark_Completed_Submission_As_Viewed()
+    public async Task ViewLatestSubmission_Should_Mark_Latest_Completed_Submission_As_Viewed()
     {
         var submission = GetCompletedSubmissionForCompletedSection();
+        var latestResponse = await _getLatestResponseListForSubmissionQuery.GetLatestResponses(ESTABLISHMENT_ID, submission.SectionId, true);
+        var latestSubmission = _submissions.FirstOrDefault(sub => sub.Id == latestResponse?.SubmissionId);
+
+        Assert.NotNull(latestSubmission);
+        Assert.False(latestSubmission.Viewed);
 
         await _getLatestResponseListForSubmissionQuery.ViewLatestSubmission(ESTABLISHMENT_ID, submission.SectionId);
 
-        Assert.True(submission.Viewed);
+        Assert.True(latestSubmission.Viewed);
     }
 
     [Fact]

--- a/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/GetLatestResponsesQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/GetLatestResponsesQueryTests.cs
@@ -250,6 +250,26 @@ public class GetLatestResponsesQueryTests
         Assert.False(submission.Deleted);
     }
 
+    [Fact]
+    public async Task ViewLatestSubmission_Should_Mark_Completed_Submission_As_Viewed()
+    {
+        var submission = GetCompletedSubmissionForCompletedSection();
+
+        await _getLatestResponseListForSubmissionQuery.ViewLatestSubmission(ESTABLISHMENT_ID, submission.SectionId);
+
+        Assert.True(submission.Viewed);
+    }
+
+    [Fact]
+    public async Task ViewLatestSubmission_Should_Not_Mark_Incomplete_Submission_As_Viewed()
+    {
+        var submission = GetIncompleteSubmissionForIncompleteSection();
+
+        await _getLatestResponseListForSubmissionQuery.ViewLatestSubmission(ESTABLISHMENT_ID, submission.SectionId);
+
+        Assert.False(submission.Viewed);
+    }
+
     private IEnumerable<Response> GenerateResponses(List<Section> sections,
                                                     Submission submission,
                                                     Faker faker)

--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/check-answer-page.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/check-answer-page.cy.js
@@ -95,8 +95,14 @@ describe("Check answers page", () => {
   });
 
   //This needs to be last on this test run, so that the question-page tests have a clean slate to work from!
-  it("submits answers and shows notification", () => {
+  it("submits answers, shows notification and preserves notification", () => {
     cy.submitAnswers();
+
+    cy.get(".govuk-tag--yellow")
+      .should("exist")
+      .and("contain", "New");
+
+    cy.reload();
 
     cy.get(".govuk-tag--yellow")
       .should("exist")


### PR DESCRIPTION
## Overview

Addresses ticket [#237183](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/237183)

Now shows the "New" tag until a recommendation has actually been viewed by someone in the organisation

## Changes

### Minor
- Adds a `viewed` column to the `submission` table that defaults to false
- Returns it from the `GetSectionStatuses` procedure so that the page can show the `"New"` tag next to a recommendation whenever `viewed` is false
- On page load of recommendations, sets `viewed` to true

## How to review the PR

I've already applied the SQL changes to dev, so it should work as soon as you swap to this branch - you can also use the test database to verify the script works.

Check that:
- Completing a topic results in a new tag
- On refreshing the page it persists
- It stays if you restart but not complete the topic and haven't viewed it yet
- As soon as someone in the organisation has clicked on it, New tag is removed
- Any unhappy paths you can think of

## Checklist

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [x] Unit tests have been added/updated
- [x] E2E tests have been added/updated
