### PR TITLE
fix: Update ApiKeyAuthorisationFilter to handle auth failures more robustly

### DIFF
--- a/src/Dfe.PlanTech.Domain/Persistence/Models/ApiAuthenticationConfiguration.cs
+++ b/src/Dfe.PlanTech.Domain/Persistence/Models/ApiAuthenticationConfiguration.cs
@@ -2,5 +2,9 @@ namespace Dfe.PlanTech.Domain.Persistence.Models;
 
 public record ApiAuthenticationConfiguration
 {
-    public string KeyValue { get; init; } = null!;
+    public string KeyValue { get; init; } = "";
+
+    public bool HaveApiKey => !string.IsNullOrEmpty(KeyValue);
+
+    public bool ApiKeyMatches(string key) => KeyValue.Equals(key);
 }

--- a/src/Dfe.PlanTech.Web/Authorisation/ApiKeyAuthorisationFilter.cs
+++ b/src/Dfe.PlanTech.Web/Authorisation/ApiKeyAuthorisationFilter.cs
@@ -1,54 +1,55 @@
 using Dfe.PlanTech.Domain.Persistence.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
-using Microsoft.IdentityModel.Tokens;
 
 namespace Dfe.PlanTech.Web.Authorisation;
 
-public class ApiKeyAuthorisationFilter(ApiAuthenticationConfiguration apiAuthenticationConfiguration, ILogger<ApiKeyAuthorisationFilter> logger) : IAuthorizationFilter
+public class ApiKeyAuthorisationFilter(ApiAuthenticationConfiguration config, ILogger<ApiKeyAuthorisationFilter> logger) : IAuthorizationFilter
 {
     public const string AuthHeaderKey = "Authorization";
     public const string AuthValuePrefix = "Bearer ";
+
     public void OnAuthorization(AuthorizationFilterContext context)
     {
-        if (!GetProvidedApiKey(context, out var providedApiKey))
-        {
-            logger.LogInformation("Request to authorised route denied due to missing authentication header");
-            context.Result = new UnauthorizedResult();
-        }
-
-        var validApiKey = apiAuthenticationConfiguration.KeyValue;
-
-        if (validApiKey.IsNullOrEmpty())
-        {
-            logger.LogError("ApiKey config value missing");
-            context.Result = new UnauthorizedResult();
-        }
-
-        if (!validApiKey!.Equals(providedApiKey))
+        if (!HaveValidConfiguration() || !AuthorisationHeaderValid(context))
         {
             context.Result = new UnauthorizedResult();
         }
     }
 
-    private static bool GetProvidedApiKey(AuthorizationFilterContext context, out string? apiKey)
+    private bool HaveValidConfiguration()
     {
-        if (!context.HttpContext.Request.Headers.TryGetValue(AuthHeaderKey, out var providedApiKey) ||
-            string.IsNullOrEmpty(providedApiKey))
+        if (config.HaveApiKey)
+        {
+            return true;
+        }
+
+        logger.LogError("API key {KeyName} is missing", nameof(config.KeyValue));
+        return false;
+    }
+
+    private bool AuthorisationHeaderValid(AuthorizationFilterContext context)
+    {
+        if (!TryGetProvidedApiKey(context, out string? providedApiKey) || string.IsNullOrEmpty(providedApiKey))
+        {
+            logger.LogInformation("Request to authorised route denied due to missing authentication header");
+            return false;
+        }
+
+        return config.ApiKeyMatches(providedApiKey);
+    }
+
+    private static bool TryGetProvidedApiKey(AuthorizationFilterContext context, out string? apiKey)
+    {
+        var authorisationHeaderValue = context.HttpContext.Request.Headers[AuthHeaderKey].ToString();
+
+        if (string.IsNullOrEmpty(authorisationHeaderValue) || !authorisationHeaderValue.StartsWith(AuthValuePrefix))
         {
             apiKey = null;
             return false;
         }
 
-        var value = providedApiKey.ToString();
-
-        if (!value.StartsWith(AuthValuePrefix))
-        {
-            apiKey = null;
-            return false;
-        }
-
-        apiKey = value[AuthValuePrefix.Length..];
+        apiKey = authorisationHeaderValue[AuthValuePrefix.Length..];
         return true;
     }
 }


### PR DESCRIPTION
## Overview

Updates `ApiKeyAuthorisationFilter` to handle missing configuration and invalid API keys more robustly

## Changes

### Minor

- Ensure API authorisation failures exit after one failure found

## Additional notes

Currently there are 3 steps in validating the API key supplied to the app:
1. Check the header value exists in the expected format.
2. Check that we have the valid API key in our config. 
3. Check that the supplied API key matches the valid API key

If any of those steps are false, then we return an unauthorised result.

_However_, we don't actually stop the rest of the validations if any of them are incorrect. E.g. if the user doesn't supply an API key (step 1 fails), we set it to return an authorised result but still continue processing steps 2 + 3. This can lead to system errors later on where we end up with null reference comparisons.

This rejigs the code a bit to ensure we always exit once a failure occurs. 

## Checklist

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [x] Unit tests have been added/updated
