### PR TITLE
fix: Build Dfe.PlanTech.Web.Node by default when building Dfe.PlanTech.Web

### DIFF
--- a/src/Dfe.PlanTech.Web/Dfe.PlanTech.Web.csproj
+++ b/src/Dfe.PlanTech.Web/Dfe.PlanTech.Web.csproj
@@ -16,22 +16,29 @@
     <ItemGroup>
         <ProjectReference Include="..\Dfe.PlanTech.Application\Dfe.PlanTech.Application.csproj" />
         <ProjectReference Include="..\Dfe.PlanTech.Domain\Dfe.PlanTech.Domain.csproj" />
-        <ProjectReference Include="..\Dfe.PlanTech.Infrastructure.Contentful\Dfe.PlanTech.Infrastructure.Contentful.csproj" />
-        <ProjectReference Include="..\Dfe.PlanTech.Infrastructure.Data\Dfe.PlanTech.Infrastructure.Data.csproj" />
-        <ProjectReference Include="..\Dfe.PlanTech.Infrastructure.SignIn\Dfe.PlanTech.Infrastructure.SignIn.csproj" />
-        <ProjectReference Include="..\Dfe.PlanTech.Infrastructure.ServiceBus\Dfe.PlanTech.Infrastructure.ServiceBus.csproj" />
-        <ProjectReference Include="..\Dfe.PlanTech.Infrastructure.Redis\Dfe.PlanTech.Infrastructure.Redis.csproj" />
+        <ProjectReference
+            Include="..\Dfe.PlanTech.Infrastructure.Contentful\Dfe.PlanTech.Infrastructure.Contentful.csproj" />
+        <ProjectReference
+            Include="..\Dfe.PlanTech.Infrastructure.Data\Dfe.PlanTech.Infrastructure.Data.csproj" />
+        <ProjectReference
+            Include="..\Dfe.PlanTech.Infrastructure.SignIn\Dfe.PlanTech.Infrastructure.SignIn.csproj" />
+        <ProjectReference
+            Include="..\Dfe.PlanTech.Infrastructure.ServiceBus\Dfe.PlanTech.Infrastructure.ServiceBus.csproj" />
+        <ProjectReference
+            Include="..\Dfe.PlanTech.Infrastructure.Redis\Dfe.PlanTech.Infrastructure.Redis.csproj" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Automapper" Version="13.0.1" />
-        <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
+        <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets"
+            Version="1.3.2" />
         <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.2.4" />
         <PackageReference Include="Azure.Identity" Version="1.13.1" />
         <PackageReference Include="EFCoreSecondLevelCacheInterceptor" Version="4.8.4" />
         <PackageReference Include="GovUk.Frontend.AspNetCore" Version="2.2.0" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
         <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore"
+            Version="8.0.10" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.10" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
@@ -39,13 +46,11 @@
         <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     </ItemGroup>
 
-    <ItemGroup>
-        <None Remove="Views\Recommendations\" />
-    </ItemGroup>
-
-    <Target Name="BuildWebAssets" BeforeTargets="Build" Condition="'$(buildWebAssets)' == 'true'">
-        <Exec Command="npm install" WorkingDirectory="../Dfe.PlanTech.Web.Node" />
-        <Exec Command="npm run build" WorkingDirectory="../Dfe.PlanTech.Web.Node" />
+    <Target Name="BuildWebAssets" BeforeTargets="Build" Condition="'$(BuildWebAssets)' != 'false'">
+        <Exec Command="npm install" WorkingDirectory="../Dfe.PlanTech.Web.Node"
+            ContinueOnError="true" />
+        <Exec Command="npm run build" WorkingDirectory="../Dfe.PlanTech.Web.Node"
+            ContinueOnError="true" />
     </Target>
 
 </Project>


### PR DESCRIPTION
## Overview

The csproj for `Dfe.PlanTech.Web` is setup to build `Dfe.PlanTech.Web.Node` before building the C# code. This is set to false by default. This PR changes it to true to minimise confusion + issues for developers in the future.

## Changes

### Minor

- Build Dfe.PlanTech.Web.Node by default when building Dfe.PlanTech.Web

## How to review the PR

1. Pull the branch
2. Build the web app in ./src/Dfe.PlanTech.Web
3. Verify that the Node project is built

## Checklist

Delete any rows that do not apply to the PR.

- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch
