### PR TITLE
Fix: improve redis caching edge cases

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -117,13 +117,40 @@ jobs:
               --output none
               &> /dev/null
 
+  flush-redis-cache:
+    runs-on: ubuntu-22.04
+    name: Flush Redis Cache on ${{ inputs.environment }}
+    environment: ${{ inputs.environment }}
+    needs: [upgrade-database, pull-image-from-gcr-and-publish-to-acr, deploy-image]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Azure CLI Login
+        uses: ./.github/actions/azure-login
+        with:
+          az_tenant_id: ${{ secrets.AZ_TENANT_ID }}
+          az_subscription_id: ${{ secrets.AZ_SUBSCRIPTION_ID }}
+          az_client_id: ${{ secrets.AZ_CLIENT_ID }}
+          az_client_secret: ${{ secrets.AZ_CLIENT_SECRET }}
+
+      - name: Flush Redis Cache
+        uses: azure/CLI@v1
+        id: azure
+        with:
+          azcliversion: 2.67.0
+          inlineScript: |
+            az redis flush --name ${{ secrets.AZ_ENVIRONMENT }}${{ secrets.DFE_PROJECT_NAME }} --resource-group ${{ secrets.AZ_ENVIRONMENT }}${{ secrets.DFE_PROJECT_NAME }} --yes
+
   run-e2e-testing:
     runs-on: ubuntu-22.04
     name: Clear Database & Run E2E Tests on ${{ inputs.environment }}
     if: ${{ inputs.environment == 'tst' || inputs.environment == 'staging' }}
     environment: ${{ inputs.environment }}
     needs:
-      [upgrade-database, pull-image-from-gcr-and-publish-to-acr, deploy-image]
+      [upgrade-database, pull-image-from-gcr-and-publish-to-acr, deploy-image, flush-redis-cache]
     env:
       az_keyvault_name: ${{ secrets.AZ_ENVIRONMENT }}${{ secrets.DFE_PROJECT_NAME }}-kv
       az_keyvault_database_connectionstring_name: ${{ secrets.AZ_KEYVAULT_DATABASE_CONNECTIONSTRING_NAME }}

--- a/src/Dfe.PlanTech.Application/Caching/Interfaces/ICmsCache.cs
+++ b/src/Dfe.PlanTech.Application/Caching/Interfaces/ICmsCache.cs
@@ -10,6 +10,7 @@ public interface ICmsCache : IDistributedCache
     /// Then removes the dependency array itself
     /// </summary>
     /// <param name="contentComponentId">Id of component to invalidate dependencies of</param>
+    /// <param name="contentType">Name of the content type of the component being invalidated</param>
     /// <returns></returns>
-    Task InvalidateCacheAsync(string contentComponentId);
+    Task InvalidateCacheAsync(string contentComponentId, string contentType);
 }

--- a/src/Dfe.PlanTech.Application/Content/Queries/GetEntityFromContentfulQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetEntityFromContentfulQuery.cs
@@ -1,4 +1,3 @@
-using Dfe.PlanTech.Application.Caching.Interfaces;
 using Dfe.PlanTech.Application.Core;
 using Dfe.PlanTech.Application.Persistence.Interfaces;
 using Dfe.PlanTech.Domain.Content.Interfaces;
@@ -16,12 +15,10 @@ public class GetEntityFromContentfulQuery : ContentRetriever, IGetEntityFromCont
     public const string ExceptionMessageEntityContentful = "Error fetching Entity from Contentful";
 
     private readonly ILogger<GetEntityFromContentfulQuery> _logger;
-    private readonly ICmsCache _cache;
 
-    public GetEntityFromContentfulQuery(ILogger<GetEntityFromContentfulQuery> logger, IContentRepository repository, ICmsCache cache) : base(repository)
+    public GetEntityFromContentfulQuery(ILogger<GetEntityFromContentfulQuery> logger, IContentRepository repository) : base(repository)
     {
         _logger = logger;
-        _cache = cache;
     }
 
     public async Task<TContent?> GetEntityById<TContent>(string contentId, CancellationToken cancellationToken = default)
@@ -29,8 +26,7 @@ public class GetEntityFromContentfulQuery : ContentRetriever, IGetEntityFromCont
     {
         try
         {
-            return await _cache.GetOrCreateAsync($"Entity:{contentId}",
-                () => repository.GetEntityById<TContent>(contentId, cancellationToken: cancellationToken));
+            return await repository.GetEntityById<TContent>(contentId, cancellationToken: cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/Dfe.PlanTech.Application/Content/Queries/GetNavigationQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetNavigationQuery.cs
@@ -1,5 +1,3 @@
-
-using Dfe.PlanTech.Application.Caching.Interfaces;
 using Dfe.PlanTech.Application.Core;
 using Dfe.PlanTech.Application.Persistence.Interfaces;
 using Dfe.PlanTech.Domain.Content.Interfaces;

--- a/src/Dfe.PlanTech.Application/Content/Queries/GetNavigationQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetNavigationQuery.cs
@@ -16,20 +16,17 @@ public class GetNavigationQuery : ContentRetriever, IGetNavigationQuery
     public const string ExceptionMessageContentful = "Error getting navigation links from Contentful";
 
     private readonly ILogger<GetNavigationQuery> _logger;
-    private readonly ICmsCache _cache;
 
-    public GetNavigationQuery(ILogger<GetNavigationQuery> logger, IContentRepository repository, ICmsCache cache) : base(repository)
+    public GetNavigationQuery(ILogger<GetNavigationQuery> logger, IContentRepository repository) : base(repository)
     {
         _logger = logger;
-        _cache = cache;
     }
 
     public async Task<IEnumerable<INavigationLink>> GetNavigationLinks(CancellationToken cancellationToken = default)
     {
         try
         {
-            var navigationLinks = await _cache.GetOrCreateAsync("NavigationLinks", () => repository.GetEntities<NavigationLink>(cancellationToken)) ?? [];
-            return navigationLinks;
+            return await repository.GetEntities<NavigationLink>(cancellationToken);
         }
         catch (Exception ex)
         {
@@ -42,7 +39,7 @@ public class GetNavigationQuery : ContentRetriever, IGetNavigationQuery
     {
         try
         {
-            return await _cache.GetOrCreateAsync($"NavigationLink:{contentId}", () => repository.GetEntityById<NavigationLink?>(contentId, cancellationToken: cancellationToken));
+            return await repository.GetEntityById<NavigationLink?>(contentId, cancellationToken: cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/Dfe.PlanTech.Application/Content/Queries/GetPageQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetPageQuery.cs
@@ -1,4 +1,3 @@
-using Dfe.PlanTech.Application.Caching.Interfaces;
 using Dfe.PlanTech.Application.Exceptions;
 using Dfe.PlanTech.Application.Persistence.Interfaces;
 using Dfe.PlanTech.Application.Persistence.Models;
@@ -12,14 +11,12 @@ namespace Dfe.PlanTech.Application.Content.Queries;
 
 public class GetPageQuery : IGetPageQuery
 {
-    private readonly ICmsCache _cache;
     private readonly IContentRepository _repository;
     private readonly ILogger<GetPageQuery> _logger;
     private readonly GetPageFromContentfulOptions _options;
 
-    public GetPageQuery(ICmsCache cache, IContentRepository repository, ILogger<GetPageQuery> logger, GetPageFromContentfulOptions options)
+    public GetPageQuery(IContentRepository repository, ILogger<GetPageQuery> logger, GetPageFromContentfulOptions options)
     {
-        _cache = cache;
         _repository = repository;
         _logger = logger;
         _options = options;
@@ -52,8 +49,7 @@ public class GetPageQuery : IGetPageQuery
     {
         try
         {
-            return await _cache.GetOrCreateAsync($"Page:{pageId}", () =>
-                _repository.GetEntityById<Page?>(pageId, cancellationToken: cancellationToken));
+            return await _repository.GetEntityById<Page?>(pageId, cancellationToken: cancellationToken);
         }
         catch (Exception ex)
         {
@@ -67,7 +63,7 @@ public class GetPageQuery : IGetPageQuery
     {
         try
         {
-            var pages = await _cache.GetOrCreateAsync($"Page:{slug}", () => _repository.GetEntities<Page?>(options, cancellationToken)) ?? [];
+            var pages = await _repository.GetEntities<Page?>(options, cancellationToken);
 
             var page = pages.FirstOrDefault();
 

--- a/src/Dfe.PlanTech.Application/Content/Queries/GetSubTopicRecommendationQuery.cs
+++ b/src/Dfe.PlanTech.Application/Content/Queries/GetSubTopicRecommendationQuery.cs
@@ -1,4 +1,3 @@
-using Dfe.PlanTech.Application.Caching.Interfaces;
 using Dfe.PlanTech.Application.Persistence.Interfaces;
 using Dfe.PlanTech.Application.Persistence.Models;
 using Dfe.PlanTech.Domain.Content.Interfaces;
@@ -11,14 +10,12 @@ using Microsoft.Extensions.Logging;
 namespace Dfe.PlanTech.Application.Content.Queries;
 
 public class GetSubTopicRecommendationQuery(IContentRepository repository,
-                                            ILogger<GetSubTopicRecommendationQuery> logger,
-                                            ICmsCache cache) : IGetSubTopicRecommendationQuery
+                                            ILogger<GetSubTopicRecommendationQuery> logger) : IGetSubTopicRecommendationQuery
 {
     public async Task<SubtopicRecommendation?> GetSubTopicRecommendation(string subtopicId, CancellationToken cancellationToken = default)
     {
         var options = CreateGetEntityOptions(subtopicId);
-        var subTopicRecommendations = await cache.GetOrCreateAsync($"SubtopicRecommendation:{subtopicId}",
-            () => repository.GetEntities<SubtopicRecommendation>(options, cancellationToken)) ?? [];
+        var subTopicRecommendations = await repository.GetEntities<SubtopicRecommendation>(options, cancellationToken);
 
         var subtopicRecommendation = subTopicRecommendations.FirstOrDefault();
 
@@ -35,8 +32,7 @@ public class GetSubTopicRecommendationQuery(IContentRepository repository,
         var options = CreateGetEntityOptions(subtopicId, 2);
         options.Select = ["fields.intros", "sys"];
 
-        var subtopicRecommendations = await cache.GetOrCreateAsync($"RecommendationViewDto:{subtopicId}",
-            () => repository.GetEntities<SubtopicRecommendation>(options, cancellationToken)) ?? [];
+        var subtopicRecommendations = await repository.GetEntities<SubtopicRecommendation>(options, cancellationToken);
 
         var subtopicRecommendation = subtopicRecommendations.FirstOrDefault();
 

--- a/src/Dfe.PlanTech.Application/Persistence/Commands/WebhookMessageProcessor.cs
+++ b/src/Dfe.PlanTech.Application/Persistence/Commands/WebhookMessageProcessor.cs
@@ -18,7 +18,7 @@ public class WebhookMessageProcessor(ICmsCache cache,
         {
             var payload = MapMessageToPayload(body);
 
-            await cache.InvalidateCacheAsync(payload.Sys.Id);
+            await cache.InvalidateCacheAsync(payload.Sys.Id, payload.ContentType.FirstCharToUpper());
             return new ServiceBusSuccessResult();
         }
         catch (Exception ex) when (ex is JsonException)

--- a/src/Dfe.PlanTech.Application/Persistence/Commands/WebhookMessageProcessor.cs
+++ b/src/Dfe.PlanTech.Application/Persistence/Commands/WebhookMessageProcessor.cs
@@ -18,7 +18,7 @@ public class WebhookMessageProcessor(ICmsCache cache,
         {
             var payload = MapMessageToPayload(body);
 
-            await cache.InvalidateCacheAsync(payload.Sys.Id, payload.ContentType.FirstCharToUpper());
+            await cache.InvalidateCacheAsync(payload.Sys.Id, payload.ContentType);
             return new ServiceBusSuccessResult();
         }
         catch (Exception ex) when (ex is JsonException)

--- a/src/Dfe.PlanTech.Application/Persistence/Interfaces/IContentRepository.cs
+++ b/src/Dfe.PlanTech.Application/Persistence/Interfaces/IContentRepository.cs
@@ -1,3 +1,4 @@
+using Dfe.PlanTech.Application.Persistence.Models;
 using Dfe.PlanTech.Domain.Persistence.Interfaces;
 
 namespace Dfe.PlanTech.Application.Persistence.Interfaces;
@@ -16,6 +17,14 @@ public interface IContentRepository
     /// <typeparam name="TEntity"></typeparam>
     /// <returns></returns>
     Task<TEntity?> GetEntityById<TEntity>(string id, int include = 2, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get options to use for fetching an Entity by Id
+    /// </summary>
+    /// <param name="id"></param>
+    /// <param name="include"></param>
+    /// <returns></returns>
+    GetEntitiesOptions GetEntityByIdOptions(string id, int include = 2);
 
     /// <summary>
     /// Get all entities of the specified type, using the name of the generic parameter's type as the entity type id (to lower case).

--- a/src/Dfe.PlanTech.Application/Persistence/Interfaces/IContentRepository.cs
+++ b/src/Dfe.PlanTech.Application/Persistence/Interfaces/IContentRepository.cs
@@ -18,16 +18,6 @@ public interface IContentRepository
     Task<TEntity?> GetEntityById<TEntity>(string id, int include = 2, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Get all entities of the specified type.
-    /// </summary>
-    /// <param name="entityTypeId"></param>
-    /// <param name="queries">Additional filtere</param>
-    /// <param name="cancellationToken"></param>
-    /// <typeparam name="TEntity"></typeparam>
-    /// <returns></returns>
-    Task<IEnumerable<TEntity>> GetEntities<TEntity>(string entityTypeId, IGetEntitiesOptions? options, CancellationToken cancellationToken = default);
-
-    /// <summary>
     /// Get all entities of the specified type, using the name of the generic parameter's type as the entity type id (to lower case).
     /// E.g. if the TEntity is a class called "Category", then it uses "category"
     /// </summary>

--- a/src/Dfe.PlanTech.Application/Persistence/Models/GetEntitiesOptions.cs
+++ b/src/Dfe.PlanTech.Application/Persistence/Models/GetEntitiesOptions.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using System.Text;
 using Dfe.PlanTech.Domain.Persistence.Interfaces;
 

--- a/src/Dfe.PlanTech.Application/Persistence/Models/GetEntitiesOptions.cs
+++ b/src/Dfe.PlanTech.Application/Persistence/Models/GetEntitiesOptions.cs
@@ -36,6 +36,9 @@ public class GetEntitiesOptions : IGetEntitiesOptions
     {
         var builder = new StringBuilder();
 
+        builder.Append(":Include=");
+        builder.Append(Include);
+
         if (Select != null && Select.Any())
             builder.Append($":Select=[{string.Join(",", Select)}]");
 
@@ -56,10 +59,7 @@ public class GetEntitiesOptions : IGetEntitiesOptions
             builder.Length--;
             builder.Append(']');
         }
-
-        builder.Append(":Include=");
-        builder.Append(Include);
-
+        
         return builder.ToString();
     }
 }

--- a/src/Dfe.PlanTech.Application/Persistence/Models/GetEntitiesOptions.cs
+++ b/src/Dfe.PlanTech.Application/Persistence/Models/GetEntitiesOptions.cs
@@ -59,7 +59,7 @@ public class GetEntitiesOptions : IGetEntitiesOptions
             builder.Length--;
             builder.Append(']');
         }
-        
+
         return builder.ToString();
     }
 }

--- a/src/Dfe.PlanTech.Application/Questionnaire/Queries/GetSectionQuery.cs
+++ b/src/Dfe.PlanTech.Application/Questionnaire/Queries/GetSectionQuery.cs
@@ -1,4 +1,3 @@
-using Dfe.PlanTech.Application.Caching.Interfaces;
 using Dfe.PlanTech.Application.Core;
 using Dfe.PlanTech.Application.Exceptions;
 using Dfe.PlanTech.Application.Persistence.Interfaces;
@@ -12,11 +11,9 @@ namespace Dfe.PlanTech.Application.Questionnaire.Queries;
 public class GetSectionQuery : ContentRetriever, IGetSectionQuery
 {
     public const string SlugFieldPath = "fields.interstitialPage.fields.slug";
-    private readonly ICmsCache _cache;
 
-    public GetSectionQuery(IContentRepository repository, ICmsCache cache) : base(repository)
+    public GetSectionQuery(IContentRepository repository) : base(repository)
     {
-        _cache = cache;
     }
 
     public async Task<Section?> GetSectionBySlug(string sectionSlug, CancellationToken cancellationToken = default)
@@ -40,7 +37,7 @@ public class GetSectionQuery : ContentRetriever, IGetSectionQuery
 
         try
         {
-            var sections = await _cache.GetOrCreateAsync($"Section:{sectionSlug}", () => repository.GetEntities<Section>(options, cancellationToken)) ?? [];
+            var sections = await repository.GetEntities<Section>(options, cancellationToken);
             return sections.FirstOrDefault();
         }
         catch (Exception ex)
@@ -56,13 +53,9 @@ public class GetSectionQuery : ContentRetriever, IGetSectionQuery
     {
         try
         {
-            var sections = await _cache.GetOrCreateAsync("Sections", async () =>
-            {
-                var options = new GetEntitiesOptions(include: 3);
-                var sections = await repository.GetEntities<Section>(options, cancellationToken);
-                return sections.Select(MapSection);
-            }) ?? [];
-            return sections;
+            var options = new GetEntitiesOptions(include: 3);
+            var sections = await repository.GetEntities<Section>(options, cancellationToken);
+            return sections.Select(MapSection);
         }
         catch (Exception ex)
         {

--- a/src/Dfe.PlanTech.Domain/Extensions/StringHelpers.cs
+++ b/src/Dfe.PlanTech.Domain/Extensions/StringHelpers.cs
@@ -21,4 +21,6 @@ public static partial class StringHelpers
 
     private static string ReplaceNonSlugCharacters(this string text, string replacement)
     => MatchNonAlphaNumericExceptHyphensPattern().Replace(text, replacement);
+
+    public static string FirstCharToLower(this string input) => char.ToLower(input[0]) + input[1..];
 }

--- a/src/Dfe.PlanTech.Domain/Persistence/Interfaces/IGetEntitiesOptions.cs
+++ b/src/Dfe.PlanTech.Domain/Persistence/Interfaces/IGetEntitiesOptions.cs
@@ -19,4 +19,6 @@ public interface IGetEntitiesOptions
     /// If null, return all
     /// </remarks>
     public IEnumerable<string>? Select { get; set; }
+
+    public string SerializeToRedisKey();
 }

--- a/src/Dfe.PlanTech.Domain/Persistence/Interfaces/IGetEntitiesOptions.cs
+++ b/src/Dfe.PlanTech.Domain/Persistence/Interfaces/IGetEntitiesOptions.cs
@@ -20,5 +20,5 @@ public interface IGetEntitiesOptions
     /// </remarks>
     public IEnumerable<string>? Select { get; set; }
 
-    public string SerializeToRedisKey();
+    public string SerializeToRedisFormat();
 }

--- a/src/Dfe.PlanTech.Infrastructure.Contentful/Helpers/ContentfulSetup.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Contentful/Helpers/ContentfulSetup.cs
@@ -34,7 +34,8 @@ public static class ContentfulSetup
 
         services.AddTransient<IGetSubmissionStatusesQuery, GetSubmissionStatusesQuery>();
         services.AddScoped<IContentfulClient, ContentfulClient>();
-        services.AddScoped<IContentRepository, ContentfulRepository>();
+        services.AddKeyedScoped<IContentRepository, ContentfulRepository>("contentfulRepository");
+        services.AddScoped<IContentRepository, CachedContentfulRepository>();
 
 
         services.SetupRichTextRenderer();

--- a/src/Dfe.PlanTech.Infrastructure.Contentful/Persistence/CachedContentfulRepository.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Contentful/Persistence/CachedContentfulRepository.cs
@@ -31,7 +31,7 @@ public class CachedContentfulRepository : IContentRepository
     public async Task<IEnumerable<TEntity>> GetEntities<TEntity>(IGetEntitiesOptions options, CancellationToken cancellationToken = default)
     {
         var contentType = GetContentTypeName<TEntity>();
-        var jsonOptions = options.SerializeToRedisKey();
+        var jsonOptions = options.SerializeToRedisFormat();
         var key = $"{contentType}{jsonOptions}";
 
         return await _cache.GetOrCreateAsync(key, async () => await _contentRepository.GetEntities<TEntity>(options, cancellationToken)) ?? [];

--- a/src/Dfe.PlanTech.Infrastructure.Contentful/Persistence/CachedContentfulRepository.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Contentful/Persistence/CachedContentfulRepository.cs
@@ -1,0 +1,50 @@
+using Dfe.PlanTech.Application.Caching.Interfaces;
+using Dfe.PlanTech.Application.Persistence.Interfaces;
+using Dfe.PlanTech.Domain.Persistence.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dfe.PlanTech.Infrastructure.Contentful.Persistence;
+
+/// <summary>
+/// Encapsulates ContentfulClient functionality, whilst abstracting through the IEntityRepository interface
+/// </summary>
+/// <see href="IEntityRepository"/>
+public class CachedContentfulRepository : IContentRepository
+{
+    private readonly IContentRepository _contentRepository;
+    private readonly ICmsCache _cache;
+
+    public CachedContentfulRepository([FromKeyedServices("contentfulRepository")] IContentRepository contentRepository, ICmsCache cache)
+    {
+        _contentRepository = contentRepository ?? throw new ArgumentNullException(nameof(contentRepository));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+    }
+
+    public async Task<IEnumerable<TEntity>> GetEntities<TEntity>(CancellationToken cancellationToken = default)
+    {
+        string contentType = GetContentTypeName<TEntity>();
+        var key = $"{contentType}s";
+
+        return await _cache.GetOrCreateAsync(key, async () => await _contentRepository.GetEntities<TEntity>(cancellationToken)) ?? [];
+    }
+
+    public async Task<IEnumerable<TEntity>> GetEntities<TEntity>(IGetEntitiesOptions options, CancellationToken cancellationToken = default)
+    {
+        var contentType = GetContentTypeName<TEntity>();
+        var jsonOptions = options.SerializeToRedisKey();
+        var key = $"{contentType}{jsonOptions}";
+
+        return await _cache.GetOrCreateAsync(key, async () => await _contentRepository.GetEntities<TEntity>(options, cancellationToken)) ?? [];
+    }
+
+    public async Task<TEntity?> GetEntityById<TEntity>(string id, int include = 2, CancellationToken cancellationToken = default)
+    {
+        return await _contentRepository.GetEntityById<TEntity>(id, include, cancellationToken);
+    }
+
+    private static string GetContentTypeName<TEntity>()
+    {
+        var name = typeof(TEntity).Name;
+        return name == "ContentSupportPage" ? name : name.FirstCharToLower();
+    }
+}

--- a/src/Dfe.PlanTech.Infrastructure.Contentful/Persistence/ContentfulRepository.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Contentful/Persistence/ContentfulRepository.cs
@@ -7,7 +7,6 @@ using Dfe.PlanTech.Domain.Persistence.Interfaces;
 using Dfe.PlanTech.Infrastructure.Application.Models;
 using Dfe.PlanTech.Infrastructure.Contentful.Helpers;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 
 namespace Dfe.PlanTech.Infrastructure.Contentful.Persistence;
 
@@ -70,8 +69,8 @@ public class ContentfulRepository : IContentRepository
     public async Task<IEnumerable<TEntity>> GetEntities<TEntity>(IGetEntitiesOptions options, CancellationToken cancellationToken = default)
     {
         var contentType = LowerCaseFirstLetter(typeof(TEntity).Name);
-        var jsonOptions = JsonConvert.SerializeObject(options);
-        var key = $"{contentType}_{jsonOptions}";
+        var jsonOptions = options.SerializeToRedisKey();
+        var key = $"{contentType}{jsonOptions}";
 
         return await _cache.GetOrCreateAsync(key, async () => await GetEntities<TEntity>(contentType, options, cancellationToken)) ?? [];
     }

--- a/src/Dfe.PlanTech.Infrastructure.Contentful/Persistence/ContentfulRepository.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Contentful/Persistence/ContentfulRepository.cs
@@ -63,6 +63,17 @@ public class ContentfulRepository : IContentRepository
 
     public async Task<TEntity?> GetEntityById<TEntity>(string id, int include = 2, CancellationToken cancellationToken = default)
     {
+        var options = GetEntityByIdOptions(id, include);
+        var entities = (await GetEntities<TEntity>(options, cancellationToken)).ToList();
+
+        if (entities.Count > 1)
+            throw new GetEntitiesException($"Found more than 1 entity with id {id}");
+
+        return entities.FirstOrDefault();
+    }
+
+    public GetEntitiesOptions GetEntityByIdOptions(string id, int include = 2)
+    {
         if (string.IsNullOrEmpty(id))
             throw new ArgumentNullException(nameof(id));
 
@@ -70,20 +81,11 @@ public class ContentfulRepository : IContentRepository
         //option doesn't seem to have any effect there - it only seems to return the main parent entry
         //with links to children. This was proving rather useless, so I have used the "GetEntries" option here
         //instead.
-        var options = new GetEntitiesOptions(include, new[] {
+        return new GetEntitiesOptions(include, new[] {
             new ContentQueryEquals(){
                 Field = "sys.id",
                 Value = id
-        }});
-
-        var entities = (await GetEntities<TEntity>(options, cancellationToken)).ToList();
-
-        if (entities.Count > 1)
-        {
-            throw new GetEntitiesException($"Found more than 1 entity with id {id}");
-        }
-
-        return entities.FirstOrDefault();
+            }});
     }
 
     private static string GetContentTypeName<TEntity>()

--- a/src/Dfe.PlanTech.Infrastructure.Redis/IRedisDependencyManager.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Redis/IRedisDependencyManager.cs
@@ -8,6 +8,11 @@ namespace Dfe.PlanTech.Infrastructure.Redis;
 public interface IRedisDependencyManager
 {
     /// <summary>
+    /// Key to use for dependencies of a content fetch that returns nothing
+    /// </summary>
+    string EmptyCollectionDependencyKey { get; }
+
+    /// <summary>
     /// Find and set dependencies for a given <see cref="IContentComponent"/>
     /// </summary>
     /// <typeparam name="T">Type of the value to register as a dependency.</typeparam>

--- a/src/Dfe.PlanTech.Infrastructure.Redis/RedisCache.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Redis/RedisCache.cs
@@ -1,7 +1,6 @@
 using Dfe.PlanTech.Application.Caching.Interfaces;
 using Dfe.PlanTech.Domain.Background;
 using Dfe.PlanTech.Domain.Caching.Models;
-using Dfe.PlanTech.Domain.Content.Models;
 using Microsoft.Extensions.Logging;
 using Polly;
 using Polly.Retry;

--- a/src/Dfe.PlanTech.Infrastructure.Redis/RedisCache.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Redis/RedisCache.cs
@@ -14,6 +14,7 @@ namespace Dfe.PlanTech.Infrastructure.Redis;
 /// </summary>
 public class RedisCache : ICmsCache
 {
+    private const string EmptyCollectionDependencyKey = "Missing";
     private readonly IRedisConnectionManager _connectionManager;
     private readonly AsyncRetryPolicy _retryPolicyAsync;
     private readonly ILogger<RedisCache> _logger;
@@ -61,14 +62,20 @@ public class RedisCache : ICmsCache
 
             if (result is IEnumerable<ContentComponent> components)
             {
-                foreach (var component in components)
+                var componentList = components.ToList();
+                if (componentList.Count > 0)
                 {
-                    var dependencyKey = _dependencyManager.GetDependencyKey(component.Sys.Id);
-                    _logger.LogTrace("Setting {Key} as a dependency of {DependencyKey}", key, dependencyKey);
-                    await SetAddAsync(dependencyKey, key);
+                    foreach (var component in componentList)
+                    {
+                        var dependencyKey = _dependencyManager.GetDependencyKey(component.Sys.Id);
+                        _logger.LogTrace("Setting {Key} as a dependency of {DependencyKey}", key, dependencyKey);
+                        await SetAddAsync(dependencyKey, key);
+                    }
+                    return result;
                 }
             }
-
+            _logger.LogTrace("Cache item with key: {Key} is empty", key);
+            await SetAddAsync(EmptyCollectionDependencyKey, key);
             return result;
         }
         catch (RedisConnectionException redisException)
@@ -270,14 +277,22 @@ public class RedisCache : ICmsCache
     => _backgroundTaskService.QueueBackgroundWorkItemAsync(async (cancellationToken) =>
         {
             var key = _dependencyManager.GetDependencyKey(contentComponentId);
-            var dependencies = (await GetSetMembersAsync(key)).ToList();
-            foreach (var item in dependencies)
-            {
-                await RemoveAsync(item);
-            }
-            await SetRemoveItemsAsync(key, dependencies);
+            await RemoveDependenciesAsync(key);
+
+            // Invalidate all empty collections
+            await RemoveDependenciesAsync(EmptyCollectionDependencyKey);
 
             // Invalidate collection of the content type if there is one
             await RemoveAsync($"{contentType}s");
         });
+
+    private async Task RemoveDependenciesAsync(string dependencyKey)
+    {
+        var dependencies = (await GetSetMembersAsync(dependencyKey)).ToList();
+        foreach (var item in dependencies)
+        {
+            await RemoveAsync(item);
+        }
+        await SetRemoveItemsAsync(dependencyKey, dependencies);
+    }
 }

--- a/src/Dfe.PlanTech.Infrastructure.Redis/RedisCache.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Redis/RedisCache.cs
@@ -1,7 +1,6 @@
 using Dfe.PlanTech.Application.Caching.Interfaces;
 using Dfe.PlanTech.Domain.Background;
 using Dfe.PlanTech.Domain.Caching.Models;
-using Dfe.PlanTech.Domain.Content.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models;
 using Microsoft.Extensions.Logging;
 using Polly;

--- a/src/Dfe.PlanTech.Infrastructure.Redis/RedisDependencyManager.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Redis/RedisDependencyManager.cs
@@ -30,6 +30,7 @@ public class RedisDependencyManager(IBackgroundTaskQueue backgroundTaskQueue) : 
         var tasks = GetDependencies(value).Select(dependency => batch.SetAddAsync(GetDependencyKey(dependency), key, CommandFlags.FireAndForget)).ToArray();
         if (tasks.Length == 0)
         {
+            // If the value has no dependencies (is empty) it should be invalidated when new content comes in
             tasks = tasks.Append(batch.SetAddAsync(EmptyCollectionDependencyKey, key, CommandFlags.FireAndForget)).ToArray();
         }
         batch.Execute();

--- a/src/Dfe.PlanTech.Infrastructure.Redis/RedisDependencyManager.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Redis/RedisDependencyManager.cs
@@ -1,6 +1,5 @@
 using Dfe.PlanTech.Domain.Background;
 using Dfe.PlanTech.Domain.Content.Interfaces;
-using Dfe.PlanTech.Domain.Content.Models;
 using StackExchange.Redis;
 
 namespace Dfe.PlanTech.Infrastructure.Redis;

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetEntityFromContentfulQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetEntityFromContentfulQueryTests.cs
@@ -13,20 +13,13 @@ public class GetEntityFromContentfulQueryTests
 {
     private readonly IContentRepository _contentRepository = Substitute.For<IContentRepository>();
     private readonly ILogger<GetEntityFromContentfulQuery> _logger = Substitute.For<ILogger<GetEntityFromContentfulQuery>>();
-    private readonly ICmsCache _cache = Substitute.For<ICmsCache>();
     private readonly GetEntityFromContentfulQuery _getEntityFromContentfulQuery;
 
     private readonly Question _firstQuestion = new() { Sys = new SystemDetails { Id = "question-1" } };
 
     public GetEntityFromContentfulQueryTests()
     {
-        _getEntityFromContentfulQuery = new GetEntityFromContentfulQuery(_logger, _contentRepository, _cache);
-        _cache.GetOrCreateAsync(Arg.Any<string>(), Arg.Any<Func<Task<Question?>>>())
-            .Returns(callInfo =>
-            {
-                var func = callInfo.ArgAt<Func<Task<Question?>>>(1);
-                return func();
-            });
+        _getEntityFromContentfulQuery = new GetEntityFromContentfulQuery(_logger, _contentRepository);
     }
 
 

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetEntityFromContentfulQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetEntityFromContentfulQueryTests.cs
@@ -1,4 +1,3 @@
-using Dfe.PlanTech.Application.Caching.Interfaces;
 using Dfe.PlanTech.Application.Content.Queries;
 using Dfe.PlanTech.Application.Persistence.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models;

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetNavigationQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetNavigationQueryTests.cs
@@ -1,4 +1,3 @@
-using Dfe.PlanTech.Application.Caching.Interfaces;
 using Dfe.PlanTech.Application.Content.Queries;
 using Dfe.PlanTech.Application.Persistence.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models;

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetPageQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetPageQueryTests.cs
@@ -21,7 +21,6 @@ public class GetPageQueryTests
 
     private readonly IContentRepository _repoSubstitute = Substitute.For<IContentRepository>();
     private readonly ILogger<GetPageQuery> _logger = Substitute.For<ILogger<GetPageQuery>>();
-    private readonly ICmsCache _cache = Substitute.For<ICmsCache>();
 
     private readonly List<Page> _pages = new() {
         new Page(){
@@ -56,18 +55,6 @@ public class GetPageQueryTests
     public GetPageQueryTests()
     {
         SetupRepository();
-        _cache.GetOrCreateAsync(Arg.Any<string>(), Arg.Any<Func<Task<IEnumerable<Page>?>>>())
-            .Returns(callInfo =>
-            {
-                var func = callInfo.ArgAt<Func<Task<IEnumerable<Page>?>>>(1);
-                return func();
-            });
-        _cache.GetOrCreateAsync(Arg.Any<string>(), Arg.Any<Func<Task<Page?>>>())
-            .Returns(callInfo =>
-            {
-                var func = callInfo.ArgAt<Func<Task<Page?>>>(1);
-                return func();
-            });
     }
 
     private void SetupRepository()
@@ -98,7 +85,7 @@ public class GetPageQueryTests
     }
 
     private GetPageQuery CreateGetPageQuery()
-        => new(_cache, _repoSubstitute, _logger, new GetPageFromContentfulOptions() { Include = 4 });
+        => new(_repoSubstitute, _logger, new GetPageFromContentfulOptions() { Include = 4 });
 
 
     [Fact]

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetPageQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetPageQueryTests.cs
@@ -1,4 +1,3 @@
-using Dfe.PlanTech.Application.Caching.Interfaces;
 using Dfe.PlanTech.Application.Content.Queries;
 using Dfe.PlanTech.Application.Exceptions;
 using Dfe.PlanTech.Application.Persistence.Interfaces;

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationQueryTests.cs
@@ -23,7 +23,6 @@ public class GetSubTopicRecommendationQueryTests
 
     private readonly List<SubtopicRecommendation> _subtopicRecommendations = [];
     private readonly ILogger<GetSubTopicRecommendationQuery> _logger = Substitute.For<ILogger<GetSubTopicRecommendationQuery>>();
-    private readonly ICmsCache _cache = Substitute.For<ICmsCache>();
 
     public GetSubTopicRecommendationQueryTests()
     {
@@ -135,13 +134,7 @@ public class GetSubTopicRecommendationQueryTests
         _subtopicRecommendations.Add(_subtopicRecommendationOne);
         _subtopicRecommendations.Add(_subtopicRecommendationTwo);
 
-        _query = new(_repoSubstitute, _logger, _cache);
-        _cache.GetOrCreateAsync(Arg.Any<string>(), Arg.Any<Func<Task<IEnumerable<SubtopicRecommendation>?>>>())
-            .Returns(callInfo =>
-            {
-                var func = callInfo.ArgAt<Func<Task<IEnumerable<SubtopicRecommendation>?>>>(1);
-                return func();
-            });
+        _query = new(_repoSubstitute, _logger);
     }
 
     [Fact]

--- a/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Content/Queries/GetSubTopicRecommendationQueryTests.cs
@@ -1,4 +1,3 @@
-using Dfe.PlanTech.Application.Caching.Interfaces;
 using Dfe.PlanTech.Application.Content.Queries;
 using Dfe.PlanTech.Application.Persistence.Interfaces;
 using Dfe.PlanTech.Application.Persistence.Models;

--- a/tests/Dfe.PlanTech.Application.UnitTests/Persistence/Commands/WebhookMessageProcessorTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Persistence/Commands/WebhookMessageProcessorTests.cs
@@ -42,7 +42,7 @@ public class WebhookMessageProcessorTests
         var result = await _webhookMessageProcessor.ProcessMessage(subject, QuestionJsonBody, "message id", CancellationToken.None);
 
         Assert.IsType<ServiceBusSuccessResult>(result);
-        await _cache.Received(1).InvalidateCacheAsync(QuestionId, "Question");
+        await _cache.Received(1).InvalidateCacheAsync(QuestionId, "question");
     }
 
     [Fact]

--- a/tests/Dfe.PlanTech.Application.UnitTests/Persistence/Commands/WebhookMessageProcessorTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Persistence/Commands/WebhookMessageProcessorTests.cs
@@ -42,7 +42,7 @@ public class WebhookMessageProcessorTests
         var result = await _webhookMessageProcessor.ProcessMessage(subject, QuestionJsonBody, "message id", CancellationToken.None);
 
         Assert.IsType<ServiceBusSuccessResult>(result);
-        await _cache.Received(1).InvalidateCacheAsync(QuestionId);
+        await _cache.Received(1).InvalidateCacheAsync(QuestionId, "Question");
     }
 
     [Fact]

--- a/tests/Dfe.PlanTech.Application.UnitTests/Persistence/GetEntitiesOptionsTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Persistence/GetEntitiesOptionsTests.cs
@@ -77,10 +77,10 @@ public class GetEntitiesOptionsTests
 
     [Theory]
     [InlineData("Empty", ":Include=2")]
-    [InlineData("Select", ":Select=[field.intros,field.sys]:Include=2")]
+    [InlineData("Select", ":Include=2:Select=[field.intros,field.sys]")]
     [InlineData("Include", ":Include=4")]
-    [InlineData("Query", ":Queries=[slug=/,id=1234,toinclude=[value1,value2]]:Include=2")]
-    [InlineData("Combined", ":Select=[field.intros,field.sys]:Queries=[slug=/test]:Include=6")]
+    [InlineData("Query", ":Include=2:Queries=[slug=/,id=1234,toinclude=[value1,value2]]")]
+    [InlineData("Combined", ":Include=6:Select=[field.intros,field.sys]:Queries=[slug=/test]")]
     public void Should_Serialise_Options_Into_Suitable_Redis_Format(string testDataKey, string expectedValue)
     {
         var testData = _testData[testDataKey];

--- a/tests/Dfe.PlanTech.Application.UnitTests/Persistence/GetEntitiesOptionsTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Persistence/GetEntitiesOptionsTests.cs
@@ -6,6 +6,42 @@ namespace Dfe.PlanTech.Application.UnitTests.Persistence;
 
 public class GetEntitiesOptionsTests
 {
+    private readonly Dictionary<string, GetEntitiesOptions> _testData;
+
+    public GetEntitiesOptionsTests()
+    {
+        _testData = new Dictionary<string, GetEntitiesOptions>
+        {
+            { "Empty", new GetEntitiesOptions() },
+            { "Include", new GetEntitiesOptions(include: 4) },
+            {
+                "Select", new GetEntitiesOptions()
+                {
+                    Select = ["field.intros", "field.sys"]
+                }
+            },
+            {
+                "Query", new GetEntitiesOptions(queries:
+                [
+                    new ContentQueryEquals() { Field = "slug", Value = "/" },
+                    new ContentQueryEquals() { Field = "id", Value = "1234" },
+                    new ContentQueryIncludes() { Field = "toinclude", Value = ["value1", "value2"] }
+                ])
+            },
+            {
+                "Combined", new GetEntitiesOptions()
+                {
+                    Select = ["field.intros", "field.sys"],
+                    Queries =
+                    [
+                        new ContentQueryEquals() { Field = "slug", Value = "/test" },
+                    ],
+                    Include = 6
+                }
+            }
+        };
+    }
+
     [Fact]
     public void Should_Set_Include()
     {
@@ -37,6 +73,19 @@ public class GetEntitiesOptionsTests
 
         Assert.Equal(2, options.Include);
         Assert.Null(options.Queries);
+    }
+
+    [Theory]
+    [InlineData("Empty", ":Include=2")]
+    [InlineData("Select", ":Select=[field.intros,field.sys]:Include=2")]
+    [InlineData("Include", ":Include=4")]
+    [InlineData("Query", ":Queries=[slug=/,id=1234,toinclude=[value1,value2]]:Include=2")]
+    [InlineData("Combined", ":Select=[field.intros,field.sys]:Queries=[slug=/test]:Include=6")]
+    public void Should_Serialise_Options_Into_Suitable_Redis_Format(string testDataKey, string expectedValue)
+    {
+        var testData = _testData[testDataKey];
+        var serialized = testData.SerializeToRedisFormat();
+        Assert.Equal(expectedValue, serialized);
     }
 
 }

--- a/tests/Dfe.PlanTech.Application.UnitTests/Questionnaire/Queries/GetSectionQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Questionnaire/Queries/GetSectionQueryTests.cs
@@ -1,4 +1,3 @@
-using Dfe.PlanTech.Application.Caching.Interfaces;
 using Dfe.PlanTech.Application.Exceptions;
 using Dfe.PlanTech.Application.Persistence.Interfaces;
 using Dfe.PlanTech.Application.Persistence.Models;

--- a/tests/Dfe.PlanTech.Application.UnitTests/Questionnaire/Queries/GetSectionQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Questionnaire/Queries/GetSectionQueryTests.cs
@@ -75,17 +75,6 @@ public class GetSectionQueryTests
     };
 
     private readonly Section[] _sections = new[] { FirstSection, SecondSection, ThirdSection };
-    private readonly ICmsCache _cache = Substitute.For<ICmsCache>();
-
-    public GetSectionQueryTests()
-    {
-        _cache.GetOrCreateAsync(Arg.Any<string>(), Arg.Any<Func<Task<IEnumerable<Section>?>>>())
-            .Returns(callInfo =>
-            {
-                var func = callInfo.ArgAt<Func<Task<IEnumerable<Section>?>>>(1);
-                return func();
-            });
-    }
 
     [Fact]
     public async Task GetSectionBySlug_Returns_Section_From_Repository()
@@ -108,7 +97,7 @@ public class GetSectionQueryTests
             return _sections.Where(section => section.InterstitialPage?.Slug == slugQuery.Value);
         });
 
-        var getSectionQuery = new GetSectionQuery(repository, _cache);
+        var getSectionQuery = new GetSectionQuery(repository);
         await getSectionQuery.GetSectionBySlug(sectionSlug, cancellationToken);
 
         Assert.Equal(FirstSection.InterstitialPage.Slug, sectionSlug);
@@ -129,7 +118,7 @@ public class GetSectionQueryTests
             .When(repo => repo.GetEntities<Section>(Arg.Any<GetEntitiesOptions>(), cancellationToken))
             .Throw(new Exception("Dummy Exception"));
 
-        var getSectionQuery = new GetSectionQuery(repository, _cache);
+        var getSectionQuery = new GetSectionQuery(repository);
 
         await Assert.ThrowsAsync<ContentfulDataUnavailableException>(
             async () => await getSectionQuery.GetSectionBySlug(sectionSlug, cancellationToken)
@@ -144,7 +133,7 @@ public class GetSectionQueryTests
             .When(repo => repo.GetEntities<Section>(Arg.Any<GetEntitiesOptions>(), Arg.Any<CancellationToken>()))
             .Throw(new Exception("Dummy Exception"));
 
-        var getSectionQuery = new GetSectionQuery(repository, _cache);
+        var getSectionQuery = new GetSectionQuery(repository);
 
         await Assert.ThrowsAsync<ContentfulDataUnavailableException>(
             async () => await getSectionQuery.GetAllSections(CancellationToken.None)
@@ -158,7 +147,7 @@ public class GetSectionQueryTests
         repository.GetEntities<Section>(Arg.Any<GetEntitiesOptions>(), Arg.Any<CancellationToken>())
             .Returns(_ => _sections);
 
-        var getSectionQuery = new GetSectionQuery(repository, _cache);
+        var getSectionQuery = new GetSectionQuery(repository);
         var sections = (await getSectionQuery.GetAllSections()).ToList();
         Assert.Equal(_sections.Length, sections.Count);
 

--- a/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Persistence/CachedContentfulRepositoryTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Persistence/CachedContentfulRepositoryTests.cs
@@ -1,0 +1,83 @@
+using Dfe.PlanTech.Application.Caching.Interfaces;
+using Dfe.PlanTech.Application.Persistence.Interfaces;
+using Dfe.PlanTech.Application.Persistence.Models;
+using Dfe.PlanTech.Domain.Questionnaire.Models;
+using Dfe.PlanTech.Infrastructure.Application.Models;
+using Dfe.PlanTech.Infrastructure.Contentful.Persistence;
+using NSubstitute;
+
+namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
+{
+    public class CachedContentfulRepositoryTests
+    {
+        private readonly IContentRepository _contentRepository = Substitute.For<IContentRepository>();
+        private readonly ICmsCache _cache = Substitute.For<ICmsCache>();
+        private readonly IContentRepository _cachedContentRepository;
+
+        public CachedContentfulRepositoryTests()
+        {
+            _cachedContentRepository = new CachedContentfulRepository(_contentRepository, _cache);
+            _cache.GetOrCreateAsync(Arg.Any<string>(), Arg.Any<Func<Task<Question?>>>())
+                .Returns(callInfo =>
+                {
+                    var func = callInfo.ArgAt<Func<Task<Question?>>>(1);
+                    return func();
+                });
+            _cache.GetOrCreateAsync(Arg.Any<string>(), Arg.Any<Func<Task<IEnumerable<Question>?>>>())
+                .Returns(callInfo =>
+                {
+                    var func = callInfo.ArgAt<Func<Task<IEnumerable<Question>?>>>(1);
+                    return func();
+                });
+            _contentRepository
+                .GetEntityByIdOptions(Arg.Any<string>(), Arg.Any<int>())
+                .Returns(callinfo =>
+                {
+                    var id = callinfo.ArgAt<string>(0);
+                    var include = callinfo.ArgAt<int>(1);
+                    return new GetEntitiesOptions(include, [
+                        new ContentQueryEquals()
+                        {
+                            Field = "sys.id",
+                            Value = id
+                        }
+                    ]);
+                });
+        }
+
+        [Fact]
+        public async Task Should_Cache_GetEntities_Without_Options()
+        {
+            await _cachedContentRepository.GetEntities<Question>();
+            await _cache.Received(1).GetOrCreateAsync(Arg.Any<string>(), Arg.Any<Func<Task<IEnumerable<Question>>>>());
+            await _contentRepository.Received(1).GetEntities<Question>();
+        }
+
+        [Fact]
+        public async Task Should_Cache_GetEntities_With_Options()
+        {
+            var options = new GetEntitiesOptions(include: 3);
+            await _cachedContentRepository.GetEntities<Question>(options);
+            await _cache.Received(1).GetOrCreateAsync(Arg.Any<string>(), Arg.Any<Func<Task<IEnumerable<Question>>>>());
+            await _contentRepository.Received(1).GetEntities<Question>(options);
+        }
+
+        [Fact]
+        public async Task Should_Cache_GetEntityById()
+        {
+            var id = "test-id";
+            await _cachedContentRepository.GetEntityById<Question>(id);
+            await _cache.Received(1).GetOrCreateAsync(Arg.Any<string>(), Arg.Any<Func<Task<IEnumerable<Question>>>>());
+            await _contentRepository.Received(1).GetEntities<Question>(
+                Arg.Is<GetEntitiesOptions>(arg => ValidateGetEntitiesOptions(arg, id)));
+        }
+
+        private static bool ValidateGetEntitiesOptions(GetEntitiesOptions arg, string id)
+        {
+            var first = arg.Queries?.FirstOrDefault();
+            return first is ContentQueryEquals queryEquals &&
+                   queryEquals.Field == "sys.id" &&
+                   queryEquals.Value == id;
+        }
+    }
+}

--- a/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Persistence/ContentfulRepositoryTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Persistence/ContentfulRepositoryTests.cs
@@ -2,7 +2,6 @@ using System.Web;
 using Contentful.Core;
 using Contentful.Core.Models;
 using Contentful.Core.Search;
-using Dfe.PlanTech.Application.Caching.Interfaces;
 using Dfe.PlanTech.Infrastructure.Contentful.Helpers;
 using Dfe.PlanTech.Infrastructure.Contentful.Persistence;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -13,7 +12,6 @@ namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
     public class ContentfulRepositoryTests
     {
         private readonly IContentfulClient _clientSubstitute = Substitute.For<IContentfulClient>();
-        private readonly ICmsCache _cacheSubstitute = Substitute.For<ICmsCache>();
         private readonly List<TestClass> _substituteData = new()
         {
             new TestClass(),
@@ -58,26 +56,12 @@ namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
                     var matching = _substituteData.FirstOrDefault(test => test.Id == id);
                     return Task.FromResult(matching == null ? new ContentfulResult<TestClass>() : new ContentfulResult<TestClass>("etag", matching));
                 });
-
-            _cacheSubstitute.GetOrCreateAsync(Arg.Any<string>(), Arg.Any<Func<Task<TestClass?>>>())
-                .Returns(callInfo =>
-                {
-                    var func = callInfo.ArgAt<Func<Task<TestClass?>>>(1);
-                    return func();
-                });
-
-            _cacheSubstitute.GetOrCreateAsync(Arg.Any<string>(), Arg.Any<Func<Task<IEnumerable<TestClass>?>>>())
-                .Returns(callInfo =>
-                {
-                    var func = callInfo.ArgAt<Func<Task<IEnumerable<TestClass>?>>>(1);
-                    return func();
-                });
         }
 
         [Fact]
         public async Task Should_Call_Client_Method_When_Using_GetEntities()
         {
-            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute, _cacheSubstitute);
+            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute);
             var result = await repository.GetEntities<TestClass>();
             Assert.NotNull(result);
         }
@@ -85,7 +69,7 @@ namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
         [Fact]
         public async Task Should_CallClientMethod_When_Using_GetEntityById()
         {
-            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute, _cacheSubstitute);
+            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute);
             var result = await repository.GetEntityById<TestClass>("testId");
             Assert.NotNull(result);
         }
@@ -93,7 +77,7 @@ namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
         [Fact]
         public async Task GetEntities_Should_ReturnItems_When_ClassMatches()
         {
-            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute, _cacheSubstitute);
+            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute);
             var result = await repository.GetEntities<TestClass>();
             Assert.NotNull(result);
             Assert.Equal(_substituteData, result);
@@ -102,7 +86,7 @@ namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
         [Fact]
         public async Task GetEntities_Should_ReturnEmptyIEnumerable_When_NoDataFound()
         {
-            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute, _cacheSubstitute);
+            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute);
             var result = await repository.GetEntities<OtherTestClass>();
             Assert.NotNull(result);
             Assert.Empty(result);
@@ -112,7 +96,7 @@ namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
         public async Task GetEntityById_Should_FindMatchingItem_When_IdMatches()
         {
             var testId = "testId";
-            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute, _cacheSubstitute);
+            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute);
             var result = await repository.GetEntityById<TestClass>(testId);
             Assert.NotNull(result);
             Assert.Equal(result.Id, testId);
@@ -121,21 +105,21 @@ namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
         [Fact]
         public async Task GetEntityById_Should_ThrowException_When_IdIsNull()
         {
-            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute, _cacheSubstitute);
+            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute);
             await Assert.ThrowsAsync<ArgumentNullException>(() => repository.GetEntityById<TestClass>(null));
         }
 
         [Fact]
         public async Task GetEntityById_Should_ThrowException_When_IdIsEmpty()
         {
-            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute, _cacheSubstitute);
+            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute);
             await Assert.ThrowsAsync<ArgumentNullException>(() => repository.GetEntityById<TestClass>(""));
         }
 
         [Fact]
         public async Task Should_ReturnNull_When_IdNotFound()
         {
-            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute, _cacheSubstitute);
+            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute);
             var result = await repository.GetEntityById<TestClass>("not a real id");
             Assert.Null(result);
         }
@@ -144,7 +128,7 @@ namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
         public async Task GetEntityById_Should_Throw_GetEntitiesIDException_When_DuplicateIds()
         {
             var testId = "duplicateId";
-            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute, _cacheSubstitute);
+            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute);
             await Assert.ThrowsAsync<GetEntitiesException>(() => repository.GetEntityById<TestClass>(testId));
         }
 
@@ -152,7 +136,7 @@ namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
         public async Task GetEntityById_Should_Throw_GetEntitiesIDException_With_Correct_Exception_Message_When_DuplicateIds()
         {
             var testId = "duplicateId";
-            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute, _cacheSubstitute);
+            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute);
             var exception = await Assert.ThrowsAsync<GetEntitiesException>(() => repository.GetEntityById<TestClass>(testId));
             Assert.Equal("Found more than 1 entity with id duplicateId", exception.Message);
         }

--- a/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Persistence/ContentfulRepositoryTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Contentful.UnitTests/Persistence/ContentfulRepositoryTests.cs
@@ -2,6 +2,7 @@ using System.Web;
 using Contentful.Core;
 using Contentful.Core.Models;
 using Contentful.Core.Search;
+using Dfe.PlanTech.Application.Caching.Interfaces;
 using Dfe.PlanTech.Infrastructure.Contentful.Helpers;
 using Dfe.PlanTech.Infrastructure.Contentful.Persistence;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -12,6 +13,7 @@ namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
     public class ContentfulRepositoryTests
     {
         private readonly IContentfulClient _clientSubstitute = Substitute.For<IContentfulClient>();
+        private readonly ICmsCache _cacheSubstitute = Substitute.For<ICmsCache>();
         private readonly List<TestClass> _substituteData = new()
         {
             new TestClass(),
@@ -56,12 +58,26 @@ namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
                     var matching = _substituteData.FirstOrDefault(test => test.Id == id);
                     return Task.FromResult(matching == null ? new ContentfulResult<TestClass>() : new ContentfulResult<TestClass>("etag", matching));
                 });
+
+            _cacheSubstitute.GetOrCreateAsync(Arg.Any<string>(), Arg.Any<Func<Task<TestClass?>>>())
+                .Returns(callInfo =>
+                {
+                    var func = callInfo.ArgAt<Func<Task<TestClass?>>>(1);
+                    return func();
+                });
+
+            _cacheSubstitute.GetOrCreateAsync(Arg.Any<string>(), Arg.Any<Func<Task<IEnumerable<TestClass>?>>>())
+                .Returns(callInfo =>
+                {
+                    var func = callInfo.ArgAt<Func<Task<IEnumerable<TestClass>?>>>(1);
+                    return func();
+                });
         }
 
         [Fact]
         public async Task Should_Call_Client_Method_When_Using_GetEntities()
         {
-            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute);
+            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute, _cacheSubstitute);
             var result = await repository.GetEntities<TestClass>();
             Assert.NotNull(result);
         }
@@ -69,7 +85,7 @@ namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
         [Fact]
         public async Task Should_CallClientMethod_When_Using_GetEntityById()
         {
-            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute);
+            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute, _cacheSubstitute);
             var result = await repository.GetEntityById<TestClass>("testId");
             Assert.NotNull(result);
         }
@@ -77,7 +93,7 @@ namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
         [Fact]
         public async Task GetEntities_Should_ReturnItems_When_ClassMatches()
         {
-            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute);
+            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute, _cacheSubstitute);
             var result = await repository.GetEntities<TestClass>();
             Assert.NotNull(result);
             Assert.Equal(_substituteData, result);
@@ -86,7 +102,7 @@ namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
         [Fact]
         public async Task GetEntities_Should_ReturnEmptyIEnumerable_When_NoDataFound()
         {
-            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute);
+            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute, _cacheSubstitute);
             var result = await repository.GetEntities<OtherTestClass>();
             Assert.NotNull(result);
             Assert.Empty(result);
@@ -96,7 +112,7 @@ namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
         public async Task GetEntityById_Should_FindMatchingItem_When_IdMatches()
         {
             var testId = "testId";
-            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute);
+            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute, _cacheSubstitute);
             var result = await repository.GetEntityById<TestClass>(testId);
             Assert.NotNull(result);
             Assert.Equal(result.Id, testId);
@@ -105,21 +121,21 @@ namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
         [Fact]
         public async Task GetEntityById_Should_ThrowException_When_IdIsNull()
         {
-            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute);
+            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute, _cacheSubstitute);
             await Assert.ThrowsAsync<ArgumentNullException>(() => repository.GetEntityById<TestClass>(null));
         }
 
         [Fact]
         public async Task GetEntityById_Should_ThrowException_When_IdIsEmpty()
         {
-            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute);
+            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute, _cacheSubstitute);
             await Assert.ThrowsAsync<ArgumentNullException>(() => repository.GetEntityById<TestClass>(""));
         }
 
         [Fact]
         public async Task Should_ReturnNull_When_IdNotFound()
         {
-            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute);
+            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute, _cacheSubstitute);
             var result = await repository.GetEntityById<TestClass>("not a real id");
             Assert.Null(result);
         }
@@ -128,7 +144,7 @@ namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
         public async Task GetEntityById_Should_Throw_GetEntitiesIDException_When_DuplicateIds()
         {
             var testId = "duplicateId";
-            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute);
+            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute, _cacheSubstitute);
             await Assert.ThrowsAsync<GetEntitiesException>(() => repository.GetEntityById<TestClass>(testId));
         }
 
@@ -136,7 +152,7 @@ namespace Dfe.PlanTech.Infrastructure.Contentful.UnitTests.Persistence
         public async Task GetEntityById_Should_Throw_GetEntitiesIDException_With_Correct_Exception_Message_When_DuplicateIds()
         {
             var testId = "duplicateId";
-            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute);
+            var repository = new ContentfulRepository(new NullLoggerFactory(), _clientSubstitute, _cacheSubstitute);
             var exception = await Assert.ThrowsAsync<GetEntitiesException>(() => repository.GetEntityById<TestClass>(testId));
             Assert.Equal("Found more than 1 entity with id duplicateId", exception.Message);
         }

--- a/tests/Dfe.PlanTech.Infrastructure.Redis.UnitTests/RedisCacheTestHelpers.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Redis.UnitTests/RedisCacheTestHelpers.cs
@@ -28,4 +28,5 @@ public static class RedisCacheTestHelpers
     public static Answer FirstAnswer => _firstAnswer;
     public static Answer SecondAnswer => _secondAnswer;
     public static Question Question => _question;
+    public static List<Question> EmptyQuestionCollection => [];
 }

--- a/tests/Dfe.PlanTech.Infrastructure.Redis.UnitTests/RedisCacheTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Redis.UnitTests/RedisCacheTests.cs
@@ -186,7 +186,7 @@ public class RedisCacheTests : RedisCacheTestsBase
         var dependencies = keys.Select(dep => new RedisValue(dep)).ToArray();
 
         Database.SetMembersAsync(firstAnswerKey, Arg.Any<CommandFlags>()).Returns(dependencies);
-        await _cache.InvalidateCacheAsync(RedisCacheTestHelpers.FirstAnswer.Sys.Id, "Answer");
+        await _cache.InvalidateCacheAsync(RedisCacheTestHelpers.FirstAnswer.Sys.Id, "answer");
 
         Assert.NotNull(QueuedFunc);
 

--- a/tests/Dfe.PlanTech.Infrastructure.Redis.UnitTests/RedisCacheTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Redis.UnitTests/RedisCacheTests.cs
@@ -23,6 +23,11 @@ public class RedisCacheTests : RedisCacheTestsBase
         );
 
         _connectionManager.GetDatabaseAsync(Arg.Any<int>()).Returns(Database);
+        _dependencyManager.GetDependencyKey(Arg.Any<string>()).Returns(callinfo =>
+        {
+            var arg = callinfo.ArgAt<string>(0);
+            return $"Dependency:{arg}";
+        });
     }
 
     [Fact]

--- a/tests/Dfe.PlanTech.Infrastructure.Redis.UnitTests/RedisCacheTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Redis.UnitTests/RedisCacheTests.cs
@@ -186,7 +186,7 @@ public class RedisCacheTests : RedisCacheTestsBase
         var dependencies = keys.Select(dep => new RedisValue(dep)).ToArray();
 
         Database.SetMembersAsync(firstAnswerKey, Arg.Any<CommandFlags>()).Returns(dependencies);
-        await _cache.InvalidateCacheAsync(RedisCacheTestHelpers.FirstAnswer.Sys.Id);
+        await _cache.InvalidateCacheAsync(RedisCacheTestHelpers.FirstAnswer.Sys.Id, "Answer");
 
         Assert.NotNull(QueuedFunc);
 

--- a/tests/Dfe.PlanTech.Infrastructure.Redis.UnitTests/RedisCacheTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Redis.UnitTests/RedisCacheTests.cs
@@ -12,6 +12,7 @@ public class RedisCacheTests : RedisCacheTestsBase
     private readonly IRedisConnectionManager _connectionManager = Substitute.For<IRedisConnectionManager>();
     private readonly IRedisDependencyManager _dependencyManager = Substitute.For<IRedisDependencyManager>();
     private readonly RedisCache _cache;
+    private readonly string _missingKey = "Missing";
 
     public RedisCacheTests()
     {
@@ -23,6 +24,7 @@ public class RedisCacheTests : RedisCacheTestsBase
         );
 
         _connectionManager.GetDatabaseAsync(Arg.Any<int>()).Returns(Database);
+        _dependencyManager.EmptyCollectionDependencyKey.Returns(_missingKey);
         _dependencyManager.GetDependencyKey(Arg.Any<string>()).Returns(callinfo =>
         {
             var arg = callinfo.ArgAt<string>(0);
@@ -188,9 +190,12 @@ public class RedisCacheTests : RedisCacheTestsBase
     {
         var firstAnswerKey = _dependencyManager.GetDependencyKey(RedisCacheTestHelpers.FirstAnswer.Sys.Id);
         var keys = new List<string> { "one", "two", "three" };
+        var missingKeys = new List<string> { "four" };
         var dependencies = keys.Select(dep => new RedisValue(dep)).ToArray();
+        var missingDependencies = missingKeys.Select(dep => new RedisValue(dep)).ToArray();
 
         Database.SetMembersAsync(firstAnswerKey, Arg.Any<CommandFlags>()).Returns(dependencies);
+        Database.SetMembersAsync(_missingKey, Arg.Any<CommandFlags>()).Returns(missingDependencies);
         await _cache.InvalidateCacheAsync(RedisCacheTestHelpers.FirstAnswer.Sys.Id, "answer");
 
         Assert.NotNull(QueuedFunc);
@@ -199,6 +204,15 @@ public class RedisCacheTests : RedisCacheTestsBase
         await Database.Received(1).SetRemoveAsync(
             firstAnswerKey,
             Arg.Is<RedisValue[]>(arg => dependencies.All(dep => arg.Contains(dep))),
+            Arg.Any<CommandFlags>());
+
+        await Database.Received(1).SetRemoveAsync(
+            _missingKey,
+            Arg.Is<RedisValue[]>(arg => missingDependencies.All(dep => arg.Contains(dep))),
+            Arg.Any<CommandFlags>());
+
+        await Database.Received(1).KeyDeleteAsync(
+            "answers",
             Arg.Any<CommandFlags>());
     }
 }

--- a/tests/Dfe.PlanTech.Infrastructure.Redis.UnitTests/RedisDependencyManagerTests.cs
+++ b/tests/Dfe.PlanTech.Infrastructure.Redis.UnitTests/RedisDependencyManagerTests.cs
@@ -31,6 +31,21 @@ public class RedisDependencyManagerTests : RedisCacheTestsBase
     }
 
     [Fact]
+    public async Task RegisterDependencyAsync_StoresEmptyCollectionsUnderMissing()
+    {
+        var batch = Substitute.For<IBatch>();
+        Database.CreateBatch().Returns(batch);
+
+        await _dependencyManager.RegisterDependenciesAsync(Database, Key, RedisCacheTestHelpers.EmptyQuestionCollection);
+
+        Assert.NotNull(QueuedFunc);
+
+        await QueuedFunc(default);
+
+        await batch.Received(1).SetAddAsync(_dependencyManager.EmptyCollectionDependencyKey, Key, CommandFlags.FireAndForget);
+    }
+
+    [Fact]
     public void GetDependencies_ThrowsException_When_Value_NotIContentComponent()
     {
         var testValue = "this should throw an exception";


### PR DESCRIPTION
## Overview

Addresses ticket [#237738](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/237738)

This changes redis caching from being done by the application layer, to being done on the repository instead. This way it lives in just two places and covers all contentful calls.

It also fixes two bugs in dependency management

## Changes

### Major
- All cache methods moved into the Contentful repository class and removed from elsewhere
- Updates deployment pipeline to clear the cache upon release (see historic flush redis cache workflow in actions history as tests that this works)

### Minor
- For whole content collections, the key is always `<contentType>s`
- For content queried with options, the key is `<contentType>_<serialisedOptions>`
- Amends existing dependency management to check whether there are no dependencies:
  - If so, store a dependency of `Missing` -> key 
- Upon cache invalidation for a particular id
  - Anything under `Dependency:<componentId>` is removed as usual
  - Everything under `Missing` is removed
  - This removes more than is strictly required, but storing empty content should be in the minority, and removing any empty content from the cache is less complex and more failsafe than trying to do pattern matching on the keys (though shout if you have another idea)
  
## How to review the PR

Review the implementation and whether it will cover the edge cases we're currently aware of

### Cases to test
**Note: Make sure your locally running instance of plan tech is recieving the webhook messages for cache invalidation, best to put a breakpoint on it, keep editing it in contentful after trivial changes to ensure your local instance picks up the message**

#### Fixes collections not being invalidated
1. Go to self assessment page and verify navigationLinks has appeared in the cache
2. Create a new navigation link
3. Verify that the navigationLinks cache key has been invalidated

#### Fixes not found pages stuck in the cache due to no dependencies
1. Try to navigate to a page that does not exist (e.g. /fake-page
2. verify that page is in the cache (something like page_{"fields":"slug":"fake-page"}....)
3. Now create fake-page in contentful
4. Verify that the fake-page in the cache is removed

## Release requirements

The cache will need fully clearing as this changes all the keys.

## Checklist

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [x] Unit tests have been added/updated
- [x] GitHub workflows/actions have been added/updated
- [ ] Documentation has been updated where relevant
