### PR TITLE
fix: Add environment to inputs on qa visualiser workflow

### DIFF
--- a/.github/workflows/matrix-deploy.yml
+++ b/.github/workflows/matrix-deploy.yml
@@ -113,7 +113,7 @@ jobs:
         target: [Staging]
     uses: ./.github/workflows/qa-viz.yml
     with:
-      usepreview: ${{ matrix.target == 'Staging' }}
+      environment: ${{ matrix.target }}
     secrets: inherit
 
   plan-terraform-for-staging:

--- a/.github/workflows/qa-viz.yml
+++ b/.github/workflows/qa-viz.yml
@@ -4,14 +4,15 @@ name: QA Visualisation Workflow
 on:
   workflow_dispatch:
     inputs:
-      usepreview:
-        description: Include preview content
+      environment:
+        description: Which environment to run the QA visualiser on
         required: true
-        type: boolean
-        default: true
+        type: choice
+        options: ['Dev', 'Tst', 'Staging', 'Production']
+        default: 'Staging'
   workflow_call:
     inputs:
-      usepreview:
+      environment:
         type: string
         required: true
 
@@ -21,6 +22,8 @@ env:
 jobs:
   generate_images:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    name: Generate visualisations for ${{ inputs.environment }}
     env:
       az_keyvault_name: ${{ secrets.AZ_ENVIRONMENT }}${{ secrets.DFE_PROJECT_NAME }}-kv
       az_resource_group_name: ${{ secrets.AZ_ENVIRONMENT }}${{ secrets.DFE_PROJECT_NAME }}
@@ -64,7 +67,6 @@ jobs:
         shell: bash
         working-directory: ./build
         run: |
-          export Contentful__UsePreviewApi=${{ inputs.usepreview }}
           export ASPNETCORE_ENVIRONMENT=E2E
           export KeyVaultName=${{ env.az_keyvault_name }}
           export Kestrel__Endpoints__Https__Url=https://*:8081


### PR DESCRIPTION
## Overview

Changes the inputs of the qa workflow from a use preview option to an environment option, previously it wasn't using the staging vars so is outputting dev content, this should fix that.
