### PR TITLE
feat: Add option to disable Service Bus processing

### DIFF
--- a/src/Dfe.PlanTech.Domain/ServiceBus/Models/ServiceBusOptions.cs
+++ b/src/Dfe.PlanTech.Domain/ServiceBus/Models/ServiceBusOptions.cs
@@ -2,5 +2,8 @@ namespace Dfe.PlanTech.Domain.ServiceBus.Models;
 
 public record ServiceBusOptions
 {
-    public int MessagesPerBatch { get; init; } = 10;
+    /// <summary>
+    /// Enables reading + processing of messages from the Service Bus
+    /// </summary>
+    public bool EnableQueueReading { get; init; } = true;
 }

--- a/src/Dfe.PlanTech.Infrastructure.ServiceBus/ContentfulServiceBusProcessor.cs
+++ b/src/Dfe.PlanTech.Infrastructure.ServiceBus/ContentfulServiceBusProcessor.cs
@@ -2,11 +2,13 @@ using System.Text;
 using Azure.Messaging.ServiceBus;
 using Dfe.PlanTech.Application.Persistence.Commands;
 using Dfe.PlanTech.Domain.Persistence.Interfaces;
+using Dfe.PlanTech.Domain.ServiceBus.Models;
 using Dfe.PlanTech.Infrastructure.ServiceBus.Results;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Dfe.PlanTech.Infrastructure.ServiceBus;
 
@@ -20,7 +22,8 @@ namespace Dfe.PlanTech.Infrastructure.ServiceBus;
 public class ContentfulServiceBusProcessor(IAzureClientFactory<ServiceBusProcessor> processorFactory,
                                            IServiceBusResultProcessor resultProcessor,
                                            ILogger<ContentfulServiceBusProcessor> logger,
-                                           IServiceScopeFactory serviceScopeFactory) : BackgroundService
+                                           IServiceScopeFactory serviceScopeFactory,
+                                           IOptions<ServiceBusOptions> options) : BackgroundService
 {
     private readonly ServiceBusProcessor _processor = processorFactory.CreateClient("contentfulprocessor");
 
@@ -29,12 +32,17 @@ public class ContentfulServiceBusProcessor(IAzureClientFactory<ServiceBusProcess
     /// </summary>
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        if (!options.Value.EnableQueueReading)
+        {
+            logger.LogInformation("{QueueReadingProperty} is set to disabling - not enabling processing queue reading", nameof(options.Value.EnableQueueReading));
+            return;
+        }
         _processor.ProcessMessageAsync += MessageHandler;
         _processor.ProcessErrorAsync += ErrorHandler;
 
         await _processor.StartProcessingAsync(stoppingToken);
 
-        stoppingToken.Register(async () => await StopProcessingAsync());
+        stoppingToken.Register(() =>  StopProcessingAsync().GetAwaiter().GetResult());
     }
 
     /// <summary>

--- a/src/Dfe.PlanTech.Infrastructure.ServiceBus/ContentfulServiceBusProcessor.cs
+++ b/src/Dfe.PlanTech.Infrastructure.ServiceBus/ContentfulServiceBusProcessor.cs
@@ -42,7 +42,7 @@ public class ContentfulServiceBusProcessor(IAzureClientFactory<ServiceBusProcess
 
         await _processor.StartProcessingAsync(stoppingToken);
 
-        stoppingToken.Register(() =>  StopProcessingAsync().GetAwaiter().GetResult());
+        stoppingToken.Register(() => StopProcessingAsync().GetAwaiter().GetResult());
     }
 
     /// <summary>

--- a/src/Dfe.PlanTech.Infrastructure.ServiceBus/DependencyInjection.cs
+++ b/src/Dfe.PlanTech.Infrastructure.ServiceBus/DependencyInjection.cs
@@ -58,7 +58,7 @@ public static class DependencyInjection
         services.AddTransient<IQueueWriter, QueueWriter>();
         services.AddTransient<IWriteCmsWebhookToQueueCommand, WriteCmsWebhookToQueueCommand>();
 
-        services.AddSingleton(new ServiceBusOptions() { MessagesPerBatch = 10 });
+        services.Configure<ServiceBusOptions>(configuration.GetSection(nameof(ServiceBusOptions)));
         return services;
     }
 

--- a/src/Dfe.PlanTech.Web/appsettings.Development.json
+++ b/src/Dfe.PlanTech.Web/appsettings.Development.json
@@ -18,5 +18,8 @@
     "GTM": {
         "Id": "GTM-MFLR9ZK",
         "SiteVerificationId": "rhK9PD6EMeai5M5a3qySWTZTxwZxyzUjU2fifZ_ezjs"
+    },
+    "ServiceBusOptions": {
+        "EnableQueueReading": true
     }
 }


### PR DESCRIPTION
## Overview

Adds option to disable the Service Bus processing on the web app; this should allow us to test various things easier (e.g. caching) by disabling the job on dev.

## Changes

### Minor

- Adds configuration to disable Service Bus reading + processing for Contentful content changes

## How to review the PR

Run the app from this branch and ensure that the Service Bus processing still happens like normal (check console).

Then set ServiceBusOptions:EnableQueueReading to false in `appsettings.Development.json` and restart app. Validate that it no longer reads + processes the queue.

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [x] Unit tests have been added/updated