### PR TITLE
Fix: Increase json max depth

### DIFF
--- a/src/Dfe.PlanTech.Infrastructure.Redis/JsonSerialiser.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Redis/JsonSerialiser.cs
@@ -22,7 +22,8 @@ public static class JsonSerialiser
             new DefaultJsonTypeInfoResolver().WithAddedModifier(ContentComponentJsonExtensions.AddContentComponentPolymorphicInfo<IContentComponent>)
             .WithAddedModifier(ContentComponentJsonExtensions.AddContentComponentPolymorphicInfo<ContentComponent>)
             .WithAddedModifier(ContentComponentJsonExtensions.AddContentComponentPolymorphicInfo<ContentBase>),
-        ReferenceHandler = ReferenceHandler.Preserve
+        ReferenceHandler = ReferenceHandler.Preserve,
+        MaxDepth = 256
     };
 
     /// <summary>

--- a/src/Dfe.PlanTech.Web/appsettings.Staging.json
+++ b/src/Dfe.PlanTech.Web/appsettings.Staging.json
@@ -4,6 +4,7 @@
         "SiteVerificationId": ""
     },
     "Contentful": {
-        "UsePreview": true
+        "UsePreview": true,
+        "UsePreviewApi": true
     }
 }


### PR DESCRIPTION
## Overview

Addresses ticket [#245053](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/245053)

Fix from Jim discussed in the call yesterday

## Changes

- Increase JSON max depth
- Also set `UsePreviewApi` to true, as this broke last time we released to staging

## How to review the PR
- Change your .NET secrets to use staging and production contentful instead of dev
- Use local redis
- Clear your redis cache
- Run PT locally on dev branch
- See self-assessment page is dead
- Checkout this branch
- Clear redis cache locally
- See self-assessment page is revived

## Checklist

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
