### PR TITLE
refactor(redis): Only cache unique dependencies in Redis cache

### DIFF
--- a/src/Dfe.PlanTech.Infrastructure.Redis/RedisDependencyManager.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Redis/RedisDependencyManager.cs
@@ -27,12 +27,16 @@ public class RedisDependencyManager(IBackgroundTaskQueue backgroundTaskQueue) : 
     private async Task GetAndSetDependencies<T>(IDatabase database, string key, T value)
     {
         var batch = database.CreateBatch();
-        var tasks = GetDependencies(value).Select(dependency => batch.SetAddAsync(GetDependencyKey(dependency), key, CommandFlags.FireAndForget)).ToArray();
+        var tasks = GetDependencies(value).Distinct()
+                                                     .Select(dependency => batch.SetAddAsync(GetDependencyKey(dependency), key, CommandFlags.FireAndForget))
+                                                     .ToArray();
+
         if (tasks.Length == 0)
         {
             // If the value has no dependencies (is empty) it should be invalidated when new content comes in
             tasks = tasks.Append(batch.SetAddAsync(EmptyCollectionDependencyKey, key, CommandFlags.FireAndForget)).ToArray();
         }
+
         batch.Execute();
         await Task.WhenAll(tasks);
     }


### PR DESCRIPTION
## Overview

Improves management of Contentful references in Redis cache by only caching _distinct_/_unique_ dependencies, not all that are found. 

This is not necessarily an improvement on a lot of requests - the majority won't be impacted - but it can bring huge gains in certain places. 

For example, this results in "only" 361 dependencies being cached for the self-assessment page, instead of 1,117,592.

Benchmarks for self-assessment page:

Non-distinct references (i.e. current code):
```
Took 00:00:03.3419284ms to run
Took 00:00:03.1357516ms to run
Took 00:00:02.9805817ms to run
Took 00:00:02.8001258ms to run
Took 00:00:02.8983749ms to run
Took 00:00:02.9443596ms to run
Took 00:00:02.7144764ms to run
Took 00:00:02.7460535ms to run
Took 00:00:02.7035062ms to run
Took 00:00:03.3185940ms to run
Took 2958.3752099999997ms on average for non-distinct dependencies
```

Distinct references (this version):
```
Took 00:00:00.9671270ms to run
Took 00:00:00.9763498ms to run
Took 00:00:00.9661385ms to run
Took 00:00:00.9733045ms to run
Took 00:00:00.9702717ms to run
Took 00:00:00.9518550ms to run
Took 00:00:00.9591098ms to run
Took 00:00:00.9574165ms to run
Took 00:00:00.9560910ms to run
Took 00:00:00.9643383ms to run
Took 964.20021ms on average for distinct depende
```

## Changes

### Minor

- Get only _distinct_/_unique_ references when caching Contentful dependencies

## How to review the PR

Run the web app, clear cache, load self-assessment page; see improvements in speed.

I do have a benchmarking program specifically for this PR if anyone wants it let me know and I'll post the code.

## Checklist

Delete any rows that do not apply to the PR.

- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch
- [ ] Unit tests have been added/updated