### PR TITLE
fix(contentful): Export processor fixes

### DIFF
--- a/contentful/export-processor/.gitignore
+++ b/contentful/export-processor/.gitignore
@@ -7,3 +7,4 @@ inserted-groups.json
 
 #Env variables
 .env
+.env.*

--- a/contentful/export-processor/content-types/recommendation-section.js
+++ b/contentful/export-processor/content-types/recommendation-section.js
@@ -3,43 +3,64 @@ import RecommendationChunk from "./recommendation-chunk.js";
 import ErrorLogger from "../errors/error-logger.js";
 
 export default class RecommendationSection {
-  answers;
-  chunks;
-  id;
+    /**
+     * @type {Answer[]}
+     */
+    answers;
 
-  constructor({ fields, sys }) {
-    this.id = sys.id;
+    /**
+     * @type {RecommendationChunk[]}
+     */
+    chunks;
 
-    this.answers = fields.answers?.map((answer) => new Answer(answer)) ?? [];
+    /**
+     * @type {string}
+     */
+    id;
 
-    this.chunks = fields.chunks?.map((chunk) => new RecommendationChunk(chunk)) ?? [];
-    this.logErrorIfMissingRelationships("chunks");
-  }
+    /**
+     *
+     * @param {{fields: Record<string, any>, sys: { id: string }}} param0
+     */
+    constructor({ fields, sys }) {
+        this.id = sys.id;
 
-  logErrorIfMissingRelationships(field) {
-    const matching = this[field];
-    if (!matching || matching.length == 0) {
-      ErrorLogger.addError({ id: this.id, contentType: "recommendationSection", message: `No ${field} found` });
+        this.answers =
+            fields.answers?.map((answer) => new Answer(answer)) ?? [];
+
+        this.chunks =
+            fields.chunks?.map((chunk) => new RecommendationChunk(chunk)) ?? [];
+
+        this.logErrorIfMissingRelationships("chunks");
     }
-  }
 
-  getChunksForPath(path) {
-      const answerIds = path.map(pathPart => pathPart.answer.id);
+    logErrorIfMissingRelationships(field) {
+        const matching = this[field];
+        if (!matching || matching.length == 0) {
+            ErrorLogger.addError({
+                id: this.id,
+                contentType: "recommendationSection",
+                message: `No ${field} found`,
+            });
+        }
+    }
 
-      const filteredChunks = this.chunks.filter(chunk =>
-          chunk.answers.some(answer => answerIds.includes(answer.id))
-      );
+    getChunksForPath(path) {
+        const answerIds = path.map((pathPart) => pathPart.answer.id);
 
-      const uniqueChunks = [];
-      const seen = new Set();
+        const filteredChunks = this.chunks.filter((chunk) =>
+            chunk.answers.some((answer) => answerIds.includes(answer.id))
+        );
 
-      for (const chunk of filteredChunks) {
-          const chunkStr = JSON.stringify(chunk);
-          if (!seen.has(chunkStr)) {
-              seen.add(chunkStr);
-              uniqueChunks.push(chunk);
-          }
-      }
-      return uniqueChunks;
-  }
+        const uniqueChunks = [];
+        const seen = new Set();
+
+        for (const chunk of filteredChunks) {
+            if (!seen.has(chunk.id)) {
+                seen.add(chunk.id);
+                uniqueChunks.push(chunk);
+            }
+        }
+        return uniqueChunks;
+    }
 }

--- a/contentful/export-processor/content-types/section.js
+++ b/contentful/export-processor/content-types/section.js
@@ -1,6 +1,7 @@
 import { Question } from "./question.js";
 import { PathCalculator } from "../user-journey/path-calculator.js";
 import { SectionStats } from "#src/user-journey/section-stats";
+import { UserJourney } from "#src/user-journey/user-journey";
 
 /**
  * @typedef {import("./subtopic-recommendation.js").SubtopicRecommendation} SubtopicRecommendation
@@ -13,7 +14,6 @@ import { SectionStats } from "#src/user-journey/section-stats";
 /**
  * @typedef {import("#src/user-journey/user-journey").UserJourneyMinimalOutput} UserJourneyMinimalOutput
  */
-
 
 /**
  * @typedef {import("#src/user-journey/user-journey").UserJourney} UserJourney
@@ -86,10 +86,22 @@ export class Section {
      * @returns {SectionMinimalOutput} Minimal section info
      */
     toMinimalOutput(writeAllPossiblePaths) {
-        return {
+        const recommendationPaths =
+            this.pathInfo.minimumPathsForRecommendations;
+
+        for (const [maturity, path] of Object.entries(recommendationPaths)) {
+            recommendationPaths[maturity] = path.map((part) =>
+                part.toMinimalOutput()
+            );
+        }
+
+        const result = {
             section: this.name,
             allPathsStats: this.stats.pathsPerMaturity,
-            minimumQuestionPaths: this.pathInfo.minimumPathsToNavigateQuestions,
+            minimumQuestionPaths:
+                this.pathInfo.minimumPathsToNavigateQuestions.map((path) =>
+                    path.map((part) => part.toMinimalOutput())
+                ),
             minimumRecommendationPaths:
                 this.pathInfo.minimumPathsForRecommendations,
             pathsForAnswers: this.pathInfo.pathsForAllPossibleAnswers.map(
@@ -99,6 +111,8 @@ export class Section {
                 ? this.pathInfo.paths.map((path) => path.toMinimalOutput())
                 : undefined,
         };
+
+        return result;
     }
 }
 

--- a/contentful/export-processor/data-mapper.js
+++ b/contentful/export-processor/data-mapper.js
@@ -1,6 +1,7 @@
 import ContentType from "./content-types/content-type.js";
 import SubtopicRecommendation from "./content-types/subtopic-recommendation.js";
 import ErrorLogger from "./errors/error-logger.js";
+import { log } from "#src/helpers/log";
 
 /**
  * @typedef {import("./content-types/section.js").Section} Section
@@ -20,7 +21,7 @@ export default class DataMapper {
 
     /**
      * Get the mapped sections
-     * @returns {IterableIterator<Section>} Iterator for mapped sections
+     * @returns {Section[]} Iterator for mapped sections
      */
     get mappedSections() {
         if (!this._alreadyMappedSections)
@@ -130,9 +131,18 @@ export default class DataMapper {
         }
 
         for (const [, subtopicRecommendation] of subtopicRecommendations) {
-            const mapped = new SubtopicRecommendation(subtopicRecommendation);
+            try {
+                const mapped = new SubtopicRecommendation(
+                    subtopicRecommendation
+                );
 
-            yield mapped.subtopic;
+                yield mapped.subtopic;
+            } catch (e) {
+                console.error(
+                    `Error trying to created SubtopicRecommendation: ${e}`,
+                    subtopicRecommendation
+                );
+            }
         }
     }
 

--- a/contentful/export-processor/data-tools.js
+++ b/contentful/export-processor/data-tools.js
@@ -6,32 +6,40 @@ import WriteUserJourneyPaths from "./write-user-journey-paths.js";
 import { options } from "./options.js";
 
 async function processContentfulData(args) {
-  const contentfulData = await ExportContentfulData({ ...args });
+    const contentfulData = await ExportContentfulData({ ...args });
 
-  if (!args.generateTestSuites && !args.exportUserJourneyPaths && !args.exportUserJourneyPaths) {
-    console.log(`No options set for using data - ending run`);
-    return;
-  }
+    if (
+        !args.generateTestSuites &&
+        !args.exportUserJourneyPaths &&
+        !args.exportUserJourneyPaths
+    ) {
+        console.log(`No options set for using data - ending run`);
+        return;
+    }
 
-  if (!contentfulData.entries || !contentfulData.contentTypes) {
-    console.error('Missing entries or content types');
-    return;
-  }
+    if (!contentfulData.entries || !contentfulData.contentTypes) {
+        console.error("Missing entries or content types");
+        return;
+    }
 
-  const dataMapper = new DataMapper(contentfulData);
+    const dataMapper = new DataMapper(contentfulData);
 
-  const outputDir = args.outputDir;
+    const outputDir = args.outputDir;
 
-  if (args.generateTestSuites) {
-    GenerateTestSuites({ dataMapper, outputDir });
-  }
+    if (args.generateTestSuites) {
+        GenerateTestSuites({ dataMapper, outputDir });
+    }
 
-  if (!!args.exportUserJourneyPaths) {
-    WriteUserJourneyPaths({ dataMapper, outputDir, saveAllJourneys: args.saveAllJourneys });
-  }
+    if (args.exportUserJourneyPaths) {
+        WriteUserJourneyPaths({
+            dataMapper,
+            outputDir,
+            saveAllJourneys: args.saveAllJourneys,
+        });
+    }
 
-  ErrorLogger.outputDir = outputDir;
-  ErrorLogger.writeErrorsToFile();
+    ErrorLogger.outputDir = outputDir;
+    ErrorLogger.writeErrorsToFile();
 }
 
 await processContentfulData(options);

--- a/contentful/export-processor/errors/error-logger.js
+++ b/contentful/export-processor/errors/error-logger.js
@@ -2,7 +2,7 @@ import ContentError from "./content-error.js";
 import fs from "fs";
 
 /**
- * @typedef {{id: string, contentType: string, message: string}} Error 
+ * @typedef {{id: string, contentType: string, message: string}} Error
  */
 
 class ErrorLogger {
@@ -10,8 +10,8 @@ class ErrorLogger {
     outputDir = "";
 
     /**
-     * 
-     * @param {Error} error 
+     *
+     * @param {Error} error
      */
     addError({ id, contentType, message }) {
         const error = new ContentError({ id, contentType, message });
@@ -22,6 +22,8 @@ class ErrorLogger {
     }
 
     writeErrorsToFile(filePath = "content-errors.md") {
+        console.log(`Writing errors to file ${filePath}`);
+
         const groupedByContentType = this.groupBy(this.errors, "contentType");
 
         const errors =
@@ -33,12 +35,13 @@ class ErrorLogger {
                 .join("\n\n");
 
         fs.writeFileSync(this.outputDir + filePath, errors);
+        console.log(`Wrote errors to file ${filePath}`);
     }
 
     /**
-     * 
-     * @param {string} contentType 
-     * @param {Error[]} errors 
+     *
+     * @param {string} contentType
+     * @param {Error[]} errors
      * @returns {string} Error messages for a particular content type formatted as string
      */
     errorMessagesForContentType(contentType, errors) {
@@ -73,6 +76,4 @@ const errorLogger = new ErrorLogger();
 
 export default errorLogger;
 
-export {
-    ErrorLogger as ErrorLoggerClass
-}
+export { ErrorLogger as ErrorLoggerClass };

--- a/contentful/export-processor/generate-test-suites.js
+++ b/contentful/export-processor/generate-test-suites.js
@@ -2,29 +2,41 @@ import "dotenv/config";
 import TestSuite from "#src/test-suite/test-suite";
 import writeTestSuites from "./test-suite/write-csvs.js";
 import StaticPageTests from "./test-suite/static-page-tests.js";
+import { log } from "./helpers/log.js";
 
 /**
  * @param {object} args
- * @param {DataMapper} args.dataMapper - created and initialised DataMapper
+ * @param {import("./data-mapper.js").default} args.dataMapper - created and initialised DataMapper
  * @param {string} args.outputDir - directory to write journey paths to
  */
 export default function generateTestSuites({ dataMapper, outputDir }) {
-  let index = 1;
-  const staticPageTests = new StaticPageTests();
+    let index = 1;
+    const staticPageTests = new StaticPageTests();
 
-  const testSuites = Object.values(dataMapper.mappedSections)
-    .filter(section => !!section)
-    .map((section) => {
-      const testSuite = new TestSuite({
-        subtopic: section,
-        testReferenceIndex: index,
-      });
+    log("Generating test suites");
 
-      index = testSuite.testReferenceIndex;
+    const testSuites = Object.values(dataMapper.mappedSections)
+        .filter((section) => !!section)
+        .map((section) => {
+            log(`Generating test suite for ${section.name}`);
 
-      return testSuite;
-    });
+            const testSuite = new TestSuite({
+                subtopic: section,
+                testReferenceIndex: index,
+            });
+            index = testSuite.testReferenceIndex;
 
-  testSuites.push(staticPageTests); 
-  writeTestSuites({ testSuites, outputDir });
+            log(`Test suite for ${section.name} generated`, {
+                addSeperator: true,
+            });
+
+            return testSuite;
+        });
+
+    log("Generated test suites");
+
+    testSuites.push(staticPageTests);
+    writeTestSuites({ testSuites, outputDir });
+
+    log("Wrote test suite CSVs", { addSeperator: true });
 }

--- a/contentful/export-processor/helpers/json.js
+++ b/contentful/export-processor/helpers/json.js
@@ -1,0 +1,12 @@
+import { stringify as flattenedStringify } from "flatted";
+
+const stringify = (obj) => {
+    try {
+        return JSON.stringify(obj);
+    } catch (e) {
+        console.error(`Error stringifying ${obj}. Will try flatted`, e);
+        return flattenedStringify(obj);
+    }
+};
+
+export { stringify };

--- a/contentful/export-processor/helpers/log.js
+++ b/contentful/export-processor/helpers/log.js
@@ -1,0 +1,51 @@
+const defaultLogOptions = {
+    addBlankLine: true,
+    addSeperator: false,
+    seperator: "============",
+    level: "INFO",
+};
+
+/**
+ * Logs message to console with formatting
+ * @param {string} message Message to log
+ * @param {{addBlankLine: boolean, addSeperator: boolean, seperator: string, level: "INFO" | "WARNING" | "ERROR"}} options
+ */
+const logMessage = (message, options = defaultLogOptions) => {
+    const { addBlankLine, addSeperator, seperator, level } = {
+        ...defaultLogOptions,
+        ...options,
+    };
+
+    const logger = level == "ERROR" ? console.error : console.log;
+
+    const formattedMessage = formatMessage(
+        level ?? defaultLogOptions.level,
+        message
+    );
+    logger(formattedMessage);
+
+    if (addBlankLine) {
+        console.log("");
+    }
+
+    if (addSeperator) {
+        console.log(seperator);
+        console.log("");
+    }
+};
+
+/**
+ *
+ * @param {string} level
+ * @param {string} message
+ * @returns
+ */
+const formatMessage = (level, message) =>
+    `[${getTimeString()}] ${level} - ${message}`;
+
+const getTimeString = () => {
+    var now = new Date();
+    return `${now.getHours()}:${now.getMinutes()}:${now.getSeconds()}`;
+};
+
+export { logMessage as log };

--- a/contentful/export-processor/test-suite/test-suite.js
+++ b/contentful/export-processor/test-suite/test-suite.js
@@ -1,132 +1,138 @@
 import TestSuiteRow from "./test-suite-row.js";
 import AppendixRow from "./appendix-row.js";
+import { log } from "#src/helpers/log";
 
 const ADO_TAG = "Functional.js";
 
 export default class TestSuiteForSubTopic {
-  subtopic;
-  testReferenceIndex;
+    /**
+     * @type {import ("../content-types/section.js").Section}
+     */
+    subtopic;
+    testReferenceIndex;
 
-  testCaseGenerators = [
-    this.generateCanNavigateToSubtopic.bind(this),
-    this.generateCanSaveAnswers.bind(this),
-    this.generateAttemptsSaveWithoutAnswer.bind(this),
-    this.generateSavesPartialAnswers.bind(this),
-    this.generateReturnToPartialAnswers.bind(this),
-    this.generateManualNavToURLQuestion.bind(this),
-    this.generateCompleteJourney.bind(this),
-    this.generateUpdateResubmitResponses.bind(this),
-    this.generateReceivesLowScoringLogic.bind(this),
-    this.generateReceivesHighScoringLogic.bind(this),
-    this.generateReceivesMidScoringLogic.bind(this),
-    this.generateChangeAnswersCheckYourAnswers.bind(this),
-    this.generateReturnToSelfAssessment.bind(this),
-    this.generateUseBackButton.bind(this),
-    this.generateSharePage.bind(this),
-    this.generateNavigateLowMatChunks.bind(this),
-    this.generateNavigateLowMatCSLinks.bind(this),
-  ];
+    testCaseGenerators = [
+        this.generateCanNavigateToSubtopic.bind(this),
+        this.generateCanSaveAnswers.bind(this),
+        this.generateAttemptsSaveWithoutAnswer.bind(this),
+        this.generateSavesPartialAnswers.bind(this),
+        this.generateReturnToPartialAnswers.bind(this),
+        this.generateManualNavToURLQuestion.bind(this),
+        this.generateCompleteJourney.bind(this),
+        this.generateUpdateResubmitResponses.bind(this),
+        this.generateReceivesLowScoringLogic.bind(this),
+        this.generateReceivesHighScoringLogic.bind(this),
+        this.generateReceivesMidScoringLogic.bind(this),
+        this.generateChangeAnswersCheckYourAnswers.bind(this),
+        this.generateReturnToSelfAssessment.bind(this),
+        this.generateUseBackButton.bind(this),
+        this.generateSharePage.bind(this),
+        this.generateNavigateLowMatChunks.bind(this),
+        this.generateNavigateLowMatCSLinks.bind(this),
+    ];
 
-  testCases = [];
-  appendix = [];
-  subtopicName;
+    testCases = [];
+    appendix = [];
+    subtopicName;
 
-  constructor({ subtopic, testReferenceIndex }) {
-    this.subtopic = subtopic;
-    this.subtopicName = this.subtopic.name.trim();
-    this.testReferenceIndex = testReferenceIndex;
+    constructor({ subtopic, testReferenceIndex }) {
+        this.subtopic = subtopic;
+        this.subtopicName = this.subtopic.name.trim();
+        this.testReferenceIndex = testReferenceIndex;
 
-    this.testCases = this.testCaseGenerators.map((generator) => generator()).filter((testCase) => !!testCase);
-  }
-
-  /**
-   * 
-   * @param {*} testScenario 
-   * @param {*} testSteps 
-   * @param {*} expectedOutcome 
-   * @param {AppendixRow | undefined} appendix 
-   * @returns 
-   */
-  createRow(testScenario, testSteps, expectedOutcome, appendix) {
-    const row = new TestSuiteRow({
-      testReference: `Access_${this.testReferenceIndex++}`,
-      adoTag: ADO_TAG,
-      subtopic: this.subtopicName,
-      testScenario: testScenario,
-      preConditions: "User is signed into the DfE Sign in service",
-      testSteps: testSteps,
-      expectedOutcome: expectedOutcome,
-      appendixRef: appendix?.reference
-    });
-
-    if (appendix) {
-      this.appendix.push(appendix);
+        this.testCases = this.testCaseGenerators
+            .map((generator) => generator())
+            .filter((testCase) => !!testCase);
     }
 
-    return row;
-  }
+    /**
+     *
+     * @param {*} testScenario
+     * @param {*} testSteps
+     * @param {*} expectedOutcome
+     * @param {AppendixRow | undefined} appendix
+     * @returns
+     */
+    createRow(testScenario, testSteps, expectedOutcome, appendix) {
+        const row = new TestSuiteRow({
+            testReference: `Access_${this.testReferenceIndex++}`,
+            adoTag: ADO_TAG,
+            subtopic: this.subtopicName,
+            testScenario: testScenario,
+            preConditions: "User is signed into the DfE Sign in service",
+            testSteps: testSteps,
+            expectedOutcome: expectedOutcome,
+            appendixRef: appendix?.reference,
+        });
 
-  generateCanNavigateToSubtopic() {
-    const testScenario = `User can navigate to the ${this.subtopicName} subtopic from the self-assessment page`;
-    const testSteps = `1 - Navigate to ${this.subtopicName} subtopic`;
-    const expectedOutcome = `User sees ${this.subtopicName} interstitial page`;
-    return this.createRow(testScenario, testSteps, expectedOutcome);
-  }
+        if (appendix) {
+            this.appendix.push(appendix);
+        }
 
-  generateCanSaveAnswers() {
-    const testScenario = `User can save answers to questions for ${this.subtopicName} subtopic`;
-    const testSteps = `1 - Navigate to ${this.subtopicName} subtopic 2 - Answer and save each question presented 3 - Compare the answers presented on 'Check your answers' page to your answers`;
-    const expectedOutcome = `Answers match. Can save and continue.`;
-    return this.createRow(testScenario, testSteps, expectedOutcome);
-  }
+        return row;
+    }
 
-  generateAttemptsSaveWithoutAnswer() {
-    const testScenario = `User attempts to save and continue without selecting an answer`;
-    const testSteps = `1 - Navigate to ${this.subtopicName} subtopic
+    generateCanNavigateToSubtopic() {
+        const testScenario = `User can navigate to the ${this.subtopicName} subtopic from the self-assessment page`;
+        const testSteps = `1 - Navigate to ${this.subtopicName} subtopic`;
+        const expectedOutcome = `User sees ${this.subtopicName} interstitial page`;
+        return this.createRow(testScenario, testSteps, expectedOutcome);
+    }
+
+    generateCanSaveAnswers() {
+        const testScenario = `User can save answers to questions for ${this.subtopicName} subtopic`;
+        const testSteps = `1 - Navigate to ${this.subtopicName} subtopic 2 - Answer and save each question presented 3 - Compare the answers presented on 'Check your answers' page to your answers`;
+        const expectedOutcome = `Answers match. Can save and continue.`;
+        return this.createRow(testScenario, testSteps, expectedOutcome);
+    }
+
+    generateAttemptsSaveWithoutAnswer() {
+        const testScenario = `User attempts to save and continue without selecting an answer`;
+        const testSteps = `1 - Navigate to ${this.subtopicName} subtopic
                         2 - Do not answer question
                         3 - Select 'save and continue'`;
-    const expectedOutcome = `User sees modal that states 'There is a problem. You must select an answer to continue'.`;
-    return this.createRow(testScenario, testSteps, expectedOutcome);
-  }
+        const expectedOutcome = `User sees modal that states 'There is a problem. You must select an answer to continue'.`;
+        return this.createRow(testScenario, testSteps, expectedOutcome);
+    }
 
-  generateSavesPartialAnswers() {
-    const testScenario = `User saves partially completed ${this.subtopicName} subtopic answers`;
-    const testSteps = `1 - Navigate to ${this.subtopicName} subtopic
+    generateSavesPartialAnswers() {
+        const testScenario = `User saves partially completed ${this.subtopicName} subtopic answers`;
+        const testSteps = `1 - Navigate to ${this.subtopicName} subtopic
                       2 - Select first answer
                       3 - Select back until reaching self assessment page`;
-    const expectedOutcome = `User is returned to self assessment page. Broadband connection status shows 'In progress'.`;
-    return this.createRow(testScenario, testSteps, expectedOutcome);
-  }
+        const expectedOutcome = `User is returned to self assessment page. Broadband connection status shows 'In progress'.`;
+        return this.createRow(testScenario, testSteps, expectedOutcome);
+    }
 
-  generateReturnToPartialAnswers() {
-    const testScenario = `User can return to a partially completed ${this.subtopicName} question set and pick up where they left off`;
-    const testSteps = `1 - Navigate to ${this.subtopicName} subtopic
+    generateReturnToPartialAnswers() {
+        const testScenario = `User can return to a partially completed ${this.subtopicName} question set and pick up where they left off`;
+        const testSteps = `1 - Navigate to ${this.subtopicName} subtopic
                         2 - Navigate through the interstitial page`;
-    const expectedOutcome = `User is returned to the first unanswered question. User can continue through to reach a recommendation.`;
-    return this.createRow(testScenario, testSteps, expectedOutcome);
-  }
+        const expectedOutcome = `User is returned to the first unanswered question. User can continue through to reach a recommendation.`;
+        return this.createRow(testScenario, testSteps, expectedOutcome);
+    }
 
-  generateManualNavToURLQuestion() {
-    const testScenario = `User manually goes to a question ahead of their journey for a subtopic via URL`;
-    const testSteps = `1 - Navigate to ${this.subtopicName} subtopic
+    generateManualNavToURLQuestion() {
+        const testScenario = `User manually goes to a question ahead of their journey for a subtopic via URL`;
+        const testSteps = `1 - Navigate to ${this.subtopicName} subtopic
 2 - Navigate ahead of journey via URL`;
-    const expectedOutcome = `User journey shows in progress.`;
-    return this.createRow(testScenario, testSteps, expectedOutcome);
-  }
+        const expectedOutcome = `User journey shows in progress.`;
+        return this.createRow(testScenario, testSteps, expectedOutcome);
+    }
 
-  generateCompleteJourney() {
-    const testScenario = `User can complete journey through all questions in ${this.subtopicName} topic`;
-    const testSteps = `1 - Navigate to ${this.subtopicName} subtopic
+    generateCompleteJourney() {
+        const testScenario = `User can complete journey through all questions in ${this.subtopicName} topic`;
+        const testSteps = `1 - Navigate to ${this.subtopicName} subtopic
                         2 - Navigate through the interstitial page
                         3 - Navigate through questions/check answers
                         4 - Save and continue`;
-    const expectedOutcome = `User returns to self-assessment page and sees success modal.`;
-    return this.createRow(testScenario, testSteps, expectedOutcome);
-  }
+        const expectedOutcome = `User returns to self-assessment page and sees success modal.`;
+        return this.createRow(testScenario, testSteps, expectedOutcome);
+    }
 
-  generateSharePage() {
-    const testScenario = `User navigates to the share/download page`;
-    const testSteps = `1 - Navigate to ${this.subtopicName} subtopic
+    generateSharePage() {
+        const testScenario = `User navigates to the share/download page`;
+        const testSteps = `1 - Navigate to ${this.subtopicName} subtopic
                         2 - Navigate through the interstitial page
                         3 - Navigate through questions all questions and the check answers page
                         4 - Save and continue
@@ -135,213 +141,262 @@ export default class TestSuiteForSubTopic {
                         7 - Verify that you are redirected to the share/download page,
                         8 - Verify that the print button is present and works as expected`;
 
+        const expectedOutcome = `User can access the share/download page.`;
+        return this.createRow(testScenario, testSteps, expectedOutcome);
+    }
 
-    const expectedOutcome = `User can access the share/download page.`;
-    return this.createRow(testScenario, testSteps, expectedOutcome);
-  }
-
-  generateUpdateResubmitResponses() {
-    const testScenario = `A different user can update and re-submit their responses`;
-    const testSteps = `1 - Navigate to the ${this.subtopicName} subtopic
+    generateUpdateResubmitResponses() {
+        const testScenario = `A different user can update and re-submit their responses`;
+        const testSteps = `1 - Navigate to the ${this.subtopicName} subtopic
                         2 - Navigate through the interstitial page
                         3 - Navigate through questions/check answers
                         4 - Save and continue`;
-    const expectedOutcome = `Recommendations are updated.`;
-    return this.createRow(testScenario, testSteps, expectedOutcome);
-  }
-
-  generateReceivesLowScoringLogic() {
-    return this.generateTestForMaturity("Low");
-  }
-
-  generateReceivesHighScoringLogic() {
-    return this.generateTestForMaturity("High");
-  }
-
-  generateReceivesMidScoringLogic() {
-    return this.generateTestForMaturity("Medium");
-  }
-
-  generateTestForMaturity(maturity) {
-    const pathForLow = this.getPathForMaturity(maturity)
-    if (!pathForLow) {
-      console.error(`No '${maturity}' maturity journey for ${this.subtopicName}`);
-      return;
+        const expectedOutcome = `Recommendations are updated.`;
+        return this.createRow(testScenario, testSteps, expectedOutcome);
     }
 
-    const testScenario = `User receives recommendation for ${maturity} maturity`;
+    generateReceivesLowScoringLogic() {
+        return this.generateTestForMaturity("Low");
+    }
 
-    const testSteps = [`1 - Navigate to the ${this.subtopicName} subtopic`, `2 - Navigate through the interstitial page`,
-    ...pathForLow.map((pathPart, index) => `3.${index + 1} - Choose answer '${pathPart.answer.text}' for question '${pathPart.question.text}'`),
-      `4 - Save and continue`, `5 - View ${this.subtopicName} recommendation`].join("\n").replace(",", "");
+    generateReceivesHighScoringLogic() {
+        return this.generateTestForMaturity("High");
+    }
 
-    const content = this.subtopic.recommendation.getContentForMaturityAndPath({ maturity, path: pathForLow });
+    generateReceivesMidScoringLogic() {
+        return this.generateTestForMaturity("Medium");
+    }
 
+    generateTestForMaturity(maturity) {
+        const pathForLow = this.getPathForMaturity(maturity);
+        if (!pathForLow) {
+            log(`No '${maturity}' maturity journey for ${this.subtopicName}`, {
+                level: "ERROR",
+            });
+            return;
+        }
 
-    const expectedOutcome = `User taken to '${maturity}' recommendation page with slug '${content.intro.slug}' for ${this.subtopicName}.`;
+        const testScenario = `User receives recommendation for ${maturity} maturity`;
 
-    const intro = {
-      header: content.intro.header,
-      content: content.intro.content
-    };
+        const testSteps = [
+            `1 - Navigate to the ${this.subtopicName} subtopic`,
+            `2 - Navigate through the interstitial page`,
+            ...pathForLow.map(
+                (pathPart, index) =>
+                    `3.${index + 1} - Choose answer '${
+                        pathPart.answer.text
+                    }' for question '${pathPart.question.text}'`
+            ),
+            `4 - Save and continue`,
+            `5 - View ${this.subtopicName} recommendation`,
+        ]
+            .join("\n")
+            .replace(",", "");
 
-    const chunkContents = content.chunks.map(chunk => ({
-      header: chunk.header,
-      title: chunk.title,
-      content: chunk.content
-    }));
+        const content =
+            this.subtopic.recommendation.getContentForMaturityAndPath({
+                maturity,
+                path: pathForLow,
+            });
 
-    const asCsvContent = `
+        const expectedOutcome = `User taken to '${maturity}' recommendation page with slug '${content.intro.slug}' for ${this.subtopicName}.`;
+
+        const intro = {
+            header: content.intro.header,
+            content: content.intro.content,
+        };
+
+        const chunkContents = content.chunks.map((chunk) => ({
+            header: chunk.header,
+            title: chunk.title,
+            content: chunk.content,
+        }));
+
+        const asCsvContent = `
     Expected intro:
   Header: '${intro.header}'
   Content: '${intro.content}'
 
-  ${chunkContents.map((chunk, index) =>
-      `Accordion section ${index + 2}:
+  ${chunkContents
+      .map(
+          (chunk, index) =>
+              `Accordion section ${index + 2}:
     Header: '${chunk.header}'
     Title: '${chunk.title}'
     Content: '${chunk.content}'
-    `).join("\n")}`;
+    `
+      )
+      .join("\n")}`;
 
-    const appendixRow = new AppendixRow({ reference: `Access_${this.testReferenceIndex}_Appendix`, content: asCsvContent });
+        const appendixRow = new AppendixRow({
+            reference: `Access_${this.testReferenceIndex}_Appendix`,
+            content: asCsvContent,
+        });
 
-    return this.createRow(testScenario, testSteps, expectedOutcome, appendixRow);
-  }
+        return this.createRow(
+            testScenario,
+            testSteps,
+            expectedOutcome,
+            appendixRow
+        );
+    }
 
-  generateChangeAnswersCheckYourAnswers() {
-    const testScenario = `User can change answers via the 'Check your answers' page`;
-    const testSteps =
-      `1 - Navigate to the ${this.subtopicName} subtopic
+    generateChangeAnswersCheckYourAnswers() {
+        const testScenario = `User can change answers via the 'Check your answers' page`;
+        const testSteps = `1 - Navigate to the ${this.subtopicName} subtopic
     2 - Navigate through the interstitial page
     3 - Navigate to the change button on 'Check your answers' page
     4 - Change answer`;
 
-    const expectedOutcome = `Users answers update to match new answers.`;
-    return this.createRow(testScenario, testSteps, expectedOutcome);
-  }
+        const expectedOutcome = `Users answers update to match new answers.`;
+        return this.createRow(testScenario, testSteps, expectedOutcome);
+    }
 
-  generateReturnToSelfAssessment() {
-    const testScenario = `User returns to self - assessment screen during question routing`;
-    const testSteps =
-      `1 - Navigate to the ${this.subtopicName} subtopic
+    generateReturnToSelfAssessment() {
+        const testScenario = `User returns to self - assessment screen during question routing`;
+        const testSteps = `1 - Navigate to the ${this.subtopicName} subtopic
     2 - Navigate through the interstitial page
     3 - Answer first question, save and continue
     4 - User clicks PTFYS header`;
-    const expectedOutcome = `User returned to self - assessment page.${this.subtopicName} subtopic shows 'In progress'.`;
-    return this.createRow(testScenario, testSteps, expectedOutcome);
-  }
+        const expectedOutcome = `User returned to self - assessment page.${this.subtopicName} subtopic shows 'In progress'.`;
+        return this.createRow(testScenario, testSteps, expectedOutcome);
+    }
 
-  generateUseBackButton() {
-    const testScenario = `User uses back button to navigate back through questions to self assesment page`;
-    const testSteps = 
-    `1 - Navigate to the ${this.subtopicName} subtopic
+    generateUseBackButton() {
+        const testScenario = `User uses back button to navigate back through questions to self assesment page`;
+        const testSteps = `1 - Navigate to the ${this.subtopicName} subtopic
     2 - Navigate through the interstitial page
     3 - Answer first question, save and continue
     4 - Use back button to return to first queston
     5 - use back button again to return to self assesment page`;
-    const expectedOutcome = `User returned to self - assessment page.${this.subtopicName} subtopic shows 'In progress'.`;
-    return this.createRow(testScenario, testSteps, expectedOutcome);
-  }
-
-  generateNavigateForRecommendationChunks(maturity) {
-    const pathForMaturity = this.getPathForMaturity(maturity)
-  
-    if (!pathForMaturity) {
-      console.error(`No '${maturity}' maturity journey for ${this.subtopicName}`);
-      return;
+        const expectedOutcome = `User returned to self - assessment page.${this.subtopicName} subtopic shows 'In progress'.`;
+        return this.createRow(testScenario, testSteps, expectedOutcome);
     }
-  
-    const answerIds = this.getAnswerIds(pathForMaturity);
-    const chunks = this.subtopic.recommendation.section.chunks;
-  
-    const filteredChunks = this.getAnswerBasedChunks(chunks, answerIds)
-  
-    const testScenario = `User can navigate between recommendation chunks`;
-    const testSteps = [
-      `1 - Navigate to the ${this.subtopicName} subtopic`,
-      `2 - Navigate through the interstitial page`,
-      ...pathForMaturity.map((pathPart, index) => `3.${index + 1} - Choose answer '${pathPart.answer.text}' for question '${pathPart.question.text}'`),
-      `4 - Save and continue`,
-      `5 - View ${this.subtopicName} recommendation`,
-      `6 - Using the navigation bar and pagination buttons, navigate between the different recommendation chunks:`,
-      ...filteredChunks.map((chunk, index) => `6.${index + 1} - Navigate to the '${chunk.header}' chunk`)
-    ].join("\n").replace(",", "");
-  
-    const expectedOutcome = `User is able to view each recommendation chunk.`;
-    return this.createRow(testScenario, testSteps, expectedOutcome);
-  }
 
-  generateCSLinkChunks(maturity) {
-    const pathForMaturity = this.getPathForMaturity(maturity);
-  
-    if (!pathForMaturity) {
-      console.error(`No '${maturity}' maturity journey for ${this.subtopicName}`);
-      return;
-    }
-  
-    const answerIds = this.getAnswerIds(pathForMaturity);
-    const chunks = this.subtopic.recommendation.section.chunks;
-  
-    const filteredChunks = this.getCSLinkChunks(chunks, answerIds)
-  
-    if (filteredChunks.length === 0) {
-      console.log(`No chunks with CSLink for maturity '${maturity}' in ${this.subtopicName}.`);
-      return;
-    }
-  
-    const testScenario = `User can navigate between recommendation chunks with C&S links and to C&S content`;
-    const testSteps = [
-      `1 - Navigate to the ${this.subtopicName} subtopic`,
-      `2 - Navigate through the interstitial page`,
-      ...pathForMaturity.map((pathPart, index) => `3.${index} - Choose answer '${pathPart.answer.text}' for question '${pathPart.question.text}'`),
-      `4 - Save and continue`,
-      `5 - View ${this.subtopicName} recommendation`,
-      `6 - Using the navigation bar and pagination buttons, navigate between the different recommendation chunks with unique csLink:`,
-      ...filteredChunks.flatMap((chunk, index) => [
-        `6.${index} - Navigate to the '${chunk.header}' chunk`,
-        `6.${index} - Click the link with text '${chunk.csLink.linkText}'`,
-        `6.${index} - Verify the C&S content renders correctly`,
-        `6.${index} - Go back to the recommendation chunks using the back button`
-      ])
-    ].join("\n").replace(",", "");
-  
-    const expectedOutcome = `User is able to view the recommendation chunk with C&S link and verify the C&S content.`;
-    return this.createRow(testScenario, testSteps, expectedOutcome);
-  }
+    generateNavigateForRecommendationChunks(maturity) {
+        const pathForMaturity = this.getPathForMaturity(maturity);
 
-  generateNavigateLowMatChunks() {
-    return this.generateNavigateForRecommendationChunks('Low');
-  }
-
-  generateNavigateLowMatCSLinks() {
-    return this.generateCSLinkChunks('Low');
-  }
-
-  getPathForMaturity(maturity) {
-    return this.subtopic.minimumPathsForRecommendations[maturity];
-  }
-  
-  getAnswerIds(pathForMaturity) {
-    return pathForMaturity.map(q => q.answer.id);
-  }
-  
-  getAnswerBasedChunks(chunks, answerIds) {
-    return chunks.filter(chunk => 
-      chunk.answers.some(answer => answerIds.includes(answer.id))
-    );
-  }
-
-  getCSLinkChunks(chunks, answerIds) {
-    const uniqueCsLinks = new Set();
-    return chunks.filter(chunk => {
-      if (chunk.csLink && chunk.answers.some(answer => answerIds.includes(answer.id))) {
-        const linkText = chunk.csLink.linkText;
-        if (!uniqueCsLinks.has(linkText)) {
-          uniqueCsLinks.add(linkText);
-          return true;
+        if (!pathForMaturity) {
+            log(`No '${maturity}' maturity journey for ${this.subtopicName}`, {
+                level: "ERROR",
+            });
+            return;
         }
-      }
-      return false;
-    });
-  }
+
+        const answerIds = this.getAnswerIds(pathForMaturity);
+        const chunks = this.subtopic.recommendation.section.chunks;
+
+        const filteredChunks = this.getAnswerBasedChunks(chunks, answerIds);
+
+        const testScenario = `User can navigate between recommendation chunks`;
+        const testSteps = [
+            `1 - Navigate to the ${this.subtopicName} subtopic`,
+            `2 - Navigate through the interstitial page`,
+            ...pathForMaturity.map(
+                (pathPart, index) =>
+                    `3.${index + 1} - Choose answer '${
+                        pathPart.answer.text
+                    }' for question '${pathPart.question.text}'`
+            ),
+            `4 - Save and continue`,
+            `5 - View ${this.subtopicName} recommendation`,
+            `6 - Using the navigation bar and pagination buttons, navigate between the different recommendation chunks:`,
+            ...filteredChunks.map(
+                (chunk, index) =>
+                    `6.${index + 1} - Navigate to the '${chunk.header}' chunk`
+            ),
+        ]
+            .join("\n")
+            .replace(",", "");
+
+        const expectedOutcome = `User is able to view each recommendation chunk.`;
+        return this.createRow(testScenario, testSteps, expectedOutcome);
+    }
+
+    generateCSLinkChunks(maturity) {
+        const pathForMaturity = this.getPathForMaturity(maturity);
+
+        if (!pathForMaturity) {
+            log(`No '${maturity}' maturity journey for ${this.subtopicName}`, {
+                level: "ERROR",
+            });
+            return;
+        }
+
+        const answerIds = this.getAnswerIds(pathForMaturity);
+        const chunks = this.subtopic.recommendation.section.chunks;
+
+        const filteredChunks = this.getCSLinkChunks(chunks, answerIds);
+
+        if (filteredChunks.length === 0) {
+            log(
+                `No chunks with CSLink for maturity '${maturity}' in ${this.subtopicName}.`,
+                { level: "WARNING" }
+            );
+            return;
+        }
+
+        const testScenario = `User can navigate between recommendation chunks with C&S links and to C&S content`;
+        const testSteps = [
+            `1 - Navigate to the ${this.subtopicName} subtopic`,
+            `2 - Navigate through the interstitial page`,
+            ...pathForMaturity.map(
+                (pathPart, index) =>
+                    `3.${index} - Choose answer '${pathPart.answer.text}' for question '${pathPart.question.text}'`
+            ),
+            `4 - Save and continue`,
+            `5 - View ${this.subtopicName} recommendation`,
+            `6 - Using the navigation bar and pagination buttons, navigate between the different recommendation chunks with unique csLink:`,
+            ...filteredChunks.flatMap((chunk, index) => [
+                `6.${index} - Navigate to the '${chunk.header}' chunk`,
+                `6.${index} - Click the link with text '${chunk.csLink.linkText}'`,
+                `6.${index} - Verify the C&S content renders correctly`,
+                `6.${index} - Go back to the recommendation chunks using the back button`,
+            ]),
+        ]
+            .join("\n")
+            .replace(",", "");
+
+        const expectedOutcome = `User is able to view the recommendation chunk with C&S link and verify the C&S content.`;
+        return this.createRow(testScenario, testSteps, expectedOutcome);
+    }
+
+    generateNavigateLowMatChunks() {
+        return this.generateNavigateForRecommendationChunks("Low");
+    }
+
+    generateNavigateLowMatCSLinks() {
+        return this.generateCSLinkChunks("Low");
+    }
+
+    getPathForMaturity(maturity) {
+        return this.subtopic.pathInfo.minimumPathsForRecommendations[maturity];
+    }
+
+    getAnswerIds(pathForMaturity) {
+        return pathForMaturity.map((q) => q.answer.id);
+    }
+
+    getAnswerBasedChunks(chunks, answerIds) {
+        return chunks.filter((chunk) =>
+            chunk.answers.some((answer) => answerIds.includes(answer.id))
+        );
+    }
+
+    getCSLinkChunks(chunks, answerIds) {
+        const uniqueCsLinks = new Set();
+        return chunks.filter((chunk) => {
+            if (
+                chunk.csLink &&
+                chunk.answers.some((answer) => answerIds.includes(answer.id))
+            ) {
+                const linkText = chunk.csLink.linkText;
+                if (!uniqueCsLinks.has(linkText)) {
+                    uniqueCsLinks.add(linkText);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
 }

--- a/contentful/export-processor/test-suite/write-csvs.js
+++ b/contentful/export-processor/test-suite/write-csvs.js
@@ -2,97 +2,100 @@ import fs from "fs";
 import path from "path";
 // eslint-disable-next-line no-unused-vars
 import TestSuite from "./test-suite.js";
+import { log } from "#src/helpers/log";
 
 const mainSheetColumns = [
-  { testReference: "Test Reference" },
-  { appendixRef: "Appendix Reference" },
-  { adoTag: "ADO Tag" },
-  { subtopic: "Sub-topic" },
-  { testScenario: "Test Scenario" },
-  { preConditions: "Pre-conditions" },
-  { testSteps: "Test Steps" },
-  { expectedOutcome: "Expected Outcome" },
-  { testApproved: "Test Approved" },
+    { testReference: "Test Reference" },
+    { appendixRef: "Appendix Reference" },
+    { adoTag: "ADO Tag" },
+    { subtopic: "Sub-topic" },
+    { testScenario: "Test Scenario" },
+    { preConditions: "Pre-conditions" },
+    { testSteps: "Test Steps" },
+    { expectedOutcome: "Expected Outcome" },
+    { testApproved: "Test Approved" },
 ];
 
-const appendixColumns = [
-  { reference: "Reference" },
-  { content: "Content" },
-];
+const appendixColumns = [{ reference: "Reference" }, { content: "Content" }];
 
 const createCsvInfo = (columns) => {
-  const keys = [];
-  const headers = [];
+    const keys = [];
+    const headers = [];
 
-  columns.forEach((columnObj) => {
-    const [key, header] = Object.entries(columnObj)[0];
-    keys.push(key);
-    headers.push(header);
-  });
+    columns.forEach((columnObj) => {
+        const [key, header] = Object.entries(columnObj)[0];
+        keys.push(key);
+        headers.push(header);
+    });
 
-  return {
-    headers: headers,
-    keys: keys
-  };
+    return {
+        headers: headers,
+        keys: keys,
+    };
 };
 
 const createCsvs = () => {
-  const mainCsv = createCsvInfo(mainSheetColumns);
-  const appendixCsv = createCsvInfo(appendixColumns);
+    const mainCsv = createCsvInfo(mainSheetColumns);
+    const appendixCsv = createCsvInfo(appendixColumns);
 
-  return { mainCsv, appendixCsv };
+    return { mainCsv, appendixCsv };
 };
 
 /**
- * 
- * @param {*} param0 
+ *
+ * @param {*} param0
  * @param {TestSuite[]} param0.testSuites - test suites to save as CSV
  * @param {string} param0.outputDir - where to save files to
  */
 export default function writeTestSuites({ testSuites, outputDir }) {
-  const { mainCsv, appendixCsv } = createCsvs();
+    log(`Creating CSVs for test suites`);
+    const { mainCsv, appendixCsv } = createCsvs();
 
-  outputDir = createTestSuitesSubDirectory(outputDir);
+    outputDir = createTestSuitesSubDirectory(outputDir);
 
-  writeSheet({
-    content: testSuites.flatMap(suite => suite.testCases),
-    outputDir,
-    fileName: "plan-tech-test-suite.csv",
-    ...mainCsv
-  });
+    writeSheet({
+        content: testSuites.flatMap((suite) => suite.testCases),
+        outputDir,
+        fileName: "plan-tech-test-suite.csv",
+        ...mainCsv,
+    });
 
-  writeSheet({
-    content: testSuites.flatMap(suite => suite.appendix),
-    outputDir,
-    fileName: "plan-tech-test-suite-appendix.csv",
-    ...appendixCsv
-  });
+    writeSheet({
+        content: testSuites.flatMap((suite) => suite.appendix),
+        outputDir,
+        fileName: "plan-tech-test-suite-appendix.csv",
+        ...appendixCsv,
+    });
 }
 
 const createTestSuitesSubDirectory = (outputDir) => {
-  const subDirectory = path.join(outputDir, "test-suites");
+    const subDirectory = path.join(outputDir, "test-suites");
 
-  try {
-    fs.mkdirSync(subDirectory, { recursive: true });
-  }
-  catch (e) {
-    console.error(`Error creating test-suites subdirectory`, e);
-    return outputDir;
-  }
+    try {
+        fs.mkdirSync(subDirectory, { recursive: true });
+    } catch (e) {
+        console.error(`Error creating test-suites subdirectory`, e);
+        return outputDir;
+    }
 
-  return subDirectory;
+    return subDirectory;
 };
 
 const writeSheet = ({ content, headers, keys, fileName, outputDir }) => {
-  const rows = content
-    .filter((testCase) => testCase != null)
-    .map((testCase) => `"${keys.map(key => testCase[key] ?? " ").join(`","`)}"`)
-    .join("\n");
+    log(`Writing sheet for ${fileName}`);
+    const rows = content
+        .filter((testCase) => testCase != null)
+        .map(
+            (testCase) =>
+                `"${keys.map((key) => testCase[key] ?? " ").join(`","`)}"`
+        )
+        .join("\n");
 
-  const headerRow = headers.join(",");
-  const csv = `${headerRow}\n${rows}`;
+    const headerRow = headers.join(",");
+    const csv = `${headerRow}\n${rows}`;
 
-  const filePath = path.join(outputDir, fileName);
+    const filePath = path.join(outputDir, fileName);
 
-  fs.writeFileSync(filePath, csv);
+    fs.writeFileSync(filePath, csv);
+    log(`Wrote for ${fileName}`);
 };

--- a/contentful/export-processor/user-journey/minimum-path-calculator.js
+++ b/contentful/export-processor/user-journey/minimum-path-calculator.js
@@ -29,8 +29,8 @@ export class MinimumPathCalculator {
     sectionId;
 
     /**
-     * 
-     * @param {{ questions: Question[], paths: UserJourney[], sortedPaths: UserJourney[], sectionId: string}} params 
+     *
+     * @param {{ questions: Question[], paths: UserJourney[], sortedPaths: UserJourney[], sectionId: string}} params
      */
     constructor({ questions, paths, sortedPaths, sectionId }) {
         this.questions = questions;
@@ -80,16 +80,19 @@ export class MinimumPathCalculator {
 
             minimumPaths.push(path.path);
 
-            this.removeItemsFromArray(remainingQuestions, path.questionIdsAnswered);
+            this.removeItemsFromArray(
+                remainingQuestions,
+                path.questionIdsAnswered
+            );
         }
 
         return this.handleRemainingQuestions(remainingQuestions, minimumPaths);
     }
 
     /**
-     * 
-     * @param {string[]} remainingQuestions 
-     * @param {Path[]} minimumPaths 
+     *
+     * @param {string[]} remainingQuestions
+     * @param {Path[]} minimumPaths
      * @returns {Path[]}
      */
     handleRemainingQuestions(remainingQuestions, minimumPaths) {
@@ -105,9 +108,9 @@ export class MinimumPathCalculator {
     }
 
     /**
-     * 
-     * @param {string} questionId 
-     * @returns 
+     *
+     * @param {string} questionId
+     * @returns
      */
     getFirstPathContainingQuestion(questionId) {
         // Find the first path that contains the remaining question

--- a/contentful/export-processor/user-journey/path-calculator.js
+++ b/contentful/export-processor/user-journey/path-calculator.js
@@ -16,28 +16,28 @@ import errorLogger from "#src/errors/error-logger";
 export class PathCalculator {
     /** @type {Question[]} Questions in the section */
     questions;
-    
+
     /** @type {UserJourney[]} All possible paths through the questions */
     paths;
-    
+
     /** @type {PathBuilder} Builds paths through questions */
     pathBuilder;
-    
+
     /** @type {SubtopicRecommendation} Recommendation for the section */
     recommendation;
-    
+
     /** @type {string} Unique identifier for the section */
     sectionId;
 
     /** @type {UserJourney[] | undefined} Cached sorted paths */
     _sortedPaths;
-    
+
     /** @type {UserJourney[] | undefined} Cached minimum paths to navigate questions */
     _minimumPathsToNavigateQuestions;
-    
+
     /** @type {Record<string, Path> | undefined} Cached minimum paths for recommendations */
     _minimumPathsForRecommendations;
-    
+
     /** @type {UserJourney[] | undefined} Cached paths for all possible answers */
     _pathsForAllPossibleAnswers;
 
@@ -124,8 +124,8 @@ export class PathCalculator {
     }
 
     /**
-     * 
-     * @param {Path} path 
+     *
+     * @param {Path} path
      * @returns {UserJourney}
      */
     pathToUserJourney(path) {
@@ -161,7 +161,11 @@ export class PathCalculator {
         if (sectionChunks.length !== uniqueTestedChunks.length) {
             sectionChunks
                 .filter((chunkId) => !uniqueTestedChunks.includes(chunkId))
-                .forEach((missingChunk) => this._addError(`Recommendation chunk ${missingChunk} not included in any test paths.`));
+                .forEach((missingChunk) =>
+                    this._addError(
+                        `Recommendation chunk ${missingChunk} not included in any test paths.`
+                    )
+                );
         }
     }
 
@@ -186,7 +190,9 @@ export class PathCalculator {
                     continue;
                 }
 
-                this._addError(`Could not find question with ID '${nextQuestionId}' for answer ${answer.text} ${answer.id} in ${question.text} ${question.id}`);
+                this._addError(
+                    `Could not find question with ID '${nextQuestionId}' for answer ${answer.text} ${answer.id} in ${question.text} ${question.id}`
+                );
                 answer.nextQuestion = null;
             }
         }
@@ -194,14 +200,13 @@ export class PathCalculator {
 
     /**
      * Adds message to error logger using the section's id.
-     * @param {string} message 
+     * @param {string} message
      */
-    _addError(message){
+    _addError(message) {
         errorLogger.addError({
             id: this.sectionId,
             contentType: "section",
-            message: message
+            message: message,
         });
-
     }
 }

--- a/contentful/export-processor/user-journey/path-part.js
+++ b/contentful/export-processor/user-journey/path-part.js
@@ -16,8 +16,15 @@ export default class PathPart {
      * @param {Question} params.question - The question in this path part
      * @param {Answer} params.answer - The answer selected for this question
      */
-    constructor({ question, answer }){
+    constructor({ question, answer }) {
         this.question = question;
         this.answer = answer;
+    }
+
+    toMinimalOutput() {
+        return {
+            question: this.question.text,
+            answer: this.answer.text,
+        };
     }
 }

--- a/contentful/export-processor/user-journey/user-journey.js
+++ b/contentful/export-processor/user-journey/user-journey.js
@@ -122,10 +122,14 @@ export class UserJourney {
      */
     mapPathToOnlyQuestionAnswerTexts() {
         return this.path.map((pathPart) => {
-            return {
-                question: pathPart.question.text,
-                answer: pathPart.answer.text,
-            };
+            try {
+                return pathPart.toMinimalOutput();
+            } catch (e) {
+                return {
+                    question: pathPart.question.text,
+                    answer: pathPart.answer.text,
+                };
+            }
         });
     }
 

--- a/contentful/export-processor/write-user-journey-paths.js
+++ b/contentful/export-processor/write-user-journey-paths.js
@@ -2,7 +2,12 @@ import fs from "fs";
 // eslint-disable-next-line no-unused-vars
 import DataMapper from "./data-mapper.js";
 import path from "path";
-import { stringify } from "flatted";
+import { stringify } from "#src/helpers/json";
+import { log } from "#src/helpers/log";
+
+/**
+ * @typedef {import("#src/content-types/section").SectionMinimalOutput} SectionMinimalOutput
+ */
 
 /**
  * @param {object} args
@@ -10,61 +15,124 @@ import { stringify } from "flatted";
  * @param {string} args.outputDir - directory to write journey paths to
  * @param {boolean} args.saveAllJourneys - if true saves _all_ user journeys, otherwise writes 1 (or more if needed) to navigate through every question, and 1 per maturity
  */
-export default function writeUserJourneyPaths({ dataMapper, outputDir, saveAllJourneys }) {
-  outputDir = createUserJourneyDirectory(outputDir);
+export default function writeUserJourneyPaths({
+    dataMapper,
+    outputDir,
+    saveAllJourneys,
+}) {
+    log(`Writing all user journey paths`);
 
-  const journeys = mapJourneysToMinimalSectionInfo(dataMapper, saveAllJourneys);
+    outputDir = createUserJourneyDirectory(outputDir);
 
-  saveUserJourneys(journeys, outputDir);
-  saveSubtopicPathsOverview(journeys, outputDir);
+    const journeys = mapJourneysToMinimalSectionInfo(
+        dataMapper,
+        saveAllJourneys
+    );
+
+    saveUserJourneys(journeys, outputDir);
+    saveSubtopicPathsOverview(journeys, outputDir);
+
+    log(`Finished writing all user journey paths`);
 }
 
 /**
- * 
- * @param {DataMapper} dataMapper 
- * @param {boolean} saveAllJourneys 
- * @returns 
+ *
+ * @param {DataMapper} dataMapper
+ * @param {boolean} saveAllJourneys
+ * @returns {SectionMinimalOutput[]}
  */
-const mapJourneysToMinimalSectionInfo = (dataMapper, saveAllJourneys) => dataMapper.mappedSections.map(section => section.toMinimalOutput(saveAllJourneys));
+const mapJourneysToMinimalSectionInfo = (dataMapper, saveAllJourneys) =>
+    dataMapper.mappedSections.map((section) =>
+        section.toMinimalOutput(saveAllJourneys)
+    );
 
+/**
+ *
+ * @param {SectionMinimalOutput[]} journeys
+ * @param {string} outputDir
+ */
 const saveSubtopicPathsOverview = (journeys, outputDir) => {
-  const combined = journeys.map(journey => ({
-    subtopic: journey.section,
-    stats: journey.allPathsStats,
-  }));
+    log(`Writing all subtopic paths overview`, { addBlankLine: false });
 
-  try {
-    fs.writeFileSync(`${outputDir}subtopic-paths-overview.json`, JSON.stringify(combined));
-  }
-  catch (e) {
-    console.error(`Error saving subtopic paths overview`, e);
-  }
-};
-
-const saveUserJourneys = (journeys, outputDir) => {
-  for (const journey of journeys) {
-    const fileName = journey.section + ".json";
-    const filePath = path.join(outputDir, fileName);
+    const combined = journeys.map((journey) => ({
+        subtopic: journey.section,
+        stats: journey.allPathsStats,
+    }));
 
     try {
-      fs.writeFileSync(filePath, JSON.stringify(journey));
+        fs.writeFileSync(
+            `${outputDir}subtopic-paths-overview.json`,
+            stringify(combined)
+        );
+    } catch (e) {
+        console.error(`Error saving subtopic paths overview`, e);
     }
-    catch (e) {
-      console.error(`Error saving user journeys for ${journey.section}. Will try flatted`, e);
-      fs.writeFileSync(filePath, stringify(journey));
-    }
-  }
+
+    log(`Wrote all subtopic paths overview`);
 };
 
-const createUserJourneyDirectory = (outputDir) => {
-  const userJourneyDirectory = path.join(outputDir, "user-journeys");
+/**
+ *
+ * @param {SectionMinimalOutput[]} journeys
+ * @param {string} outputDir
+ */
+const saveUserJourneys = (journeys, outputDir) => {
+    log(`Writing user journey path files`);
+    for (const journey of journeys) {
+        const fileName = journey.section + ".json";
+        const filePath = path.join(outputDir, fileName);
 
-  try {
-    fs.mkdirSync(userJourneyDirectory);
-    return userJourneyDirectory;
-  }
-  catch (e) {
-    console.error(`Error creating user journey directory ${userJourneyDirectory}`, e);
-    return outputDir;
-  }
+        saveUserJourney(journey, filePath);
+    }
+
+    log(`Wrote all user journey paths`);
+};
+
+/**
+ *
+ * @param {SectionMinimalOutput} journey
+ * @param {string} filePath
+ */
+const saveUserJourney = (journey, filePath) => {
+    log(`Writing user journey path file for ${journey.section}`);
+
+    try {
+        fs.writeFileSync(filePath, stringify(journey));
+    } catch (e) {
+        console.error(`Error saving user journeys for ${journey.section}`, e);
+
+        if (!journey.allPossiblePaths || journey.allPossiblePaths.length == 0) {
+            return;
+        }
+        log(
+            `Will clearing all possible paths from subtopic paths and try again`
+        );
+
+        journey.allPossiblePaths = undefined;
+        saveUserJourney(journey, filePath);
+    }
+
+    log(`Wrote user journey path file for ${journey.section}`, {
+        addSeperator: true,
+    });
+};
+
+/**
+ *
+ * @param {string} outputDir
+ * @returns
+ */
+const createUserJourneyDirectory = (outputDir) => {
+    const userJourneyDirectory = path.join(outputDir, "user-journeys");
+
+    try {
+        fs.mkdirSync(userJourneyDirectory);
+        return userJourneyDirectory;
+    } catch (e) {
+        console.error(
+            `Error creating user journey directory ${userJourneyDirectory}`,
+            e
+        );
+        return outputDir;
+    }
 };


### PR DESCRIPTION
## Overview

Fixes a couple of problems with the test suite generation in the export-processor, as well as adding minor things such as more logging outputs, JSDoc comments, etc.

## Changes

### Minor

- [recommendation-section.js](/contentful/export-processor/content-types/recommendation-section.js): modify `getChunksForPath` to only compare chunk IDs for unique chunks

- [section.js](/contentful/export-processor/content-types/section.js): ensure _all paths_ generated for `toMinimalOutput` are "minimalised" - i.e. only return the question text and answer text, not _the actual question and answer objects_

- log.js - logging helper

- json.js - Extract a method what was used for handling JSON.stringify errors caused by too large an object being stringified. This should actually not be needed anymore due to the fix in section.js but kept in just inc ase.

- Logging + JSDOc comments added/fixed in various places

## How to review the PR

Run the test suite generator against master/development/actual environment names/etc. Ensure they all work. Try with exporting all paths too - I think that _should_ work for most if not all subtopics.

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch