### PR TITLE
fix (245585): Allow nulls returned from GetSectionStatuses

### DIFF
--- a/src/Dfe.PlanTech.Domain/CategorySection/CategorySectionRecommendationDto.cs
+++ b/src/Dfe.PlanTech.Domain/CategorySection/CategorySectionRecommendationDto.cs
@@ -10,5 +10,5 @@ public class CategorySectionRecommendationDto
 
     public string? SectionSlug { get; init; }
 
-    public bool Viewed { get; init; }
+    public bool? Viewed { get; init; }
 }

--- a/src/Dfe.PlanTech.Domain/Submissions/Models/SectionStatusDto.cs
+++ b/src/Dfe.PlanTech.Domain/Submissions/Models/SectionStatusDto.cs
@@ -12,5 +12,5 @@ public class SectionStatusDto
 
     public DateTime DateUpdated { get; set; }
 
-    public bool Viewed { get; set; }
+    public bool? Viewed { get; set; }
 }

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/CategorySection/SubtopicRecommendation.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/CategorySection/SubtopicRecommendation.cshtml
@@ -8,7 +8,7 @@
 }
 else if (Model.RecommendationSlug != null)
 {
-    if (!Model.Viewed)
+    if (Model.Viewed == false)
     {
         <task-list-tag colour="@TagColour.Yellow">New</task-list-tag>
     }


### PR DESCRIPTION
## Overview

Addresses ticket [#245585](www.ticket-link.com)

Allowed DTO and related classes to accept NULL values from GetSectionStatuses stored procedure. Changed display logic on Razor page.

## How to review the PR

Follow instructions to reproduce on [ticket](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/245585/) in development branch. Then swap to this branch and check functionality is fixed.

## Checklist

Delete any rows that do not apply to the PR.

- [v] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [v] PR targets development branch
