### PR TITLE
Replace standard Hyphens with non breaking hyphens

### DIFF
--- a/src/Dfe.PlanTech.Application/Extensions/StringExtensions.cs
+++ b/src/Dfe.PlanTech.Application/Extensions/StringExtensions.cs
@@ -16,7 +16,7 @@ public static class StringExtensions
         return $"{destination}{input.AsSpan(1)}";
     }
 
-    public static string? UseNonBreakingHyphenAndHtmlDecode(this string text)
+    public static string? UseNonBreakingHyphenAndHtmlDecode(this string? text)
     {
         if (string.IsNullOrEmpty(text))
         {

--- a/src/Dfe.PlanTech.Application/Extensions/StringExtensions.cs
+++ b/src/Dfe.PlanTech.Application/Extensions/StringExtensions.cs
@@ -1,7 +1,10 @@
+using System.Net;
+
 namespace Dfe.PlanTech;
 
 public static class StringExtensions
 {
+    public const string NonBreakingHyphen = "&#8209;";
     public static string FirstCharToUpper(this string input)
     {
         if (string.IsNullOrEmpty(input))
@@ -11,5 +14,14 @@ public static class StringExtensions
         Span<char> destination = stackalloc char[1];
         input.AsSpan(0, 1).ToUpperInvariant(destination);
         return $"{destination}{input.AsSpan(1)}";
+    }
+
+    public static string? UseNonBreakingHyphenAndHtmlDecode(this string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return text;
+        }
+        return WebUtility.HtmlDecode(text.Replace("-", NonBreakingHyphen));
     }
 }

--- a/src/Dfe.PlanTech.Web/Models/PageViewModel.cs
+++ b/src/Dfe.PlanTech.Web/Models/PageViewModel.cs
@@ -10,7 +10,8 @@ public class PageViewModel
 
     public PageViewModel(Page page, Controller controller, IUser user, ILogger logger, bool displayBlueBanner = true)
     {
-        controller.ViewData["Title"] = System.Net.WebUtility.HtmlDecode(page.Title?.Text) ??
+
+        controller.ViewData["Title"] = StringExtensions.UseNonBreakingHyphenAndHtmlDecode(page.Title?.Text) ??
                                        "Plan Technology For Your School";
         Page = page;
         DisplayBlueBanner = displayBlueBanner;

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/Title.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/Title.cshtml
@@ -1,3 +1,4 @@
+@using Dfe.PlanTech
 @model Dfe.PlanTech.Domain.Content.Models.Title;
 
-<h1 class="govuk-heading-xl">@System.Net.WebUtility.HtmlDecode(Model.Text)</h1>
+<h1 class="govuk-heading-xl">@StringExtensions.UseNonBreakingHyphenAndHtmlDecode(Model.Text)</h1>

--- a/tests/Dfe.PlanTech.Web.UnitTests/Helpers/StringExtensionsTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Helpers/StringExtensionsTests.cs
@@ -4,6 +4,7 @@ namespace Dfe.PlanTech.Web.UnitTests.Helpers
 {
     public class StringExtensionsTests
     {
+        // Just to be clear, the expectedText Hyphens are Non breaking Hyphens and inputText Hyphens are standard
         [Theory]
         [InlineData("Single test-", "Single test‑")]
         [InlineData("Single-test", "Single‑test")]

--- a/tests/Dfe.PlanTech.Web.UnitTests/Helpers/StringExtensionsTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Helpers/StringExtensionsTests.cs
@@ -1,0 +1,21 @@
+﻿using Xunit;
+
+namespace Dfe.PlanTech.Web.UnitTests.Helpers
+{
+    public class StringExtensionsTests
+    {
+        [Theory]
+        [InlineData("Single test-", "Single test‑")]
+        [InlineData("Single-test", "Single‑test")]
+        [InlineData("This is -a-test-", "This is ‑a‑test‑")]
+        [InlineData("This is-a-test", "This is‑a‑test")]
+        [InlineData(null, null)]
+        [InlineData("", "")]
+        public void CheckHyphensConvertedCorrectly(string inputText, string expectedText)
+        {
+            var result = StringExtensions.UseNonBreakingHyphenAndHtmlDecode(inputText);
+
+            Assert.Equal(expectedText, result);
+        }
+    }
+}


### PR DESCRIPTION
Replace hyphens with non breaking hyphens so that they behave the same as full words
Also added unit tests that should cover this and point of failure

Minor
- Replace hyphen functionality in string extensions

Non-functional changes (e.g. documentation)
- unit tests to cover this
