### PR TITLE
test(237003): replace Moq with NSubstitute in C&S unit tests

### DIFF
--- a/tests/Dfe.PlanTech.Web.UnitTests/Content/ContentServiceTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Content/ContentServiceTests.cs
@@ -3,23 +3,23 @@ using Dfe.PlanTech.Domain.Content.Models.ContentSupport.Mapped;
 using Dfe.PlanTech.Domain.Content.Queries;
 using Dfe.PlanTech.Web.Content;
 using FluentAssertions;
-using Moq;
 using Xunit;
+using NSubstitute;
 
 namespace Dfe.PlanTech.Web.UnitTests.Content
 {
     public class ContentServiceTests
     {
-        private readonly Mock<IModelMapper> _mapperMock;
-        private readonly Mock<IGetContentSupportPageQuery> _getContentSupportPageQueryMock;
+        private readonly IModelMapper _mapperMock;
+        private readonly IGetContentSupportPageQuery _getContentSupportPageQueryMock;
 
         public ContentServiceTests()
         {
-            _mapperMock = new Mock<IModelMapper>();
-            _getContentSupportPageQueryMock = new Mock<IGetContentSupportPageQuery>();
+            _mapperMock = Substitute.For<IModelMapper>();
+            _getContentSupportPageQueryMock = Substitute.For<IGetContentSupportPageQuery>();
         }
 
-        private ContentService GetService() => new(_mapperMock.Object, _getContentSupportPageQueryMock.Object);
+        private ContentService GetService() => new(_mapperMock, _getContentSupportPageQueryMock);
 
         [Fact]
         public async Task GetContent_Calls_Query_Once()
@@ -28,25 +28,20 @@ namespace Dfe.PlanTech.Web.UnitTests.Content
             var sut = GetService();
             var contentSupportPage = new ContentSupportPage { Slug = slug };
 
-            _getContentSupportPageQueryMock
-                .Setup(o => o.GetContentSupportPage(slug, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(contentSupportPage);
+            _getContentSupportPageQueryMock.GetContentSupportPage(slug, Arg.Any<CancellationToken>())
+                .Returns(contentSupportPage);
 
             await sut.GetContent(slug);
 
-            _getContentSupportPageQueryMock.Verify(o =>
-                    o.GetContentSupportPage(slug, It.IsAny<CancellationToken>()),
-                Times.Once
-            );
+            await _getContentSupportPageQueryMock.Received(1).GetContentSupportPage(slug, Arg.Any<CancellationToken>());
         }
 
         [Fact]
         public async Task GetContent_EmptyResponse_Returns_Null()
         {
             var slug = "slug1";
-            _getContentSupportPageQueryMock
-                .Setup(o => o.GetContentSupportPage(slug, It.IsAny<CancellationToken>()))
-                .ReturnsAsync((ContentSupportPage?)null);
+            _getContentSupportPageQueryMock.GetContentSupportPage(slug, Arg.Any<CancellationToken>())
+                .Returns((ContentSupportPage?)null);
 
             var sut = GetService();
 
@@ -62,12 +57,11 @@ namespace Dfe.PlanTech.Web.UnitTests.Content
             var expectedPage = new ContentSupportPage { Slug = slug };
             var expectedCsPage = new CsPage { Slug = slug }; // Adjust this mapping as needed
 
-            _getContentSupportPageQueryMock
-                .Setup(o => o.GetContentSupportPage(slug, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(expectedPage);
+            _getContentSupportPageQueryMock.GetContentSupportPage(slug, Arg.Any<CancellationToken>())
+                .Returns(expectedPage);
 
-            _mapperMock.Setup(m => m.MapToCsPage(expectedPage))
-                       .Returns(expectedCsPage);
+            _mapperMock.MapToCsPage(expectedPage)
+                .Returns(expectedCsPage);
 
             var sut = GetService();
             var result = await sut.GetContent(slug);

--- a/tests/Dfe.PlanTech.Web.UnitTests/Content/ContentServiceTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Content/ContentServiceTests.cs
@@ -3,8 +3,8 @@ using Dfe.PlanTech.Domain.Content.Models.ContentSupport.Mapped;
 using Dfe.PlanTech.Domain.Content.Queries;
 using Dfe.PlanTech.Web.Content;
 using FluentAssertions;
-using Xunit;
 using NSubstitute;
+using Xunit;
 
 namespace Dfe.PlanTech.Web.UnitTests.Content
 {

--- a/tests/Dfe.PlanTech.Web.UnitTests/Content/ModelMapperTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Content/ModelMapperTests.cs
@@ -124,7 +124,7 @@ public class ModelMapperTests
     [Fact]
     public void Unknown_Returns_Unknown()
     {
-        var testValue = Arg.Any<string>();
+        var testValue = "Any string value";
 
         var sut = GetService();
         var result = sut.ConvertToRichTextNodeType(testValue);

--- a/tests/Dfe.PlanTech.Web.UnitTests/Content/ModelMapperTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Content/ModelMapperTests.cs
@@ -6,7 +6,7 @@ using Dfe.PlanTech.Domain.Content.Models.ContentSupport.Mapped.Types;
 using Dfe.PlanTech.Web.Configuration;
 using Dfe.PlanTech.Web.Content;
 using FluentAssertions;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace Dfe.PlanTech.Web.UnitTests.Content;
@@ -124,7 +124,7 @@ public class ModelMapperTests
     [Fact]
     public void Unknown_Returns_Unknown()
     {
-        var testValue = It.IsAny<string>();
+        var testValue = Arg.Any<string>();
 
         var sut = GetService();
         var result = sut.ConvertToRichTextNodeType(testValue);

--- a/tests/Dfe.PlanTech.Web.UnitTests/Content/ModelMapperTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Content/ModelMapperTests.cs
@@ -6,7 +6,6 @@ using Dfe.PlanTech.Domain.Content.Models.ContentSupport.Mapped.Types;
 using Dfe.PlanTech.Web.Configuration;
 using Dfe.PlanTech.Web.Content;
 using FluentAssertions;
-using NSubstitute;
 using Xunit;
 
 namespace Dfe.PlanTech.Web.UnitTests.Content;

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/ContentControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/ContentControllerTests.cs
@@ -79,7 +79,7 @@ public class ContentControllerTests
     {
         var slug = "slug";
 
-        _contentServiceMock.GetContent(Arg.Any<String>(), Arg.Any<CancellationToken>()).Returns(Task.FromException(new Exception("An exception occurred loading content")));
+        _contentServiceMock.GetContent(Arg.Any<String>(), Arg.Any<CancellationToken>()).Returns(Task.FromException<CsPage?>(new Exception("An exception occurred loading content")));
 
         var sut = GetController();
 

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/ContentControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/ContentControllerTests.cs
@@ -79,7 +79,7 @@ public class ContentControllerTests
     {
         var slug = "slug";
 
-        _contentServiceMock.GetContent(Arg.Any<String>(), Arg.Any<CancellationToken>())
+        _contentServiceMock.GetContent(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(_ => Task.FromException<CsPage?>(new Exception("An exception occurred loading content")));
 
         var sut = GetController();
@@ -92,9 +92,9 @@ public class ContentControllerTests
         _loggerMock.Received(1).Log(
             LogLevel.Error,
             Arg.Any<EventId>(),
-            Arg.Is<Object>(o => o.ToString() != null && o.ToString()!.Equals($"Error loading C&S content page {slug}")),
+            Arg.Is<object>(o => o.ToString() != null && o.ToString()!.Equals($"Error loading C&S content page {slug}")),
             Arg.Any<Exception>(),
-            Arg.Any<Func<Object, Exception?, string>>()
+            Arg.Any<Func<object, Exception?, string>>()
         );
     }
 

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/ContentControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/ContentControllerTests.cs
@@ -4,9 +4,9 @@ using Dfe.PlanTech.Web.Controllers;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using Xunit;
 using NSubstitute;
 using NSubstitute.ReceivedExtensions;
+using Xunit;
 
 namespace Dfe.ContentSupport.Web.Tests.Controllers;
 

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/ContentControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/ContentControllerTests.cs
@@ -4,19 +4,20 @@ using Dfe.PlanTech.Web.Controllers;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using Moq;
 using Xunit;
+using NSubstitute;
+using NSubstitute.ReceivedExtensions;
 
 namespace Dfe.ContentSupport.Web.Tests.Controllers;
 
 public class ContentControllerTests
 {
-    private readonly Mock<ILogger<ContentController>> _loggerMock = new();
-    private readonly Mock<IContentService> _contentServiceMock = new();
+    private readonly ILogger<ContentController> _loggerMock = Substitute.For<ILogger<ContentController>>();
+    private readonly IContentService _contentServiceMock = Substitute.For<IContentService>();
 
     private ContentController GetController()
     {
-        return new ContentController(_contentServiceMock.Object, new LayoutService(), _loggerMock.Object);
+        return new ContentController(_contentServiceMock, new LayoutService(), _loggerMock);
     }
 
     [Fact]
@@ -29,14 +30,13 @@ public class ContentControllerTests
         result.Should().BeOfType<RedirectToActionResult>();
         (result as RedirectToActionResult)!.ActionName.Should().BeEquivalentTo(PagesController.NotFoundPage);
 
-        _loggerMock.Verify(
-            x => x.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((o, t) => o.ToString() != null && o.ToString()!.StartsWith($"No slug received for C&S {nameof(ContentController)} {nameof(sut.Index)}")),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
+        _loggerMock.Received(1).Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Is<Object>(o => o.ToString() != null && o.ToString()!.StartsWith($"No slug received for C&S {nameof(ContentController)} {nameof(sut.Index)}")),
+            Arg.Any<Exception>(),
+            Arg.Any<Func<Object, Exception?, string>>()
+        );
     }
 
     [Fact]
@@ -47,15 +47,15 @@ public class ContentControllerTests
 
         await sut.Index(dummySlug, "", null, default);
 
-        _contentServiceMock.Verify(o => o.GetContent(dummySlug, default), Times.Once);
+        await _contentServiceMock.Received(1).GetContent(dummySlug, default);
     }
 
     [Fact]
     public async Task Index_NullResponse_ReturnsErrorAction()
     {
         var slug = "slug";
-        _contentServiceMock.Setup(o => o.GetContent(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((CsPage?)null);
+
+        _contentServiceMock.GetContent(Arg.Any<String>(), Arg.Any<CancellationToken>()).Returns((CsPage?)null);
 
         var sut = GetController();
 
@@ -64,21 +64,22 @@ public class ContentControllerTests
         result.Should().BeOfType<RedirectToActionResult>();
         (result as RedirectToActionResult)!.ActionName.Should().BeEquivalentTo(PagesController.NotFoundPage);
 
-        _loggerMock.Verify(x => x.Log(
-        LogLevel.Error,
-        It.IsAny<EventId>(),
-        It.Is<It.IsAnyType>((o, t) => o.ToString() != null && o.ToString()!.Equals($"Failed to load content for C&S page {slug}; no content received.")),
-        It.IsAny<Exception>(),
-        It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-    Times.Once);
+
+        _loggerMock.Received(1).Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Is<Object>(o => o.ToString() != null && o.ToString()!.Equals($"Failed to load content for C&S page {slug}; no content received.")),
+            Arg.Any<Exception>(),
+            Arg.Any<Func<Object, Exception?, string>>()
+        );
     }
 
     [Fact]
     public async Task Index_ExceptionThrown_ReturnsErrorAction()
     {
         var slug = "slug";
-        _contentServiceMock.Setup(o => o.GetContent(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new Exception("An exception occurred loading content"));
+
+        _contentServiceMock.GetContent(Arg.Any<String>(), Arg.Any<CancellationToken>()).Returns(Task.FromException(new Exception("An exception occurred loading content")));
 
         var sut = GetController();
 
@@ -87,20 +88,19 @@ public class ContentControllerTests
         result.Should().BeOfType<RedirectToActionResult>();
         (result as RedirectToActionResult)!.ActionName.Should().BeEquivalentTo("error");
 
-        _loggerMock.Verify(x => x.Log(
-        LogLevel.Error,
-        It.IsAny<EventId>(),
-        It.Is<It.IsAnyType>((o, t) => o.ToString() != null && o.ToString()!.Equals($"Error loading C&S content page {slug}")),
-        It.IsAny<Exception>(),
-        It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-    Times.Once);
+        _loggerMock.Received(1).Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Is<Object>(o => o.ToString() != null && o.ToString()!.Equals($"Error loading C&S content page {slug}")),
+            Arg.Any<Exception>(),
+            Arg.Any<Func<Object, Exception?, string>>()
+        );
     }
 
     [Fact]
     public async Task Index_WithSlug_Returns_View()
     {
-        _contentServiceMock.Setup(o => o.GetContent(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new CsPage());
+        _contentServiceMock.GetContent(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(new CsPage());
 
         var sut = GetController();
         var result = await sut.Index("slug1", "", null, default);

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/ContentControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/ContentControllerTests.cs
@@ -79,7 +79,8 @@ public class ContentControllerTests
     {
         var slug = "slug";
 
-        _contentServiceMock.GetContent(Arg.Any<String>(), Arg.Any<CancellationToken>()).Returns(Task.FromException<CsPage?>(new Exception("An exception occurred loading content")));
+        _contentServiceMock.GetContent(Arg.Any<String>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromException<CsPage?>(new Exception("An exception occurred loading content")));
 
         var sut = GetController();
 

--- a/tests/Dfe.PlanTech.Web.UnitTests/Dfe.PlanTech.Web.UnitTests.csproj
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Dfe.PlanTech.Web.UnitTests.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Dfe.PlanTech.Infrastructure.Data\Dfe.PlanTech.Infrastructure.Data.csproj"/>
-        <ProjectReference Include="..\..\src\Dfe.PlanTech.Web\Dfe.PlanTech.Web.csproj"/>
-        <ProjectReference Include="..\Dfe.PlanTech.UnitTests.Shared\Dfe.PlanTech.UnitTests.Shared.csproj"/>
+        <ProjectReference Include="..\..\src\Dfe.PlanTech.Infrastructure.Data\Dfe.PlanTech.Infrastructure.Data.csproj" />
+        <ProjectReference Include="..\..\src\Dfe.PlanTech.Web\Dfe.PlanTech.Web.csproj" />
+        <ProjectReference Include="..\Dfe.PlanTech.UnitTests.Shared\Dfe.PlanTech.UnitTests.Shared.csproj" />
     </ItemGroup>
 
     <ItemGroup>
@@ -11,11 +11,10 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
-        <PackageReference Include="Moq" Version="4.20.70"/>
-        <PackageReference Include="FluentAssertions" Version="7.0.0-alpha.3"/>
-        <PackageReference Include="NSubstitute" Version="5.3.0"/>
-        <PackageReference Include="xunit" Version="2.9.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageReference Include="FluentAssertions" Version="7.0.0-alpha.3" />
+        <PackageReference Include="NSubstitute" Version="5.3.0" />
+        <PackageReference Include="xunit" Version="2.9.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Overview

Addresses ticket [#237003](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/237003)

Switch from Moq to NSubstitute for C&S Unit tests, removed package references.

## How to review the PR

Run tests and app, check nothing failing!

## Checklist

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch