### PR TITLE
test(255445) - Added E2E tests for accordion & attachment component

### DIFF
--- a/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/content-support.cy.js
+++ b/tests/Dfe.PlanTech.Web.E2ETests/cypress/e2e/pages/content-support.cy.js
@@ -1,0 +1,39 @@
+describe("Content & Support Page Richtext components", () => {
+    const url = "/information-asset-register";
+
+    beforeEach(() => {
+        cy.visit(url);
+    });
+
+    it("renders attachment component", () => {
+        cy.get(".attachment").should("exist");
+        cy.get(".attachment-link").should("exist").and('have.attr', 'href');
+    });
+
+    it("renders accordion components", () => {
+        cy.get(".govuk-accordion").should("exist");
+        cy.get(".govuk-accordion__controls").should("exist").contains("span", "Show all sections");
+        cy.get(".govuk-accordion__section .govuk-body").should("have.length", 2);
+        cy.get(".govuk-accordion__section-toggle-text").should("have.length", 2);
+    });
+
+    it('hides section content by default', () => {
+        cy.get('.govuk-accordion__section-content').each($el => {
+            cy.wrap($el).should('have.attr', 'hidden');
+        });
+    });
+
+    it('expands and collapses a section', () => {
+        cy.get('.govuk-accordion__section-button').first().as('firstButton');
+        cy.get('.govuk-accordion__section-content').first().as('firstContent');
+
+        //expand
+        cy.get('@firstButton').click();
+        cy.get('@firstContent').should('not.have.attr', 'hidden');
+
+        //collapse
+        cy.get('@firstButton').click();
+        cy.get('@firstContent').should('have.attr', 'hidden');
+    });
+
+});


### PR DESCRIPTION
## Overview

Addresses ticket [#255445](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/255445)

Added some E2E tests for the accordion & attachment components used in Content & Support. These tests will eventually be replaced once we begin writing the new e2e testing solution, however it gives us good coverage for now.

## Changes

### Minor

- content-support.cy.js file which holds accordion & attachment component tests.

## How to review the PR

Run the E2E tests locally or check this PR test output to see if they pass.

## Checklist

Delete any rows that do not apply to the PR.

- [x ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [x] E2E tests have been added/updated
