### PR TITLE
Update Ubuntu version for E2E tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -80,7 +80,7 @@ jobs:
 
   run-tests:
     name: Run E2E Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [clear-db]
     env:
       PROJECT_PATH: ./src/Dfe.PlanTech.Web/Dfe.PlanTech.Web.csproj


### PR DESCRIPTION
Upgrade Ubuntu image used for E2E tests from 20.04 to 22.04.