### PR TITLE
v2.19.0 - Only display back-button on non-mat pages. 

### DIFF
--- a/src/Dfe.PlanTech.Web/Views/Recommendations/Header.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/Header.cshtml
@@ -3,8 +3,8 @@
 <section class="dfe-page-header">
     <div class="govuk-width-container">
         <div class="govuk-grid-row">
+            <partial name="BetaHeader" />
             <div class="govuk-grid-column-two-thirds">
-                <partial name="BetaHeader" />
                 <div>
                     <div class="recommendation-piece-header">
                         <h1 class="govuk-heading-xl govuk-!-margin-top-8">@Model.HeaderText</h1>

--- a/src/Dfe.PlanTech.Web/Views/Shared/_Layout.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/_Layout.cshtml
@@ -26,9 +26,8 @@
 		<section class="dfe-page-header">
 			<div class="govuk-width-container">
 				<div class="govuk-grid-row">
-					<partial name="BetaHeader" />
-					@await RenderSectionAsync("DfePageHeaderOuter", required: false)
-					@if (IsSectionDefined("DfePageHeaderInnerFullWidth"))
+                    <partial name="BetaHeader" />
+                    @if (IsSectionDefined("DfePageHeaderInnerFullWidth"))
 					{
 						<div class="dfe-page-header-inner">
 							@await RenderSectionAsync("DfePageHeaderInnerFullWidth", required: false)
@@ -36,13 +35,14 @@
 					}
 					else if (IsSectionDefined("DfePageHeaderInner"))
 					{
-						<div class="govuk-grid-column-two-thirds">
-							<div class="dfe-page-header-inner">
-								@await RenderSectionAsync("DfePageHeaderInner", required: false)
-							</div>
-						</div>
+                        <div class="govuk-grid-column-two-thirds">
+                            @await RenderSectionAsync("DfePageHeaderOuter", required: false)
+                            <div class="dfe-page-header-inner">
+                                @await RenderSectionAsync("DfePageHeaderInner", required: false)
+                            </div>
+                        </div>
 					}
-					
+
 				</div>
 			</div>
 		</section>


### PR DESCRIPTION
Only display back button non-mat pages.
Moved beta partial outside of the div in recommendations/header.cshtml.