### PR TITLE
fix (258218): stop groups dashboard section name from wrapping when not a link

### DIFF
--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/GroupsDashboard/GroupsSubtopics.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/GroupsDashboard/GroupsSubtopics.cshtml
@@ -28,7 +28,7 @@
                     }
                     else
                     {
-                        <div class="govuk-summary-list__key govuk-!-font-weight-regular">@groupsCategorySectionDtoItem.Name</div>
+                        <div class="govuk-summary-list__key govuk-!-font-weight-regular groups-list-key">@groupsCategorySectionDtoItem.Name</div>
                     }
                 <div class="govuk-summary-list__value govuk-!-text-align-right groups-list-tag" id="@groupsCategorySectionDtoItem.Name">
                     <task-list-tag colour=@groupsCategorySectionDtoItem.Tag.Colour>


### PR DESCRIPTION
## Overview

Addresses ticket [#258218](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/258218)

Section names on Groups Dashboard are wrapping inappropriately when the 

## Changes

### Minor

- Applied css override to non-link section names

## How to review the PR

Log in as MAT user, select Miscellaneous from the school selection (this should have no submissions for Digital technology registers), check that 'Digital technology registers' in the dashboard table does not wrap.

## Release requirements

None

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch