### PR TITLE
fix(258447): F&M roles print link

### DIFF
--- a/src/Dfe.PlanTech.Web/Views/Groups/Print.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Groups/Print.cshtml
@@ -3,6 +3,6 @@
 
 <div class="govuk-!-margin-bottom-6 govuk-!-margin-top-6">
     <p class="govuk-body">
-        <a class="govuk-link" href=" @Url.Action("GetRecommendationsPrintView", "Groups", new { schoolId = Model.SelectedEstablishmentId, schoolName = Model.SelectedEstablishmentName, sectionSlug = Model.SectionName.Slugify() })">View and print all recommendations</a>
+        <a class="govuk-link" href=" @Url.Action("GetRecommendationsPrintView", "Groups", new { schoolId = Model.SelectedEstablishmentId, schoolName = Model.SelectedEstablishmentName, sectionSlug = Model.Slug })">View and print all recommendations</a>
     </p>
 </div>


### PR DESCRIPTION
## Overview

Addresses ticket [#258447](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/258447)

Fix for 'View and print all recommendations' link in the groups recommendations view for the F&M Roles section (only this section had the bug because it is the one with a difference between the slugified section name and the section slug).

## Changes

### Minor

- Change to the slug being passed to the controller action

## How to review the PR

Log in as MAT user, select Community School (this should have the F&M Roles section already completed), click Roles to view the recommendations and click the 'View and print all recommendations' link. Should show the print page and not error. Check another section to confirm that others are unaffected.

## Release requirements

None

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch