### PR TITLE
256578 Added self assessment card view implementation

### DIFF
--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/CategorySection/SubtopicRecommendation.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/CategorySection/SubtopicRecommendation.cshtml
@@ -1,21 +1,13 @@
-@using Dfe.PlanTech.Domain.Constants
-@model Dfe.PlanTech.Domain.CategorySection.CategorySectionRecommendationDto
+@model (string Name, string? SectionSlug, string? RecommendationSlug, string? ErrorMessage)
 
+@if (!string.IsNullOrWhiteSpace(Model.ErrorMessage))
+{
+    <govuk-error-message>@Model.ErrorMessage</govuk-error-message>
+}
 
-@if (Model.NoRecommendationFoundErrorMessage != null)
-{
-    <govuk-error-message>@Model.NoRecommendationFoundErrorMessage</govuk-error-message>
-}
-else if (Model.RecommendationSlug != null)
-{
-    if (Model.Viewed == false)
-    {
-        <task-list-tag colour="@TagColour.Yellow">New</task-list-tag>
-    }
-    <govuk-button-link
-        asp-route="GetRecommendation"
-        asp-route-sectionSlug="@Model.SectionSlug"
-        asp-route-recommendationSlug="@Model.RecommendationSlug">
-        View recommendation
-    </govuk-button-link>
-}
+<a asp-route="GetRecommendation"
+   asp-route-sectionSlug="@Model.SectionSlug"
+   asp-route-recommendationSlug="@Model.RecommendationSlug"
+   class="govuk-link govuk-link--no-visited-state dfe-card-link--header">
+    @Model.Name
+</a>

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/CategorySection/Subtopics.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/CategorySection/Subtopics.cshtml
@@ -1,35 +1,73 @@
+@using Dfe.PlanTech.Domain.CategorySection
 @using Dfe.PlanTech.Web.TagHelpers.TaskList
 @using GovUk.Frontend.AspNetCore.TagHelpers
 @using AnchorTagHelper = Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper
 @model CategorySectionViewComponentViewModel
 
-<dl class="govuk-summary-list dfe-self-assessment-list">
+<dl class="dfe-grid-container govuk-!-width-two-thirds">
     @foreach (var categorySectionDtoItem in Model.CategorySectionDto)
     {
-        <div class="govuk-summary-list__row">
-            @if (categorySectionDtoItem.Slug != null)
-            {
-                <dt class="govuk-summary-list__key govuk-!-font-weight-regular">
-                    <a asp-controller="Pages" asp-action="GetByRoute" asp-route-route="@categorySectionDtoItem.Slug"
-                       class="govuk-link">
-                        @categorySectionDtoItem.Name
-                    </a>
-                </dt>
-                <dd class="govuk-summary-list__value govuk-!-text-align-left">
-                    <task-list-tag colour=@categorySectionDtoItem.Tag.Colour>
-                        @categorySectionDtoItem.Tag.Text
-                    </task-list-tag>
-                </dd>
-            }
-            else
-            {
-                <dt class="govuk-summary-list__key">
-                    <govuk-error-message>@categorySectionDtoItem.ErrorMessage</govuk-error-message>
-                </dt>
-            }
-            <dd class="govuk-summary-list__value govuk-!-text-align-right">
-                <partial name="Components/CategorySection/SubtopicRecommendation" model="@categorySectionDtoItem.Recommendation"/>
-            </dd>
+        <div class="dfe-card">
+            <div class="dfe-card-container">
+                @if (categorySectionDtoItem.Slug != null)
+                {
+                    string statusText = "Start Self-Assessment";
+                    string pagesController = "Pages";
+                    string action = "GetByRoute";
+                    string routeName = categorySectionDtoItem.Slug;
+                    string? sectionSlug = null;
+                    string? recommendationSlug = null;
+
+                    if (categorySectionDtoItem.ProgressStatus == SectionProgressStatus.StartedNeverCompleted)
+                    {
+                        statusText = "Continue Self-Assessment";
+                    }
+                    else if
+                    (categorySectionDtoItem.ProgressStatus == SectionProgressStatus.InProgress ||
+                     categorySectionDtoItem.ProgressStatus == SectionProgressStatus.CompletedStartedNew ||
+                     categorySectionDtoItem.ProgressStatus == SectionProgressStatus.Completed)
+                    {
+                        statusText = "View Recommendations";
+                        pagesController = string.Empty;
+                        action = string.Empty;
+                        routeName = string.Empty;
+
+                        if (categorySectionDtoItem.Recommendation != null)
+                        {
+                            sectionSlug = categorySectionDtoItem.Recommendation.SectionSlug;
+                            recommendationSlug = categorySectionDtoItem.Recommendation.RecommendationSlug;
+                        }
+                    }
+
+                    <h3 class="govuk-heading-m">
+                        @if (pagesController != "")
+                        {
+                            <a asp-controller="@pagesController" asp-action="@action" asp-route-route="@routeName"
+                               class="govuk-link govuk-link--no-visited-state dfe-card-link--header">
+                                @categorySectionDtoItem.Name
+                            </a>
+                        }
+                        else
+                        {
+                            @await Html.PartialAsync("Components/CategorySection/SubtopicRecommendation", (
+                                     categorySectionDtoItem.Name,
+                                     sectionSlug,
+                                     recommendationSlug,
+                                     categorySectionDtoItem.Recommendation?.NoRecommendationFoundErrorMessage
+                            ))
+                        }
+                    </h3>
+                    <p class="govuk-body-s">
+                        @statusText
+                    </p>
+                }
+                else
+                {
+                    <dt class="govuk-summary-list__key">
+                        <govuk-error-message>@categorySectionDtoItem.ErrorMessage</govuk-error-message>
+                    </dt>
+                }
+            </div>
         </div>
     }
 </dl>

--- a/tests/Dfe.PlanTech.Web.UnitTests/ViewComponents/CategorySectionViewComponentTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/ViewComponents/CategorySectionViewComponentTests.cs
@@ -1,3 +1,4 @@
+using Dfe.PlanTech.Domain.CategorySection;
 using Dfe.PlanTech.Domain.Content.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Domain.Interfaces;
@@ -210,9 +211,9 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
         }
 
         [Theory]
-        [InlineData("2015/10/15", "last completed 15 Oct 2015")]
-        [InlineData("2015/10/16 12:13:00", "last completed 1:13pm")] // British summer time GMT + 1
-        public async Task Returns_CategorySectionInfo_If_Slug_Exists_And_SectionIsCompleted(string utcTime, string expectedBadge)
+        [InlineData("2015/10/15")]
+        [InlineData("2015/10/16 12:13:00")] // British summer time GMT + 1
+        public async Task Returns_CategorySectionInfo_If_Slug_Exists_And_SectionIsCompleted(string utcTime)
         {
             _systemTime.Today.Returns(_ => new DateTime(2015, 10, 16, 0, 0, 0, DateTimeKind.Utc));
             _category.SectionStatuses.Add(new SectionStatusDto()
@@ -251,15 +252,58 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
 
             Assert.Equal("section-1", categorySectionDto.Slug);
             Assert.Equal("Test Section 1", categorySectionDto.Name);
-            Assert.Equal("grey", categorySectionDto.Tag.Colour);
-            Assert.Equal(expectedBadge, categorySectionDto.Tag.Text);
             Assert.Null(categorySectionDto.ErrorMessage);
         }
 
         [Theory]
-        [InlineData("2015/03/05", "in progress 5 Mar 2015")]
-        [InlineData("2015/03/06 10:13:00", "in progress 10:13am")] // GMT
-        public async Task Returns_CategorySelectionInfo_If_Slug_Exists_And_SectionIsNotCompleted(string utcTime, string expectedBadge)
+        [InlineData("2015/10/15")]
+        [InlineData("2015/10/16 12:13:00")] // British summer time GMT + 1
+        public async Task Returns_CategorySectionStatus_If_Slug_Exists_And_SectionIsCompleted(string utcTime)
+        {
+            _systemTime.Today.Returns(_ => new DateTime(2015, 10, 16, 0, 0, 0, DateTimeKind.Utc));
+            _category.SectionStatuses.Add(new SectionStatusDto()
+            {
+                SectionId = "Section1",
+                Completed = true,
+                DateUpdated = DateTime.Parse(utcTime),
+            });
+
+            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sections).Returns([.. _category.SectionStatuses]);
+
+            var result = await _categorySectionViewComponent.InvokeAsync(_category) as ViewViewComponentResult;
+
+            Assert.NotNull(result);
+            Assert.NotNull(result.ViewData);
+
+            var model = result.ViewData.Model;
+            Assert.NotNull(model);
+
+            var unboxed = model as CategorySectionViewComponentViewModel;
+            Assert.NotNull(unboxed);
+
+            Assert.Equal(1, unboxed.CompletedSectionCount);
+            Assert.Equal(1, unboxed.TotalSectionCount);
+
+            var categorySectionDtoList = unboxed.CategorySectionDto;
+
+            Assert.NotNull(categorySectionDtoList);
+
+            categorySectionDtoList = categorySectionDtoList.ToList();
+            Assert.NotEmpty(categorySectionDtoList);
+
+            var categorySectionDto = categorySectionDtoList.FirstOrDefault();
+
+            Assert.NotNull(categorySectionDto);
+
+            Assert.Equal("section-1", categorySectionDto.Slug);
+            Assert.Equal(SectionProgressStatus.Completed, categorySectionDto.ProgressStatus);
+            Assert.Null(categorySectionDto.ErrorMessage);
+        }
+
+        [Theory]
+        [InlineData("2015/03/05")]
+        [InlineData("2015/03/06 10:13:00")] // GMT
+        public async Task Returns_CategorySelectionInfo_If_Slug_Exists_And_SectionIsNotCompleted(string utcTime)
         {
             _systemTime.Today.Returns(_ => new DateTime(2015, 3, 6, 0, 0, 0, DateTimeKind.Utc));
             _category.Completed = 0;
@@ -300,8 +344,53 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
 
             Assert.Equal("section-1", categorySectionDto.Slug);
             Assert.Equal("Test Section 1", categorySectionDto.Name);
-            Assert.Equal("grey", categorySectionDto.Tag.Colour);
-            Assert.Equal(expectedBadge, categorySectionDto.Tag.Text);
+            Assert.Null(categorySectionDto.ErrorMessage);
+        }
+
+        [Theory]
+        [InlineData("2015/03/05")]
+        [InlineData("2015/03/06 10:13:00")] // GMT
+        public async Task Returns_CategorySelectionStatus_If_Slug_Exists_And_SectionIsStartedNeverCompleted(string utcTime)
+        {
+            _systemTime.Today.Returns(_ => new DateTime(2015, 3, 6, 0, 0, 0, DateTimeKind.Utc));
+            _category.Completed = 0;
+
+            _category.SectionStatuses.Add(new SectionStatusDto()
+            {
+                SectionId = "Section1",
+                Completed = false,
+                DateUpdated = DateTime.Parse(utcTime)
+            });
+
+            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sections).Returns([.. _category.SectionStatuses]);
+
+            var result = await _categorySectionViewComponent.InvokeAsync(_category) as ViewViewComponentResult;
+
+            Assert.NotNull(result);
+            Assert.NotNull(result.ViewData);
+
+            var model = result.ViewData.Model;
+            Assert.NotNull(model);
+
+            var unboxed = model as CategorySectionViewComponentViewModel;
+            Assert.NotNull(unboxed);
+
+            Assert.Equal(0, unboxed.CompletedSectionCount);
+            Assert.Equal(1, unboxed.TotalSectionCount);
+
+            var categorySectionDtoList = unboxed.CategorySectionDto;
+
+            Assert.NotNull(categorySectionDtoList);
+
+            categorySectionDtoList = categorySectionDtoList.ToList();
+            Assert.NotEmpty(categorySectionDtoList);
+
+            var categorySectionDto = categorySectionDtoList.FirstOrDefault();
+
+            Assert.NotNull(categorySectionDto);
+
+            Assert.Equal("section-1", categorySectionDto.Slug);
+            Assert.Equal(SectionProgressStatus.StartedNeverCompleted, categorySectionDto.ProgressStatus);
             Assert.Null(categorySectionDto.ErrorMessage);
         }
 
@@ -339,8 +428,89 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
 
             Assert.Equal("section-1", categorySectionDto.Slug);
             Assert.Equal("Test Section 1", categorySectionDto.Name);
-            Assert.Equal("grey", categorySectionDto.Tag.Colour);
-            Assert.Equal("not started", categorySectionDto.Tag.Text);
+            Assert.Null(categorySectionDto.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task Returns_CategorySelectionStatus_If_Section_IsNotStarted()
+        {
+            _category.Completed = 0;
+
+            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sections).Returns([.. _category.SectionStatuses]);
+
+            var result = await _categorySectionViewComponent.InvokeAsync(_category) as ViewViewComponentResult;
+
+            Assert.NotNull(result);
+            Assert.NotNull(result.ViewData);
+
+            var model = result.ViewData.Model;
+            Assert.NotNull(model);
+
+            var unboxed = model as CategorySectionViewComponentViewModel;
+            Assert.NotNull(unboxed);
+
+            Assert.Equal(0, unboxed.CompletedSectionCount);
+            Assert.Equal(1, unboxed.TotalSectionCount);
+
+            var categorySectionDtoList = unboxed.CategorySectionDto;
+
+            Assert.NotNull(categorySectionDtoList);
+
+            categorySectionDtoList = categorySectionDtoList.ToList();
+            Assert.NotEmpty(categorySectionDtoList);
+
+            var categorySectionDto = categorySectionDtoList.FirstOrDefault();
+
+            Assert.NotNull(categorySectionDto);
+
+            Assert.Equal("section-1", categorySectionDto.Slug);
+            Assert.Equal(SectionProgressStatus.NotStarted, categorySectionDto.ProgressStatus);
+            Assert.Null(categorySectionDto.ErrorMessage);
+        }
+
+        [Theory]
+        [InlineData("2015/10/15")]
+        [InlineData("2015/10/16 12:13:00")] // British summer time GMT + 1
+        public async Task Returns_CategorySelectionStatus_If_Section_IsCompletedAndStartedNew(string utcTime)
+        {
+            _systemTime.Today.Returns(_ => new DateTime(2015, 10, 16, 0, 0, 0, DateTimeKind.Utc));
+            _category.SectionStatuses.Add(new SectionStatusDto()
+            {
+                SectionId = "Section1",
+                Completed = false,
+                LastCompletionDate = DateTime.Parse(utcTime),
+                DateUpdated = DateTime.Parse(utcTime),
+            });
+
+            _getSubmissionStatusesQuery.GetSectionSubmissionStatuses(_category.Sections).Returns([.. _category.SectionStatuses]);
+
+            var result = await _categorySectionViewComponent.InvokeAsync(_category) as ViewViewComponentResult;
+
+            Assert.NotNull(result);
+            Assert.NotNull(result.ViewData);
+
+            var model = result.ViewData.Model;
+            Assert.NotNull(model);
+
+            var unboxed = model as CategorySectionViewComponentViewModel;
+            Assert.NotNull(unboxed);
+
+            Assert.Equal(0, unboxed.CompletedSectionCount);
+            Assert.Equal(1, unboxed.TotalSectionCount);
+
+            var categorySectionDtoList = unboxed.CategorySectionDto;
+
+            Assert.NotNull(categorySectionDtoList);
+
+            categorySectionDtoList = categorySectionDtoList.ToList();
+            Assert.NotEmpty(categorySectionDtoList);
+
+            var categorySectionDto = categorySectionDtoList.FirstOrDefault();
+
+            Assert.NotNull(categorySectionDto);
+
+            Assert.Equal("section-1", categorySectionDto.Slug);
+            Assert.Equal(SectionProgressStatus.CompletedStartedNew, categorySectionDto.ProgressStatus);
             Assert.Null(categorySectionDto.ErrorMessage);
         }
 
@@ -392,8 +562,6 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
 
             Assert.Null(categorySectionDto.Slug);
             Assert.Equal("Test Section 1", categorySectionDto.Name);
-            Assert.Null(categorySectionDto.Tag.Colour);
-            Assert.Null(categorySectionDto.Tag.Text);
             Assert.NotNull(categorySectionDto.ErrorMessage);
             Assert.Equal("Test Section 1 unavailable", categorySectionDto.ErrorMessage);
         }
@@ -429,8 +597,6 @@ namespace Dfe.PlanTech.Web.UnitTests.ViewComponents
 
             Assert.Equal("section-1", categorySectionDto.Slug);
             Assert.Equal("Test Section 1", categorySectionDto.Name);
-            Assert.Equal("red", categorySectionDto.Tag.Colour);
-            Assert.Equal("unable to retrieve status", categorySectionDto.Tag.Text);
             Assert.Null(categorySectionDto.ErrorMessage);
         }
 


### PR DESCRIPTION
## Overview

Added card design to self-assessment page with dynamic routing to relevant pages depending on SA status

[256578](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/256578)

Added card design implementation to landing page

The design for the ticket is based on:
https://plantech.herokuapp.com/sprint14/landing

## Changes
- CategorySectionDto status checking
- Suptopics.cshtml required card classes
- SubtopicRecomendations.cshtml partial changes

## How to review the PR

Smoke test and check routing goes to where expected (routing will change with upcoming home journey tickets)

## Release requirements

N/A

## Additional notes

257799 home journey branch will hold new feature changes

## Checklist

Delete any rows that do not apply to the PR.

- [ x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch
- [ x] Unit tests have been added/updated
- [ ] E2E tests have been added/updated
- [ ] GitHub workflows/actions have been added/updated
- [ ] Terraform has been updated
- [ ] Documentation has been updated where relevant
- [ ] Any Key Vault secrets have been added to the development Key Vault
