### PR TITLE
257392 Add continue self-assessment route (skip interstitial page)

### DIFF
--- a/src/Dfe.PlanTech.Domain/CategorySection/CategorySectionDto.cs
+++ b/src/Dfe.PlanTech.Domain/CategorySection/CategorySectionDto.cs
@@ -22,6 +22,8 @@ public class CategorySectionDto
 
     public string Name { get; init; }
 
+    public string? QuestionSlug { get; init; }
+
     public Tag Tag { get; init; } = new Tag();
 
     public string? ErrorMessage { get; init; }
@@ -33,6 +35,7 @@ public class CategorySectionDto
     public CategorySectionDto(
         string? slug,
         string name,
+        string? questionSlug,
         bool retrievalError,
         SectionStatusDto? sectionStatus,
         CategorySectionRecommendationDto recommendation,
@@ -40,6 +43,7 @@ public class CategorySectionDto
     {
         Slug = slug;
         Name = name;
+        QuestionSlug = questionSlug;
         Recommendation = recommendation;
         var started = sectionStatus != null;
         var completed = sectionStatus?.Completed == true;

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/CategorySection/Subtopics.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/CategorySection/Subtopics.cshtml
@@ -11,38 +11,52 @@
             <div class="dfe-card-container">
                 @if (categorySectionDtoItem.Slug != null)
                 {
-                    string statusText = "Start Self-Assessment";
-                    string pagesController = "Pages";
-                    string action = "GetByRoute";
-                    string routeName = categorySectionDtoItem.Slug;
+                    string statusText;
+                    string? controller = null;
+                    string? action = null;
+                    Dictionary<string, string>? routeValues = null;
                     string? sectionSlug = null;
                     string? recommendationSlug = null;
 
-                    if (categorySectionDtoItem.ProgressStatus == SectionProgressStatus.StartedNeverCompleted)
+                    switch (categorySectionDtoItem.ProgressStatus)
                     {
-                        statusText = "Continue Self-Assessment";
-                    }
-                    else if
-                    (categorySectionDtoItem.ProgressStatus == SectionProgressStatus.InProgress ||
-                     categorySectionDtoItem.ProgressStatus == SectionProgressStatus.CompletedStartedNew ||
-                     categorySectionDtoItem.ProgressStatus == SectionProgressStatus.Completed)
-                    {
-                        statusText = "View Recommendations";
-                        pagesController = string.Empty;
-                        action = string.Empty;
-                        routeName = string.Empty;
+                        case SectionProgressStatus.StartedNeverCompleted:
+                            statusText = "Continue self-assessment";
+                            controller = "Questions";
+                            action = "GetQuestionBySlug";
+                            routeValues = new Dictionary<string, string>
+                            {
+                                ["questionSlug"] = categorySectionDtoItem.QuestionSlug ?? string.Empty,
+                                ["sectionSlug"] = categorySectionDtoItem.Slug ?? string.Empty
+                            };
+                            break;
 
-                        if (categorySectionDtoItem.Recommendation != null)
-                        {
-                            sectionSlug = categorySectionDtoItem.Recommendation.SectionSlug;
-                            recommendationSlug = categorySectionDtoItem.Recommendation.RecommendationSlug;
-                        }
+                        case SectionProgressStatus.InProgress:
+                        case SectionProgressStatus.CompletedStartedNew:
+                        case SectionProgressStatus.Completed:
+                            statusText = "View recommendations";
+                            if (categorySectionDtoItem.Recommendation != null)
+                            {
+                                sectionSlug = categorySectionDtoItem.Recommendation.SectionSlug;
+                                recommendationSlug = categorySectionDtoItem.Recommendation.RecommendationSlug;
+                            }
+                            break;
+
+                        default:
+                            statusText = "Start self-assessment";
+                            controller = "Pages";
+                            action = "GetByRoute";
+                            routeValues = new Dictionary<string, string>
+                            {
+                                ["route"] = categorySectionDtoItem.Slug ?? string.Empty
+                            };
+                            break;
                     }
 
                     <h3 class="govuk-heading-m">
-                        @if (pagesController != "")
+                        @if (!string.IsNullOrEmpty(controller) && !string.IsNullOrEmpty(action))
                         {
-                            <a asp-controller="@pagesController" asp-action="@action" asp-route-route="@routeName"
+                            <a asp-controller="@controller" asp-action="@action" asp-all-route-data="@routeValues"
                                class="govuk-link govuk-link--no-visited-state dfe-card-link--header">
                                 @categorySectionDtoItem.Name
                             </a>
@@ -57,6 +71,7 @@
                             ))
                         }
                     </h3>
+
                     <p class="govuk-body-s">
                         @statusText
                     </p>


### PR DESCRIPTION
## Overview

[257392](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/257392)

Changed route for continue self-assessment to go straight to the next unanswered question.

The design for the ticket is based on:
lucid designs and the sprint 14 prototype.

## Changes
- Changes to subtopics review to include the question slug
- Changes to category controller to get next unanswered question for the slug
- Added/updated unit tests to test new functionality
- Cleaned subtopics view code

## How to review the PR

Smoke test self-assessment page and check routing goes to where expected (continue self-assessment card should go straight to the next unanswered question)

## Release requirements

N/A

## Additional notes

257799 home journey branch will hold new feature changes

## Checklist

Delete any rows that do not apply to the PR.

- [ x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch
- [x ] Unit tests have been added/updated
- [ ] E2E tests have been added/updated
- [ ] GitHub workflows/actions have been added/updated
- [ ] Terraform has been updated
- [ ] Documentation has been updated where relevant
- [ ] Any Key Vault secrets have been added to the development Key Vault
