### PR TITLE
feat(258952): adds contact us link and text to MAT select a school view

### DIFF
--- a/src/Dfe.PlanTech.Application/Constants/UrlConstants.cs
+++ b/src/Dfe.PlanTech.Application/Constants/UrlConstants.cs
@@ -4,8 +4,6 @@ public static class UrlConstants
 {
     public const string SelfAssessmentPage = "/self-assessment";
 
-    public const string ContactUsPage = "/contact-us";
-
     public const string SelectASchoolPage = "/groups/select-a-school";
 
     public const string ServerError = "/server-error";

--- a/src/Dfe.PlanTech.Application/Constants/UrlConstants.cs
+++ b/src/Dfe.PlanTech.Application/Constants/UrlConstants.cs
@@ -4,6 +4,8 @@ public static class UrlConstants
 {
     public const string SelfAssessmentPage = "/self-assessment";
 
+    public const string ContactUsPage = "/contact-us";
+
     public const string SelectASchoolPage = "/groups/select-a-school";
 
     public const string ServerError = "/server-error";

--- a/src/Dfe.PlanTech.Web/Controllers/GroupsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/GroupsController.cs
@@ -36,10 +36,8 @@ namespace Dfe.PlanTech.Web.Controllers
         private readonly IGetSectionQuery _getSectionQuery;
         private readonly IGetLatestResponsesQuery _getLatestResponsesQuery;
         private readonly IGetSubTopicRecommendationQuery _getSubTopicRecommendationQuery;
-        private readonly IOptions<ContactOptions> _contactOptions;
-        private readonly IGetNavigationQuery _getNavigationQuery;
 
-        public GroupsController(ILogger<GroupsController> logger, IUser user, IGetEstablishmentIdQuery getEstablishmentIdQuery, IGetSubmissionStatusesQuery getSubmissionStatusesQuery, IGetGroupSelectionQuery getGroupSelectionQuery, IGetSectionQuery getSectionQuery, IGetLatestResponsesQuery getLatestResponsesQuery, IGetSubTopicRecommendationQuery getSubTopicRecommendationQuery, IOptions<ContactOptions> contactOptions, IGetNavigationQuery getNavigationQuery) : base(logger)
+        public GroupsController(ILogger<GroupsController> logger, IUser user, IGetEstablishmentIdQuery getEstablishmentIdQuery, IGetSubmissionStatusesQuery getSubmissionStatusesQuery, IGetGroupSelectionQuery getGroupSelectionQuery, IGetSectionQuery getSectionQuery, IGetLatestResponsesQuery getLatestResponsesQuery, IGetSubTopicRecommendationQuery getSubTopicRecommendationQuery) : base(logger)
         {
             _logger = logger;
             _user = user;
@@ -49,12 +47,10 @@ namespace Dfe.PlanTech.Web.Controllers
             _getSectionQuery = getSectionQuery;
             _getLatestResponsesQuery = getLatestResponsesQuery;
             _getSubTopicRecommendationQuery = getSubTopicRecommendationQuery;
-            _contactOptions = contactOptions;
-            _getNavigationQuery = getNavigationQuery;
         }
 
         [HttpGet($"{GroupsSlug}/{GroupsSelectorPageSlug}")]
-        public async Task<IActionResult> GetSelectASchoolView([FromServices] IGetPageQuery getPageQuery, CancellationToken cancellationToken)
+        public async Task<IActionResult> GetSelectASchoolView([FromServices] IGetPageQuery getPageQuery, [FromServices] IGetNavigationQuery getNavigationQuery, [FromServices] IOptions<ContactOptions> contactOptions, CancellationToken cancellationToken)
         {
             var selectASchoolPageContent = await getPageQuery.GetPageBySlug(GroupsSelectorPageSlug, cancellationToken);
             var dashboardContent = await getPageQuery.GetPageBySlug(GroupsSchoolDashboardSlug, cancellationToken);
@@ -75,7 +71,7 @@ namespace Dfe.PlanTech.Web.Controllers
                 totalSections = SubmissionStatusHelpers.GetTotalSections(categories);
             }
 
-            var contactLink = await _getNavigationQuery.GetLinkById(_contactOptions.Value.LinkId);
+            var contactLink = await getNavigationQuery.GetLinkById(contactOptions.Value.LinkId, cancellationToken);
 
             var viewModel = new GroupsSelectorViewModel()
             {

--- a/src/Dfe.PlanTech.Web/Controllers/GroupsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/GroupsController.cs
@@ -87,7 +87,7 @@ namespace Dfe.PlanTech.Web.Controllers
                 ProgressRetrievalErrorMessage = String.IsNullOrEmpty(totalSections)
                     ? "Unable to retrieve progress"
                     : null,
-                ContactLinkHref = contactLink?.Href
+                ContactLinkHref = contactLink?.Href 
             };
 
             ViewData["Title"] = "Select a school";

--- a/src/Dfe.PlanTech.Web/Controllers/GroupsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/GroupsController.cs
@@ -10,8 +10,10 @@ using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 using Dfe.PlanTech.Domain.Questionnaire.Models;
 using Dfe.PlanTech.Domain.Submissions.Interfaces;
 using Dfe.PlanTech.Domain.Users.Interfaces;
+using Dfe.PlanTech.Web.Configuration;
 using Dfe.PlanTech.Web.Models;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 namespace Dfe.PlanTech.Web.Controllers
 {
@@ -34,8 +36,10 @@ namespace Dfe.PlanTech.Web.Controllers
         private readonly IGetSectionQuery _getSectionQuery;
         private readonly IGetLatestResponsesQuery _getLatestResponsesQuery;
         private readonly IGetSubTopicRecommendationQuery _getSubTopicRecommendationQuery;
+        private readonly IOptions<ContactOptions> _contactOptions;
+        private readonly IGetNavigationQuery _getNavigationQuery;
 
-        public GroupsController(ILogger<GroupsController> logger, IUser user, IGetEstablishmentIdQuery getEstablishmentIdQuery, IGetSubmissionStatusesQuery getSubmissionStatusesQuery, IGetGroupSelectionQuery getGroupSelectionQuery, IGetSectionQuery getSectionQuery, IGetLatestResponsesQuery getLatestResponsesQuery, IGetSubTopicRecommendationQuery getSubTopicRecommendationQuery) : base(logger)
+        public GroupsController(ILogger<GroupsController> logger, IUser user, IGetEstablishmentIdQuery getEstablishmentIdQuery, IGetSubmissionStatusesQuery getSubmissionStatusesQuery, IGetGroupSelectionQuery getGroupSelectionQuery, IGetSectionQuery getSectionQuery, IGetLatestResponsesQuery getLatestResponsesQuery, IGetSubTopicRecommendationQuery getSubTopicRecommendationQuery, IOptions<ContactOptions> contactOptions, IGetNavigationQuery getNavigationQuery) : base(logger)
         {
             _logger = logger;
             _user = user;
@@ -45,6 +49,8 @@ namespace Dfe.PlanTech.Web.Controllers
             _getSectionQuery = getSectionQuery;
             _getLatestResponsesQuery = getLatestResponsesQuery;
             _getSubTopicRecommendationQuery = getSubTopicRecommendationQuery;
+            _contactOptions = contactOptions;
+            _getNavigationQuery = getNavigationQuery;
         }
 
         [HttpGet($"{GroupsSlug}/{GroupsSelectorPageSlug}")]
@@ -69,6 +75,8 @@ namespace Dfe.PlanTech.Web.Controllers
                 totalSections = SubmissionStatusHelpers.GetTotalSections(categories);
             }
 
+            var contactLink = await _getNavigationQuery.GetLinkById(_contactOptions.Value.LinkId);
+
             var viewModel = new GroupsSelectorViewModel()
             {
                 GroupName = groupName,
@@ -78,7 +86,8 @@ namespace Dfe.PlanTech.Web.Controllers
                 TotalSections = totalSections,
                 ProgressRetrievalErrorMessage = String.IsNullOrEmpty(totalSections)
                     ? "Unable to retrieve progress"
-                    : null
+                    : null,
+                ContactLinkHref = contactLink?.Href
             };
 
             ViewData["Title"] = "Select a school";

--- a/src/Dfe.PlanTech.Web/Models/GroupsSelectorViewModel.cs
+++ b/src/Dfe.PlanTech.Web/Models/GroupsSelectorViewModel.cs
@@ -18,5 +18,7 @@ namespace Dfe.PlanTech.Web.Models
         public string? TotalSections { get; set; }
 
         public string? ProgressRetrievalErrorMessage { get; init; }
+
+        public string? ContactLinkHref {  get; set; }
     }
 }

--- a/src/Dfe.PlanTech.Web/Views/Groups/GroupsSelectSchool.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Groups/GroupsSelectSchool.cshtml
@@ -29,6 +29,10 @@
                 </form>
             }
         }
+        @{
+            <hr class="govuk-section-break govuk-section-break--m" />
+            <p class="govuk-body"><a href=UrlConstants.ContactUsPage class="govuk-link">Contact us</a> if any school information is missing or incorrect.</p>
+        }
     </div>
 </div>
     

--- a/src/Dfe.PlanTech.Web/Views/Groups/GroupsSelectSchool.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Groups/GroupsSelectSchool.cshtml
@@ -30,7 +30,7 @@
             }
         }
         <hr class="govuk-section-break govuk-section-break--m" />
-        <p class="govuk-body"><a href="@Model.ContactLinkHref" target="_blank" class="govuk-link">Contact us</a> if any school information is missing or incorrect.</p>
+        <p class="govuk-body"><a href="@Model.ContactLinkHref" target="_blank" class="govuk-link">Contact us (opens in new tab)</a> if any school information is missing or incorrect.</p>
     </div>
 </div>
     

--- a/src/Dfe.PlanTech.Web/Views/Groups/GroupsSelectSchool.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Groups/GroupsSelectSchool.cshtml
@@ -29,10 +29,8 @@
                 </form>
             }
         }
-        @{
-            <hr class="govuk-section-break govuk-section-break--m" />
-            <p class="govuk-body"><a href=UrlConstants.ContactUsPage class="govuk-link">Contact us</a> if any school information is missing or incorrect.</p>
-        }
+        <hr class="govuk-section-break govuk-section-break--m" />
+        <p class="govuk-body"><a href="@Model.ContactLinkHref" target="_blank" class="govuk-link">Contact us</a> if any school information is missing or incorrect.</p>
     </div>
 </div>
     

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/GroupsControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/GroupsControllerTests.cs
@@ -37,8 +37,6 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
             _getPageQuery = Substitute.For<IGetPageQuery>();
             _getSectionQuery = Substitute.For<IGetSectionQuery>();
             _getSubTopicRecommendationQuery = Substitute.For<IGetSubTopicRecommendationQuery>();
-            _getNavigationQuery = Substitute.For<IGetNavigationQuery>();
-            _contactOptions = Substitute.For<IOptions<ContactOptions>>();
 
             _controller = new GroupsController(
                 logger,
@@ -48,9 +46,7 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
                 _getGroupSelectionQuery,
                 Substitute.For<IGetSectionQuery>(),
                 Substitute.For<IGetLatestResponsesQuery>(),
-                Substitute.For<IGetSubTopicRecommendationQuery>(),
-                _contactOptions,
-                _getNavigationQuery
+                Substitute.For<IGetSubTopicRecommendationQuery>()
             );
         }
 
@@ -106,6 +102,8 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
         [Fact]
         public async Task GetSelectASchoolView_ReturnsViewWithCorrectModel()
         {
+            var getNavigationQuery = Substitute.For<IGetNavigationQuery>();
+            var contactOptions = Substitute.For<IOptions<ContactOptions>>();
             var mockSchools = new List<EstablishmentLink>
                 { new EstablishmentLink() { Urn = "123", EstablishmentName = "School A" } };
             var orgData = new EstablishmentDto { OrgName = "GroupName" };
@@ -125,10 +123,10 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
                 LinkId = contactLinkHref
             };
 
-            _contactOptions.Value.Returns(options);
-            _getNavigationQuery.GetLinkById(contactLinkHref).Returns(contactLink);
+            contactOptions.Value.Returns(options);
+            getNavigationQuery.GetLinkById(contactLinkHref).Returns(contactLink);
 
-            var result = await _controller.GetSelectASchoolView(_getPageQuery, CancellationToken.None);
+            var result = await _controller.GetSelectASchoolView(_getPageQuery, getNavigationQuery, contactOptions, CancellationToken.None);
 
             var view = Assert.IsType<ViewResult>(result);
             var viewModel = Assert.IsType<GroupsSelectorViewModel>(view.Model);
@@ -152,9 +150,7 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
                 getGroupSelectionQuery,
                 Substitute.For<IGetSectionQuery>(),
                 Substitute.For<IGetLatestResponsesQuery>(),
-                Substitute.For<IGetSubTopicRecommendationQuery>(),
-                Substitute.For<IOptions<ContactOptions>>(),
-                _getNavigationQuery
+                Substitute.For<IGetSubTopicRecommendationQuery>()
             );
 
             var cancellationToken = CancellationToken.None;

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/GroupsControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/GroupsControllerTests.cs
@@ -6,10 +6,12 @@ using Dfe.PlanTech.Domain.Groups.Models;
 using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 using Dfe.PlanTech.Domain.Submissions.Interfaces;
 using Dfe.PlanTech.Domain.Users.Interfaces;
+using Dfe.PlanTech.Web.Configuration;
 using Dfe.PlanTech.Web.Controllers;
 using Dfe.PlanTech.Web.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Xunit;
 
@@ -22,6 +24,8 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
         private readonly IGetPageQuery _getPageQuery;
         private readonly IGetSectionQuery _getSectionQuery;
         private readonly IGetSubTopicRecommendationQuery _getSubTopicRecommendationQuery;
+        private readonly IOptions<ContactOptions> _contactOptions;
+        private readonly IGetNavigationQuery _getNavigationQuery;
 
         private readonly GroupsController _controller;
 
@@ -33,6 +37,8 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
             _getPageQuery = Substitute.For<IGetPageQuery>();
             _getSectionQuery = Substitute.For<IGetSectionQuery>();
             _getSubTopicRecommendationQuery = Substitute.For<IGetSubTopicRecommendationQuery>();
+            _getNavigationQuery = Substitute.For<IGetNavigationQuery>();
+            _contactOptions = Substitute.For<IOptions<ContactOptions>>();
 
             _controller = new GroupsController(
                 logger,
@@ -42,7 +48,9 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
                 _getGroupSelectionQuery,
                 Substitute.For<IGetSectionQuery>(),
                 Substitute.For<IGetLatestResponsesQuery>(),
-                Substitute.For<IGetSubTopicRecommendationQuery>()
+                Substitute.For<IGetSubTopicRecommendationQuery>(),
+                _contactOptions,
+                _getNavigationQuery
             );
         }
 
@@ -108,6 +116,18 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
             _getPageQuery.GetPageBySlug(Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .Returns(new Page { Content = new List<ContentComponent>() });
 
+            var contactLinkHref = "contactLinkHref";
+            var contactLink = Substitute.For<INavigationLink>();
+            contactLink.Href = contactLinkHref;
+
+            var options = new ContactOptions
+            {
+                LinkId = contactLinkHref
+            };
+
+            _contactOptions.Value.Returns(options);
+            _getNavigationQuery.GetLinkById(contactLinkHref).Returns(contactLink);
+
             var result = await _controller.GetSelectASchoolView(_getPageQuery, CancellationToken.None);
 
             var view = Assert.IsType<ViewResult>(result);
@@ -132,7 +152,9 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
                 getGroupSelectionQuery,
                 Substitute.For<IGetSectionQuery>(),
                 Substitute.For<IGetLatestResponsesQuery>(),
-                Substitute.For<IGetSubTopicRecommendationQuery>()
+                Substitute.For<IGetSubTopicRecommendationQuery>(),
+                Substitute.For<IOptions<ContactOptions>>(),
+                _getNavigationQuery
             );
 
             var cancellationToken = CancellationToken.None;


### PR DESCRIPTION
## Overview

Addresses ticket [#258952](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/258952)

Adds text to bottom of school selection directing users to the Contact Us page

The design for the ticket is based on [the prototype](https://plantech.herokuapp.com/sprint12/prototype/change-school).

## Changes

### Minor

- Adds ContactLink query to Groups Controller
- Adds link to ViewModel and View

## How to review the PR

Log in as MAT user to view Select a school, check link displays and works.

## Checklist

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch