### PR TITLE
(bug):Update deploy-image az cli version

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -107,7 +107,7 @@ jobs:
         uses: azure/CLI@v1
         id: azure
         with:
-          azcliversion: 2.45.0
+          azcliversion: 2.73.0
           inlineScript: |
             az config set extension.use_dynamic_install=yes_without_prompt
             az containerapp update \


### PR DESCRIPTION
Updating the AZ CLI version to the latest 2.73.0

Current version is 2.58 which is from 2023 which is causing issues with deployment.
