### PR TITLE
(task): Updated AZ CLI version in check-expiry and deploy-image

### DIFF
--- a/.github/actions/azure-check-expiry/action.yml
+++ b/.github/actions/azure-check-expiry/action.yml
@@ -39,7 +39,7 @@ runs:
     - name: Add Runner to KV whitelist
       uses: azure/CLI@v1
       with:
-        azcliversion: 2.45.0
+        azcliversion: 2.73.0
         inlineScript: |
           az keyvault network-rule add --name ${{ inputs.az_keyvault_name }} --ip-address ${{ steps.whats-my-ip.outputs.ip }} &> /dev/null
 
@@ -54,6 +54,6 @@ runs:
       uses: azure/CLI@v1
       if: always()
       with:
-        azcliversion: 2.45.0
+        azcliversion: 2.73.0
         inlineScript: |
           az keyvault network-rule remove --name ${{ inputs.az_keyvault_name }} --ip-address ${{ steps.whats-my-ip.outputs.ip }} &> /dev/null

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -140,7 +140,7 @@ jobs:
         uses: azure/CLI@v1
         id: azure
         with:
-          azcliversion: 2.67.0
+          azcliversion: 2.73.0
           inlineScript: |
             az redis flush --name ${{ secrets.AZ_ENVIRONMENT }}${{ secrets.DFE_PROJECT_NAME }} --resource-group ${{ secrets.AZ_ENVIRONMENT }}${{ secrets.DFE_PROJECT_NAME }} --yes
 


### PR DESCRIPTION
Old 2023 AZ CLI versions being used in the deploy-image and check-expiry pipelines.,