### PR TITLE
fix: revert change that builds web assets on local build

### DIFF
--- a/src/Dfe.PlanTech.Web/Dfe.PlanTech.Web.csproj
+++ b/src/Dfe.PlanTech.Web/Dfe.PlanTech.Web.csproj
@@ -7,9 +7,6 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <UserSecretsId>04e79986-156c-45e1-87d7-2f14405d0fe8</UserSecretsId>
     </PropertyGroup>
-    <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-        <buildWebAssets>true</buildWebAssets>
-    </PropertyGroup>
 
     <ItemGroup>
         <Content Update="Properties\launchSettings.json">


### PR DESCRIPTION
Removes buildWebAssets=true command to prevent css changes appearing on each build