### PR TITLE
297394 - Add change your answers page and logic

### DIFF
--- a/src/Dfe.PlanTech.Application/Constants/UrlConstants.cs
+++ b/src/Dfe.PlanTech.Application/Constants/UrlConstants.cs
@@ -6,6 +6,8 @@ public static class UrlConstants
 
     public const string SelectASchoolPage = "/groups/select-a-school";
 
+    public const string RecommendationsPage = "/recommendations";
+
     public const string ServerError = "/server-error";
 
     public const string Error = "/error";

--- a/src/Dfe.PlanTech.Application/Dfe.PlanTech.Application.csproj
+++ b/src/Dfe.PlanTech.Application/Dfe.PlanTech.Application.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
   </ItemGroup>

--- a/src/Dfe.PlanTech.Application/Persistence/Interfaces/IPlanTechDbContext.cs
+++ b/src/Dfe.PlanTech.Application/Persistence/Interfaces/IPlanTechDbContext.cs
@@ -4,6 +4,7 @@ using Dfe.PlanTech.Domain.Groups.Models;
 using Dfe.PlanTech.Domain.SignIns.Models;
 using Dfe.PlanTech.Domain.Submissions.Models;
 using Dfe.PlanTech.Domain.Users.Models;
+using Microsoft.EntityFrameworkCore;
 
 namespace Dfe.PlanTech.Application.Persistence.Interfaces;
 
@@ -22,6 +23,12 @@ public interface IPlanTechDbContext
     public IQueryable<ResponseAnswer> GetAnswers { get; }
 
     public void AddEstablishment(Establishment establishment);
+
+    public void AddSubmission(Submission submission);
+
+    public DbSet<Submission> Submissions { get; }
+
+    Task<Submission?> GetSubmissionById(int submissionId, CancellationToken cancellationToken = default);
 
     public Task<int> SaveChangesAsync();
 

--- a/src/Dfe.PlanTech.Application/Responses/Commands/ProcessSubmissionResponsesDto.cs
+++ b/src/Dfe.PlanTech.Application/Responses/Commands/ProcessSubmissionResponsesDto.cs
@@ -13,9 +13,9 @@ public class ProcessSubmissionResponsesDto : IProcessSubmissionResponsesCommand
         _getLatestResponseListForSubmissionQuery = getLatestResponseListForSubmissionQuery;
     }
 
-    public async Task<SubmissionResponsesDto?> GetSubmissionResponsesDtoForSection(int establishmentId, ISectionComponent section, CancellationToken cancellationToken = default)
+    public async Task<SubmissionResponsesDto?> GetSubmissionResponsesDtoForSection(int establishmentId, ISectionComponent section, CancellationToken cancellationToken = default, bool completed = false)
     {
-        var submissionResponsesDto = await _getLatestResponseListForSubmissionQuery.GetLatestResponses(establishmentId, section.Sys.Id, false, cancellationToken);
+        var submissionResponsesDto = await _getLatestResponseListForSubmissionQuery.GetLatestResponses(establishmentId, section.Sys.Id, completed, cancellationToken);
         if (submissionResponsesDto?.Responses == null || submissionResponsesDto.Responses.Count == 0)
         {
             return null;

--- a/src/Dfe.PlanTech.Application/Submissions/Commands/MarkSubmissionAsReviewedCommand.cs
+++ b/src/Dfe.PlanTech.Application/Submissions/Commands/MarkSubmissionAsReviewedCommand.cs
@@ -1,0 +1,41 @@
+﻿using Dfe.PlanTech.Application.Persistence.Interfaces;
+using Dfe.PlanTech.Domain.Submissions.Enums;
+using Dfe.PlanTech.Domain.Submissions.Interfaces;
+
+namespace Dfe.PlanTech.Application.Submissions.Commands
+{
+    public class MarkSubmissionAsReviewedCommand : IMarkSubmissionAsReviewedCommand
+    {
+        private readonly IPlanTechDbContext _db;
+
+        public MarkSubmissionAsReviewedCommand(IPlanTechDbContext db)
+        {
+            _db = db;
+        }
+
+        public async Task MarkSubmissionAsReviewed(int submissionId, CancellationToken cancellationToken)
+        {
+            var submission = await _db.GetSubmissionById(submissionId, cancellationToken)
+                             ?? throw new InvalidOperationException($"Submission not found for id {submissionId}");
+
+            submission.Status = SubmissionStatus.CompleteReviewed.ToString();
+            submission.DateCompleted = DateTime.UtcNow;
+
+            var otherSubmissions = await _db.ToListAsync(
+                _db.GetSubmissions.Where(s =>
+                    s.SectionId == submission.SectionId &&
+                    s.EstablishmentId == submission.EstablishmentId &&
+                    s.Status == SubmissionStatus.CompleteReviewed.ToString() &&
+                    s.Id != submission.Id),
+                cancellationToken
+            );
+
+            foreach (var oldSubmissions in otherSubmissions)
+            {
+                oldSubmissions.Status = SubmissionStatus.Inaccessible.ToString();
+            }
+
+            await _db.SaveChangesAsync();
+        }
+    }
+}

--- a/src/Dfe.PlanTech.Application/Submissions/Commands/SubmissionCommand.cs
+++ b/src/Dfe.PlanTech.Application/Submissions/Commands/SubmissionCommand.cs
@@ -1,0 +1,61 @@
+﻿using Dfe.PlanTech.Application.Persistence.Interfaces;
+using Dfe.PlanTech.Domain.Submissions.Enums;
+using Dfe.PlanTech.Domain.Submissions.Models;
+
+namespace Dfe.PlanTech.Application.Submissions.Commands
+{
+    public class SubmissionCommand : ISubmissionCommand
+    {
+        private readonly IPlanTechDbContext _db;
+
+        public SubmissionCommand(IPlanTechDbContext db)
+        {
+            _db = db;
+        }
+
+        public async Task<Submission> CloneSubmission(Submission? existingSubmission, CancellationToken cancellationToken)
+        {
+            if (existingSubmission is null)
+                    throw new ArgumentNullException(nameof(existingSubmission), "Submission cannot be null");
+
+            var newSubmission = new Submission
+            {
+                SectionId = existingSubmission.SectionId,
+                SectionName = existingSubmission.SectionName,
+                EstablishmentId = existingSubmission.EstablishmentId,
+                Completed = false,
+                Maturity = existingSubmission.Maturity,
+                DateCreated = DateTime.UtcNow,
+                Status = SubmissionStatus.InProgress.ToString(),
+                Responses = existingSubmission.Responses.Select(r => new Response
+                {
+                    QuestionId = r.QuestionId,
+                    AnswerId = r.AnswerId,
+                    UserId = r.UserId,
+                    Maturity = r.Maturity,
+                    Question = r.Question,
+                    Answer = r.Answer,
+                    DateCreated = DateTime.UtcNow
+                }).ToList()
+            };
+
+            _db.AddSubmission(newSubmission);
+            await _db.SaveChangesAsync();
+
+            return newSubmission;
+        }
+
+        public async Task DeleteSubmission(int submissionId, CancellationToken cancellationToken)
+        {
+            var submissions = _db.Submissions;
+            var submission = submissions.Find(submissionId);
+
+            if (submission == null)
+                    throw new ArgumentNullException(nameof(submission));
+
+            submission.Status = SubmissionStatus.Inaccessible.ToString();
+
+            await _db.SaveChangesAsync();
+        }
+    }
+}

--- a/src/Dfe.PlanTech.Application/Submissions/Queries/SectionCompleteStatusChecker.cs
+++ b/src/Dfe.PlanTech.Application/Submissions/Queries/SectionCompleteStatusChecker.cs
@@ -14,7 +14,7 @@ public static class SectionCompleteStatusChecker
         IsMatchingSubmissionStatusFunc = (userJourneyRouter) => userJourneyRouter?.SectionStatus?.Completed == true,
         ProcessSubmissionFunc = (userJourneyRouter, cancellationToken) =>
         {
-            userJourneyRouter.Status = SubmissionStatus.Completed;
+            userJourneyRouter.Status = Status.CompleteReviewed;
             userJourneyRouter.NextQuestion = userJourneyRouter.Section.Questions[0];
 
             return Task.CompletedTask;

--- a/src/Dfe.PlanTech.Application/Submissions/Queries/SectionNotStartedStatusChecker.cs
+++ b/src/Dfe.PlanTech.Application/Submissions/Queries/SectionNotStartedStatusChecker.cs
@@ -16,7 +16,7 @@ public static class SectionNotStartedStatusChecker
                                                        userJourneyRouter.SectionStatus.Status == Status.NotStarted,
         ProcessSubmissionFunc = (userJourneyRouter, cancellationToken) =>
         {
-            userJourneyRouter.Status = SubmissionStatus.NotStarted;
+            userJourneyRouter.Status = Status.NotStarted;
             userJourneyRouter.NextQuestion = userJourneyRouter.Section.Questions[0];
             return Task.CompletedTask;
         }

--- a/src/Dfe.PlanTech.Application/Submissions/Queries/SubmissionStatusProcessor.cs
+++ b/src/Dfe.PlanTech.Application/Submissions/Queries/SubmissionStatusProcessor.cs
@@ -24,7 +24,7 @@ public class SubmissionStatusProcessor : ISubmissionStatusProcessor
     public IUser User { get; init; }
     public Question? NextQuestion { get; set; }
     public SectionStatus? SectionStatus { get; private set; }
-    public SubmissionStatus Status { get; set; }
+    public Status Status { get; set; }
 
     public SubmissionStatusProcessor(IGetSectionQuery getSectionQuery,
                                     IGetSubmissionStatusesQuery getSubmissionStatusesQuery,
@@ -45,14 +45,14 @@ public class SubmissionStatusProcessor : ISubmissionStatusProcessor
         User = user;
     }
 
-    public async Task GetJourneyStatusForSection(string sectionSlug, CancellationToken cancellationToken)
+    public async Task GetJourneyStatusForSection(string sectionSlug, CancellationToken cancellationToken, bool completed)
     {
-        await GetJourneyStatus(sectionSlug, false, cancellationToken);
+        await GetJourneyStatus(sectionSlug, completed, cancellationToken);
     }
 
-    public async Task GetJourneyStatusForSectionRecommendation(string sectionSlug, CancellationToken cancellationToken)
+    public async Task GetJourneyStatusForSectionRecommendation(string sectionSlug, CancellationToken cancellationToken, bool completed)
     {
-        await GetJourneyStatus(sectionSlug, true, cancellationToken);
+        await GetJourneyStatus(sectionSlug, completed, cancellationToken);
     }
 
     /// <summary>

--- a/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2025/20250604_1315_AddSubmissionStatus.sql
+++ b/src/Dfe.PlanTech.DatabaseUpgrader/Scripts/2025/20250604_1315_AddSubmissionStatus.sql
@@ -1,0 +1,18 @@
+BEGIN TRY
+    BEGIN TRAN
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_NAME = 'submission' AND COLUMN_NAME = 'Status'
+    )
+    BEGIN
+        ALTER TABLE [dbo].[submission]
+        ADD [Status] NVARCHAR(50) NULL;
+    END
+
+    COMMIT TRAN
+END TRY
+BEGIN CATCH
+    ROLLBACK TRAN
+END CATCH

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Models/Section.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Models/Section.cs
@@ -18,7 +18,9 @@ public class Section : ContentComponent, ISectionComponent
 
     public IEnumerable<QuestionWithAnswer> GetOrderedResponsesForJourney(IEnumerable<QuestionWithAnswer> responses)
     {
-        var questionWithAnswerMap = responses.ToDictionary(questionWithAnswer => questionWithAnswer.QuestionRef, questionWithAnswer => questionWithAnswer);
+        var questionWithAnswerMap = responses
+                    .GroupBy(r => r.QuestionRef)
+                    .ToDictionary(g => g.Key, g => g.First());
 
         Question? node = Questions.FirstOrDefault();
 

--- a/src/Dfe.PlanTech.Domain/Submissions/Enums/Status.cs
+++ b/src/Dfe.PlanTech.Domain/Submissions/Enums/Status.cs
@@ -4,5 +4,7 @@ public enum Status
 {
     NotStarted,
     InProgress,
-    Completed
+    CompleteNotReviewed,
+    CompleteReviewed,
+    Inaccessible
 }

--- a/src/Dfe.PlanTech.Domain/Submissions/Enums/SubmissionStatus.cs
+++ b/src/Dfe.PlanTech.Domain/Submissions/Enums/SubmissionStatus.cs
@@ -2,8 +2,10 @@ namespace Dfe.PlanTech.Domain.Submissions.Enums;
 
 public enum SubmissionStatus
 {
+    None,
     NotStarted,
-    NextQuestion,
-    CheckAnswers,
-    Completed
+    InProgress,
+    CompleteNotReviewed,
+    CompleteReviewed,
+    Inaccessible
 }

--- a/src/Dfe.PlanTech.Domain/Submissions/Interfaces/IGetLatestResponsesQuery.cs
+++ b/src/Dfe.PlanTech.Domain/Submissions/Interfaces/IGetLatestResponsesQuery.cs
@@ -11,5 +11,9 @@ public interface IGetLatestResponsesQuery
 
     Task<DateTime?> GetLatestCompletionDate(int establishmentId, string sectionId, bool completedSubmission, CancellationToken cancellationToken = default);
 
+    Task<Submission?> GetInProgressSubmission(int establishmentId, string sectionId, CancellationToken cancellationToken = default);
+
+    Task<Submission?> GetLatestCompletedSubmission(int establishmentId, string sectionId);
+
     Task ViewLatestSubmission(int establishmentId, string sectionId);
 }

--- a/src/Dfe.PlanTech.Domain/Submissions/Interfaces/IMarkSubmissionAsReviewedCommand.cs
+++ b/src/Dfe.PlanTech.Domain/Submissions/Interfaces/IMarkSubmissionAsReviewedCommand.cs
@@ -1,0 +1,7 @@
+﻿namespace Dfe.PlanTech.Domain.Submissions.Interfaces
+{
+    public interface IMarkSubmissionAsReviewedCommand
+    {
+        Task MarkSubmissionAsReviewed(int submissionId, CancellationToken cancellationToken);
+    }
+}

--- a/src/Dfe.PlanTech.Domain/Submissions/Interfaces/IProcessSubmissionResponsesCommand.cs
+++ b/src/Dfe.PlanTech.Domain/Submissions/Interfaces/IProcessSubmissionResponsesCommand.cs
@@ -5,5 +5,5 @@ namespace Dfe.PlanTech.Domain.Submissions.Interfaces;
 
 public interface IProcessSubmissionResponsesCommand
 {
-    public Task<SubmissionResponsesDto?> GetSubmissionResponsesDtoForSection(int establishmentId, ISectionComponent section, CancellationToken cancellationToken = default);
+    public Task<SubmissionResponsesDto?> GetSubmissionResponsesDtoForSection(int establishmentId, ISectionComponent section, CancellationToken cancellationToken = default, bool completed = false);
 }

--- a/src/Dfe.PlanTech.Domain/Submissions/Interfaces/ISubmissionCommand.cs
+++ b/src/Dfe.PlanTech.Domain/Submissions/Interfaces/ISubmissionCommand.cs
@@ -1,0 +1,8 @@
+﻿using Dfe.PlanTech.Domain.Submissions.Models;
+
+public interface ISubmissionCommand
+{
+    Task<Submission> CloneSubmission(Submission? existingSubmission, CancellationToken cancellationToken);
+
+    Task DeleteSubmission(int submissionId, CancellationToken cancellationToken);
+}

--- a/src/Dfe.PlanTech.Domain/Submissions/Interfaces/ISubmissionStatusProcessor.cs
+++ b/src/Dfe.PlanTech.Domain/Submissions/Interfaces/ISubmissionStatusProcessor.cs
@@ -14,11 +14,11 @@ public interface ISubmissionStatusProcessor
 {
     public IGetLatestResponsesQuery GetResponsesQuery { get; }
     public IUser User { get; }
-    public SubmissionStatus Status { get; set; }
+    public Status Status { get; set; }
     public Question? NextQuestion { get; set; }
     public ISectionComponent Section { get; }
     public SectionStatus? SectionStatus { get; }
 
-    Task GetJourneyStatusForSection(string sectionSlug, CancellationToken cancellationToken);
-    Task GetJourneyStatusForSectionRecommendation(string sectionSlug, CancellationToken cancellationToken);
+    Task GetJourneyStatusForSection(string sectionSlug, CancellationToken cancellationToken, bool completed = false);
+    Task GetJourneyStatusForSectionRecommendation(string sectionSlug, CancellationToken cancellationToken, bool completed = false);
 }

--- a/src/Dfe.PlanTech.Domain/Submissions/Models/Submission.cs
+++ b/src/Dfe.PlanTech.Domain/Submissions/Models/Submission.cs
@@ -29,4 +29,6 @@ public class Submission
     public bool Deleted { get; set; }
 
     public bool Viewed { get; set; }
+
+    public string? Status { get; set; }
 }

--- a/src/Dfe.PlanTech.Infrastructure.Data/PlanTechDbContext.cs
+++ b/src/Dfe.PlanTech.Infrastructure.Data/PlanTechDbContext.cs
@@ -154,6 +154,7 @@ public class PlanTechDbContext : DbContext, IPlanTechDbContext
 
     public void AddSignIn(SignIn signIn) => SignIn.Add(signIn);
 
+    public void AddSubmission(Submission submission) => Submissions.Add(submission);
 
     public IQueryable<Submission> GetSubmissions => Submissions;
 
@@ -182,4 +183,15 @@ public class PlanTechDbContext : DbContext, IPlanTechDbContext
     public Task<T?> FirstOrDefaultAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default) => queryable.FirstOrDefaultAsync(cancellationToken);
 
     public Task<List<T>> ToListAsync<T>(IQueryable<T> queryable, CancellationToken cancellationToken = default) => queryable.ToListAsync(cancellationToken);
+
+    public async Task<Submission?> GetSubmissionById(int submissionId, CancellationToken cancellationToken)
+    {
+        return await GetSubmissions
+                .Where(s => s.Id == submissionId)
+                .Include(s => s.Responses)
+                    .ThenInclude(r => r.Question)
+                .Include(s => s.Responses)
+                    .ThenInclude(r => r.Answer)
+                .FirstOrDefaultAsync(cancellationToken);
+    }
 }

--- a/src/Dfe.PlanTech.Web/Controllers/ChangeAnswersController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/ChangeAnswersController.cs
@@ -1,0 +1,69 @@
+﻿using Dfe.PlanTech.Domain.Exceptions;
+using Dfe.PlanTech.Domain.Users.Interfaces;
+using Dfe.PlanTech.Web.Helpers;
+using Dfe.PlanTech.Web.Middleware;
+using Dfe.PlanTech.Web.Routing;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Dfe.PlanTech.Web.Controllers
+{
+    [LogInvalidModelState]
+    [Authorize]
+    [Route("/")]
+    public class ChangeAnswersController : BaseController<ChangeAnswersController>
+    {
+        public const string ControllerName = "ChangeAnswers";
+        public const string ChangeAnswersAction = nameof(ChangeAnswersPage);
+        public const string ChangeAnswersPageSlug = "change-answers";
+        public const string ChangeAnswersViewName = "ChangeAnswers";
+        public const string InlineRecommendationUnavailableErrorMessage = "Unable to save. Please try again. If this problem continues you can";
+
+        private readonly IUser _user;
+
+        public ChangeAnswersController(
+            ILogger<ChangeAnswersController> logger,
+            IUser user
+        ) : base(logger)
+        {
+            _user = user;
+        }
+
+        [HttpGet("{sectionSlug}/change-answers")]
+        public async Task<IActionResult> ChangeAnswersPage(
+            string sectionSlug,
+            [FromServices] IChangeAnswersRouter changeAnswersValidator,
+            [FromServices] IUserJourneyMissingContentExceptionHandler userJourneyMissingContentExceptionHandler,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                ArgumentNullException.ThrowIfNullOrEmpty(sectionSlug);
+
+                var errorMessage = TempData["ErrorMessage"]?.ToString();
+
+                return await changeAnswersValidator.ValidateRoute(sectionSlug, errorMessage, this, cancellationToken);
+            }
+            catch (UserJourneyMissingContentException userJourneyException)
+            {
+                return await userJourneyMissingContentExceptionHandler.Handle(this, userJourneyException, cancellationToken);
+            }
+        }
+
+        [HttpGet("recommendations/from-section/{sectionSlug}")]
+        public async Task<IActionResult> RedirectToRecommendation(
+            string sectionSlug,
+            [FromServices] IGetRecommendationRouter getRecommendationRouter,
+            CancellationToken cancellationToken = default)
+        {
+
+            var recommendationSlug = await getRecommendationRouter.GetRecommendationSlugForSection(sectionSlug, cancellationToken);
+
+            return RedirectToAction(
+                  RecommendationsController.GetRecommendationAction,
+                  RecommendationsController.ControllerName,
+                  new { sectionSlug, recommendationSlug }
+              );
+        }
+    }
+}

--- a/src/Dfe.PlanTech.Web/Controllers/CheckAnswersController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/CheckAnswersController.cs
@@ -23,8 +23,9 @@ public class CheckAnswersController(ILogger<CheckAnswersController> checkAnswers
 
     [HttpGet("{sectionSlug}/check-answers")]
     public async Task<IActionResult> CheckAnswersPage(string sectionSlug,
+                                                      [FromQuery] bool isChangeAnswersFlow,
                                                       [FromServices] ICheckAnswersRouter checkAnswersValidator,
-                                                      [FromServices] IUserJourneyMissingContentExceptionHandler userJourneyMissingContentExceptionHandler,
+                                                      [FromServices] IUserJourneyMissingContentExceptionHandler userJourneyMissingContentExceptionHandler,                                                     
                                                       CancellationToken cancellationToken = default)
     {
         try
@@ -33,7 +34,7 @@ public class CheckAnswersController(ILogger<CheckAnswersController> checkAnswers
 
             var errorMessage = TempData["ErrorMessage"]?.ToString();
 
-            return await checkAnswersValidator.ValidateRoute(sectionSlug, errorMessage, this, cancellationToken);
+            return await checkAnswersValidator.ValidateRoute(sectionSlug, errorMessage, this, cancellationToken, isChangeAnswersFlow);
         }
         catch (UserJourneyMissingContentException userJourneyException)
         {
@@ -47,8 +48,9 @@ public class CheckAnswersController(ILogger<CheckAnswersController> checkAnswers
         int submissionId,
         string sectionName,
         string redirectOption,
-        [FromServices] ICalculateMaturityCommand calculateMaturityCommand,
+        [FromServices] ICalculateMaturityCommand calculateMaturityCommand,         
         [FromServices] IGetRecommendationRouter getRecommendationRouter,
+        [FromServices] IMarkSubmissionAsReviewedCommand markSubmissionAsReviewedCommand,
         CancellationToken cancellationToken = default)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(submissionId);
@@ -57,6 +59,7 @@ public class CheckAnswersController(ILogger<CheckAnswersController> checkAnswers
         try
         {
             await calculateMaturityCommand.CalculateMaturityAsync(submissionId, cancellationToken);
+            await markSubmissionAsReviewedCommand.MarkSubmissionAsReviewed(submissionId, cancellationToken);
         }
         catch (Exception e)
         {

--- a/src/Dfe.PlanTech.Web/Controllers/QuestionsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/QuestionsController.cs
@@ -49,17 +49,20 @@ public class QuestionsController : BaseController<QuestionsController>
         _contactOptions = contactOptions.Value;
     }
 
-    [LogInvalidModelState]
     [HttpGet("{sectionSlug}/{questionSlug}")]
     public async Task<IActionResult> GetQuestionBySlug(string sectionSlug,
-                                                        string questionSlug,
-                                                        [FromServices] IGetQuestionBySlugRouter router,
-                                                        CancellationToken cancellationToken = default)
+                                                    string questionSlug,
+                                                    string? returnTo,
+                                                    [FromServices] IGetQuestionBySlugRouter router,
+                                                    CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrEmpty(sectionSlug))
             throw new ArgumentNullException(nameof(sectionSlug));
         if (string.IsNullOrEmpty(questionSlug))
             throw new ArgumentNullException(nameof(questionSlug));
+
+        // Optionally store the returnTo value in TempData or pass it along if router needs it
+        TempData["ReturnTo"] = returnTo;
 
         return await router.ValidateRoute(sectionSlug, questionSlug, this, cancellationToken);
     }
@@ -136,7 +139,9 @@ public class QuestionsController : BaseController<QuestionsController>
         string questionSlug,
         SubmitAnswerDto submitAnswerDto,
         [FromServices] ISubmitAnswerCommand submitAnswerCommand,
-        CancellationToken cancellationToken = default)
+        [FromServices] IGetNextUnansweredQuestionQuery getQuestionQuery,
+        CancellationToken cancellationToken = default,
+        string? returnTo = "")
     {
         if (!ModelState.IsValid)
         {
@@ -155,6 +160,46 @@ public class QuestionsController : BaseController<QuestionsController>
             var viewModel = await GenerateViewModel(sectionSlug, questionSlug, cancellationToken);
             viewModel.ErrorMessages = new[] { "Save failed. Please try again later." };
             return RenderView(viewModel);
+        }
+
+        var isChangeAnswersFlow = returnTo == "ChangeAnswers";
+
+        if (isChangeAnswersFlow)
+        {
+            var establishmentId = await _user.GetEstablishmentId();
+
+            var section = await GetSectionBySlug(sectionSlug, cancellationToken)
+                    ?? throw new InvalidOperationException($"Section not found for slug '{sectionSlug}'");
+
+            var submissionResponsesDto = await _getResponseQuery.GetLatestResponses(
+                establishmentId,
+                section.Sys.Id,
+                false,
+            cancellationToken);
+
+            if (submissionResponsesDto?.Responses == null)
+            {
+                return this.RedirectToCheckAnswers(sectionSlug, isChangeAnswersFlow);
+            }
+
+            // Check answered questions
+            var nextQuestion = GetNextAnsweredQuestion(section, submissionResponsesDto, questionSlug);
+
+            // Check unanswered to see if we really have no more questions
+            nextQuestion ??= await getQuestionQuery.GetNextUnansweredQuestion(establishmentId, section, cancellationToken);
+
+            if (nextQuestion != null)
+            {
+                return RedirectToAction(nameof(GetQuestionBySlug), new
+                {
+                    sectionSlug,
+                    questionSlug = nextQuestion.Slug,
+                    returnTo = "ChangeAnswers"
+                });
+            }
+
+            // No next questions so check answers
+            return this.RedirectToCheckAnswers(sectionSlug, isChangeAnswersFlow);
         }
 
         return RedirectToAction(nameof(GetNextUnansweredQuestion), new { sectionSlug });
@@ -179,9 +224,15 @@ public class QuestionsController : BaseController<QuestionsController>
     }
 
     [NonAction]
-    public QuestionViewModel GenerateViewModel(string? sectionSlug, Question question, ISectionComponent? section, string? latestAnswerContentfulId)
+    public QuestionViewModel GenerateViewModel(string? sectionSlug, Question question, ISectionComponent? section, string? latestAnswerContentfulId, bool includeCompleted = false)
     {
         ViewData["Title"] = question.Text;
+
+        var returnTo = TempData["ReturnTo"]?.ToString();
+        if (!string.IsNullOrEmpty(returnTo))
+        {
+            ViewData["ReturnTo"] = returnTo;
+        }
 
         return new QuestionViewModel()
         {
@@ -191,6 +242,23 @@ public class QuestionsController : BaseController<QuestionsController>
             SectionSlug = sectionSlug,
             SectionId = section?.Sys.Id
         };
+    }
+
+    private static Question? GetNextAnsweredQuestion(Section section, SubmissionResponsesDto answeredQuestions, string currentQuestionSlug)
+    {
+        // Get the valid journey based on latest answers
+        var journey = section.GetOrderedResponsesForJourney(answeredQuestions.Responses).ToList();
+
+        // This is the current position in the journey
+        var currentIndex = journey.FindIndex(q => q.QuestionSlug == currentQuestionSlug);
+
+        if (currentIndex == -1 || currentIndex + 1 >= journey.Count)
+            return null;
+
+        // The next question in the valid journey (even if unanswered)
+        var nextQuestionSlug = journey[currentIndex + 1].QuestionSlug;
+
+        return section.Questions.FirstOrDefault(q => q.Slug == nextQuestionSlug);
     }
 
     public static IActionResult RedirectToQuestionBySlug(string sectionSlug, string questionSlug, Controller controller)

--- a/src/Dfe.PlanTech.Web/Controllers/RecommendationsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/RecommendationsController.cs
@@ -69,5 +69,18 @@ public class RecommendationsController(ILogger<RecommendationsController> logger
             this,
             cancellationToken);
     }
+
+    [HttpGet("from-section/{sectionSlug}")]
+    public async Task<IActionResult> FromSection(
+        string sectionSlug,
+        [FromServices] IGetRecommendationRouter getRecommendationRouter,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(sectionSlug))
+            throw new ArgumentNullException(nameof(sectionSlug));
+
+        var recommendationSlug = await getRecommendationRouter.GetRecommendationSlugForSection(sectionSlug, cancellationToken);
+        return RedirectToAction(nameof(GetRecommendation), new { recommendationSlug });
+    }
 }
 

--- a/src/Dfe.PlanTech.Web/Helpers/PageRedirecter.cs
+++ b/src/Dfe.PlanTech.Web/Helpers/PageRedirecter.cs
@@ -9,8 +9,8 @@ public static class PageRedirecter
     public static RedirectToActionResult RedirectToSelfAssessment(this Controller controller)
     => RedirectToPage(controller, UrlConstants.SelfAssessmentPage);
 
-    public static RedirectToActionResult RedirectToCheckAnswers(this Controller controller, string sectionSlug)
-      => controller.RedirectToAction(CheckAnswersController.CheckAnswersAction, CheckAnswersController.ControllerName, new { sectionSlug });
+    public static RedirectToActionResult RedirectToCheckAnswers(this Controller controller, string sectionSlug, bool isChangeAnswersFlow = false)
+      => controller.RedirectToAction(CheckAnswersController.CheckAnswersAction, CheckAnswersController.ControllerName, new { sectionSlug, isChangeAnswersFlow });
 
     public static RedirectToActionResult RedirectToInterstitialPage(this Controller controller, string sectionSlug)
     => RedirectToPage(controller, sectionSlug);

--- a/src/Dfe.PlanTech.Web/Models/ChangeAnswersViewModel.cs
+++ b/src/Dfe.PlanTech.Web/Models/ChangeAnswersViewModel.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Domain.Questionnaire.Models;
+
+namespace Dfe.PlanTech.Web.Models;
+
+public class ChangeAnswersViewModel
+{
+    [Required]
+    public Title Title { get; init; } = null!;
+
+    [Required]
+    public string SectionName { get; init; } = null!;
+
+    [Required]
+    public SubmissionResponsesDto SubmissionResponses { get; init; } = null!;
+
+    public int? SubmissionId { get; init; }
+
+    public string? SectionSlug { get; init; } = null;
+
+    public string? Slug { get; init; } = null;
+
+    public string? ErrorMessage { get; set; } = null;
+}

--- a/src/Dfe.PlanTech.Web/ProgramExtensions.cs
+++ b/src/Dfe.PlanTech.Web/ProgramExtensions.cs
@@ -147,6 +147,7 @@ public static class ProgramExtensions
         ConfigureCookies(services, configuration);
 
         services.AddTransient<ICalculateMaturityCommand, CalculateMaturityCommand>();
+        services.AddScoped<IMarkSubmissionAsReviewedCommand, MarkSubmissionAsReviewedCommand>();
         services.AddTransient<ICreateEstablishmentCommand, CreateEstablishmentCommand>();
         services.AddTransient<ICreateUserCommand, CreateUserCommand>();
         services.AddTransient<IGetEntityFromContentfulQuery, GetEntityFromContentfulQuery>();
@@ -163,6 +164,7 @@ public static class ProgramExtensions
         services.AddTransient<IDeleteCurrentSubmissionCommand, DeleteCurrentSubmissionCommand>();
         services.AddTransient<IRecordGroupSelectionCommand, RecordGroupSelectionCommand>();
         services.AddTransient<IGetGroupSelectionQuery, GetGroupSelectionQuery>();
+        services.AddTransient<ISubmissionCommand, SubmissionCommand>();
 
         return services;
     }
@@ -225,6 +227,7 @@ public static class ProgramExtensions
         services.AddTransient<IGetRecommendationRouter, GetRecommendationRouter>();
         services.AddTransient<IGetQuestionBySlugRouter, GetQuestionBySlugRouter>();
         services.AddTransient<ICheckAnswersRouter, CheckAnswersRouter>();
+        services.AddTransient<IChangeAnswersRouter, ChangeAnswersRouter>();
 
         services.AddTransient((_) => SectionCompleteStatusChecker.SectionComplete);
         services.AddTransient((_) => SectionNotStartedStatusChecker.SectionNotStarted);

--- a/src/Dfe.PlanTech.Web/Routing/ChangeAnswersRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/ChangeAnswersRouter.cs
@@ -1,0 +1,123 @@
+﻿using Dfe.PlanTech.Application.Exceptions;
+using Dfe.PlanTech.Domain.Content.Interfaces;
+using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Domain.Submissions.Enums;
+using Dfe.PlanTech.Domain.Submissions.Interfaces;
+using Dfe.PlanTech.Domain.Users.Interfaces;
+using Dfe.PlanTech.Web.Controllers;
+using Dfe.PlanTech.Web.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Dfe.PlanTech.Web.Routing
+{
+    public class ChangeAnswersRouter : IChangeAnswersRouter
+    {
+        private const string PageTitle = "Change Answers";
+
+        private readonly IGetPageQuery _getPageQuery;
+        private readonly IProcessSubmissionResponsesCommand _processSubmissionResponsesCommand;
+        private readonly IUser _user;
+        private readonly ISubmissionStatusProcessor _router;
+        private readonly IGetLatestResponsesQuery _submissionQuery;
+        private readonly ISubmissionCommand _submissionCommand;
+
+        public ChangeAnswersRouter(
+            IGetPageQuery getPageQuery,
+            IProcessSubmissionResponsesCommand processSubmissionResponsesCommand,
+            IUser user,
+            ISubmissionStatusProcessor router,
+            IGetLatestResponsesQuery submissionQuery,
+            ISubmissionCommand submissionCommand)
+        {
+            _getPageQuery = getPageQuery;
+            _processSubmissionResponsesCommand = processSubmissionResponsesCommand;
+            _user = user;
+            _router = router;
+            _submissionQuery = submissionQuery;
+            _submissionCommand = submissionCommand;
+        }
+
+        public async Task<IActionResult> ValidateRoute(
+            string sectionSlug,
+            string? errorMessage,
+            ChangeAnswersController controller,
+            CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(sectionSlug))
+                throw new ArgumentNullException(nameof(sectionSlug));
+
+            await _router.GetJourneyStatusForSectionRecommendation(sectionSlug, cancellationToken, true);
+
+            switch (_router.Status)
+            {
+                case Status.CompleteNotReviewed:
+                    return await ProcessChangeAnswers(sectionSlug, errorMessage, controller, cancellationToken);
+
+                case Status.CompleteReviewed:
+                {
+                    var establishmentId = await _router.User.GetEstablishmentId();
+                    var sectionId = _router.Section.Sys.Id;
+
+                    // Check if an in-progress submission already exists
+                    var inProgressSubmission = await _submissionQuery.GetInProgressSubmission(
+                        establishmentId, sectionId, cancellationToken);
+
+                    if (inProgressSubmission != null)
+                    {
+                        await _submissionCommand.DeleteSubmission(inProgressSubmission.Id, cancellationToken);                  
+                    }
+
+                    var latestSubmission = await _submissionQuery.GetLatestCompletedSubmission(
+                                                        establishmentId, sectionId);
+
+                    var clonedSubmission = await _submissionCommand.CloneSubmission(
+                        latestSubmission, cancellationToken);               
+
+                    return await ProcessChangeAnswers(sectionSlug, errorMessage, controller, cancellationToken);
+                }
+
+                case Status.NotStarted:
+                    return PageRedirecter.RedirectToSelfAssessment(controller);
+
+                default:
+                    return ProcessQuestionStatus(sectionSlug, controller);
+            }
+        }
+
+        private async Task<IActionResult> ProcessChangeAnswers(
+            string sectionSlug,
+            string? errorMessage,
+            ChangeAnswersController controller,
+            CancellationToken cancellationToken)
+        {
+            var establishmentId = await _user.GetEstablishmentId();
+
+            var submissionResponsesDto = await _processSubmissionResponsesCommand
+                .GetSubmissionResponsesDtoForSection(establishmentId, _router.Section, cancellationToken, true);
+
+            await _router.GetJourneyStatusForSectionRecommendation(sectionSlug, cancellationToken, false);
+
+            if (submissionResponsesDto?.Responses == null)
+                throw new DatabaseException("Could not retrieve the answered question list");
+
+            var model = new ChangeAnswersViewModel()
+            {
+                Title = new Title() { Text = PageTitle },
+                SectionName = _router.Section.Name,
+                SubmissionResponses = submissionResponsesDto,
+                SectionSlug = sectionSlug,
+                SubmissionId = submissionResponsesDto.SubmissionId,
+                Slug = ChangeAnswersController.ChangeAnswersPageSlug,
+                ErrorMessage = errorMessage
+            };
+
+            return controller.View(ChangeAnswersController.ChangeAnswersViewName, model);
+        }
+
+        private IActionResult ProcessQuestionStatus(string sectionSlug, Controller controller)
+        {
+            var nextQuestionSlug = _router.NextQuestion?.Slug ?? _router.Section.Questions.First().Slug;
+            return QuestionsController.RedirectToQuestionBySlug(sectionSlug, nextQuestionSlug, controller);
+        }
+    }
+}

--- a/src/Dfe.PlanTech.Web/Routing/GetQuestionBySlugRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/GetQuestionBySlugRouter.cs
@@ -46,18 +46,21 @@ public class GetQuestionBySlugRouter : IGetQuestionBySlugRouter
         if (string.IsNullOrEmpty(questionSlug))
             throw new ArgumentNullException(nameof(questionSlug));
 
-        await _router.GetJourneyStatusForSection(sectionSlug, cancellationToken);
+        var returnTo = controller.TempData["ReturnTo"]?.ToString();
+        var isChangeAnswersFlow = returnTo == "ChangeAnswers";
+
+        await _router.GetJourneyStatusForSection(sectionSlug, cancellationToken, false);
 
         if (IsSlugForNextQuestion(questionSlug))
         {
-            var viewModel = controller.GenerateViewModel(sectionSlug, _router.NextQuestion!, _router.Section, null);
+            var viewModel = controller.GenerateViewModel(sectionSlug, _router.NextQuestion!, _router.Section, null, isChangeAnswersFlow);
             return controller.RenderView(viewModel);
         }
 
         if (SectionIsAtStart)
             return PageRedirecter.RedirectToInterstitialPage(controller, sectionSlug);
 
-        return await ProcessOtherStatuses(sectionSlug, questionSlug, controller, cancellationToken);
+        return await ProcessOtherStatuses(sectionSlug, questionSlug, controller, cancellationToken, isChangeAnswersFlow);
     }
 
     /// <summary>
@@ -78,11 +81,17 @@ public class GetQuestionBySlugRouter : IGetQuestionBySlugRouter
     /// <param name="controller"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    private async Task<IActionResult> ProcessOtherStatuses(string sectionSlug, string questionSlug, QuestionsController controller, CancellationToken cancellationToken)
+    private async Task<IActionResult> ProcessOtherStatuses(string sectionSlug, string questionSlug, QuestionsController controller, CancellationToken cancellationToken, bool isChangeAnswersFlow)
     {
         var question = GetQuestionForSlug(questionSlug);
 
-        var responses = await GetLatestResponsesForSection(cancellationToken);
+        var responses = await GetLatestResponsesForSection(cancellationToken, isChangeAnswersFlow);
+
+        if (responses is null)
+        {
+            throw new InvalidOperationException(
+                $"No responses were found for section '{_router.Section.Sys.Id}'");
+        }
 
         var isAttachedQuestion = IsQuestionAttached(responses, question);
 
@@ -114,11 +123,11 @@ public class GetQuestionBySlugRouter : IGetQuestionBySlugRouter
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     /// <exception cref="DatabaseException">Thrown if no responses are found</exception>
-    private async Task<List<QuestionWithAnswer>> GetLatestResponsesForSection(CancellationToken cancellationToken)
+    private async Task<List<QuestionWithAnswer>> GetLatestResponsesForSection(CancellationToken cancellationToken, bool completed = false)
     {
         var establishmentId = await _user.GetEstablishmentId();
 
-        var latestResponses = await _getResponseQuery.GetLatestResponses(establishmentId, _router.Section.Sys.Id, false, cancellationToken);
+        var latestResponses = await _getResponseQuery.GetLatestResponses(establishmentId, _router.Section.Sys.Id, completed, cancellationToken);
 
         if (latestResponses == null || latestResponses.Responses.Count == 0)
             throw new DatabaseException($"Could not find latest responses for '{_router.Section.Sys.Id}'");
@@ -162,15 +171,15 @@ public class GetQuestionBySlugRouter : IGetQuestionBySlugRouter
     private IActionResult HandleNotAttachedQuestion(string sectionSlug, QuestionsController controller)
     => _router.Status switch
     {
-        SubmissionStatus.CheckAnswers => controller.RedirectToCheckAnswers(sectionSlug),
-        SubmissionStatus.NextQuestion => QuestionsController.RedirectToQuestionBySlug(sectionSlug, _router.NextQuestion?.Slug ?? throw new InvalidDataException("NextQuestion is null"), controller),
+        Status.CompleteNotReviewed => controller.RedirectToCheckAnswers(sectionSlug),
+        Status.InProgress => QuestionsController.RedirectToQuestionBySlug(sectionSlug, _router.NextQuestion?.Slug ?? throw new InvalidDataException("NextQuestion is null"), controller),
         _ => throw new InvalidDataException("Should not be here"),
     };
 
     /// <summary>
     /// Are we at the start of the section? I.e. "NotStarted" or "Completed"
     /// </summary>
-    private bool SectionIsAtStart => _router.Status == SubmissionStatus.NotStarted || _router.Status == SubmissionStatus.Completed;
+    private bool SectionIsAtStart => _router.Status == Status.NotStarted;
 
     /// <summary>
     /// Does this slug match the NextQuestion field in the <see cref="_router"/> 

--- a/src/Dfe.PlanTech.Web/Routing/IChangeAnswersRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/IChangeAnswersRouter.cs
@@ -4,12 +4,12 @@ using Microsoft.AspNetCore.Mvc;
 namespace Dfe.PlanTech.Web.Routing;
 
 /// <summary>
-/// Router for "Check Answers" page under <see cref="CheckAnswersController"/> 
+/// Router for "Change Answers" page under <see cref="ChangeAnswersController"/> 
 /// </summary>
-public interface ICheckAnswersRouter
+public interface IChangeAnswersRouter
 {
     /// <summary>
-    /// Gets current user journey status, then either returns Check Answers page (if appropriate), 
+    /// Gets current user journey status, then either returns Change Answers page (if appropriate), 
     /// or redirects to correct next part of user journey
     /// </summary>
     /// <param name="sectionSlug"></param>
@@ -19,7 +19,6 @@ public interface ICheckAnswersRouter
     /// <returns></returns>
     Task<IActionResult> ValidateRoute(string sectionSlug,
                                       string? errorMessage,
-                                      CheckAnswersController controller,
-                                      CancellationToken cancellationToken,
-                                      bool isChangeAnswersFlow = false);
+                                      ChangeAnswersController controller,
+                                      CancellationToken cancellationToken);
 }

--- a/src/Dfe.PlanTech.Web/Views/ChangeAnswers/ChangeAnswers.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/ChangeAnswers/ChangeAnswers.cshtml
@@ -1,0 +1,65 @@
+@using Dfe.PlanTech.Application.Constants
+@using Dfe.PlanTech.Web.Controllers
+@model Dfe.PlanTech.Web.Models.ChangeAnswersViewModel
+
+@section BeforeContent {
+    @{
+        await Html.RenderPartialAsync("BackButton");
+    }
+}
+
+<div class="govuk-grid-row" id="changeYourAnswers-page">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <h3 class="govuk-caption-xl">@Model.SectionName</h3>
+        <h1 class="govuk-heading-xl">Change your answers</h1>
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+        <dl class="govuk-summary-list govuk-!-margin-bottom-0">
+            @foreach (var questionWithAnswer in Model.SubmissionResponses.Responses)
+            {
+                var anchorLabel = $"your answer for {questionWithAnswer.QuestionText}";
+
+                <div class="govuk-!-margin-bottom-5">
+                    <div class="govuk-!-margin-bottom-1">
+                        <p class="govuk-!-font-weight-bold">@questionWithAnswer.QuestionText</p>
+                    </div>
+
+                    <div class="govuk-!-margin-bottom-5">
+                        <p class="govuk-body">@questionWithAnswer.AnswerText</p>
+                    </div>
+
+                    <div class="noprint govuk-!-margin-bottom-5">
+                        <a asp-controller="Questions" asp-action="GetQuestionBySlug"
+                           asp-route-questionSlug="@questionWithAnswer.QuestionSlug"
+                           asp-route-sectionSlug="@Model.SectionSlug"
+                           asp-route-returnTo="ChangeAnswers"
+                           title="@questionWithAnswer.QuestionText"
+                           class="govuk-link">
+                            Change <span class="govuk-visually-hidden">@anchorLabel</span>
+                        </a>
+                    </div>
+
+                    <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-4 govuk-!-margin-bottom-4" />
+                </div>
+            }
+        </dl>
+        <form asp-controller="CheckAnswers" asp-action="ConfirmCheckAnswers" method="post" class="noprint">
+            <input type="hidden" name="submissionId" value="@Model.SubmissionId"/>
+            <input type="hidden" name="sectionName" value="@Model.SectionName">
+            <input type="hidden" name="sectionSlug" value="@Model.SectionSlug">
+
+            <a href="@($"{UrlConstants.RecommendationsPage}/from-section/{Model.SectionSlug}")" role="button" draggable="false"
+               class="govuk-button govuk-button--secondary" data-module="govuk-button">
+                Back to recommendations
+            </a>
+
+            @if (Model.ErrorMessage != null)
+            {
+                <p class="govuk-error-message">
+                    <span class="govuk-visually-hidden">Error:</span> @Model.ErrorMessage <a class="govuk-error-message"
+                        href="@UrlConstants.SelfAssessmentPage">return to the self-assessment page</a>
+                </p>
+            }
+
+        </form>
+    </div>
+</div>

--- a/src/Dfe.PlanTech.Web/Views/CheckAnswers/CheckAnswers.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/CheckAnswers/CheckAnswers.cshtml
@@ -51,7 +51,6 @@
             }
 
             <govuk-button class="govuk-!-margin-right-5" type="submit" name="redirectOption" value="@RecommendationsController.GetRecommendationAction">Submit and view recommendations</govuk-button>
-            <govuk-button class="govuk-button--secondary" type="submit" name="redirectOption" value="@UrlConstants.SelfAssessmentPage">Submit and go to self-assessment topics</govuk-button>
 
             @if (Model.ErrorMessage != null)
             {

--- a/src/Dfe.PlanTech.Web/Views/Questions/Question.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Questions/Question.cshtml
@@ -13,6 +13,10 @@
     <input id="QuestionId" type="hidden" value=@Model.Question.Sys.Id name="QuestionId"/>
     <input id="SectionId" type="hidden" value="@Model.SectionId" name="SectionId"/>
     <input id="SectionName" type="hidden" value="@Model.SectionName" name="SectionName"/>
+    @if (!string.IsNullOrEmpty(ViewData["ReturnTo"]?.ToString()))
+    {
+        <input type="hidden" name="returnTo" value="@ViewData["ReturnTo"]" />
+    }
 
     <govuk-radios name="ChosenAnswerJson">
         <govuk-radios-fieldset>

--- a/src/Dfe.PlanTech.Web/Views/Recommendations/Content.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/Content.cshtml
@@ -1,16 +1,30 @@
 @using Dfe.PlanTech.Domain.Questionnaire.Models
 @using GovUk.Frontend.AspNetCore.TagHelpers
 @using Microsoft.AspNetCore.Mvc.TagHelpers
-@model Dfe.PlanTech.Domain.Questionnaire.Interfaces.IHeaderWithContent
+@model Tuple<Dfe.PlanTech.Domain.Questionnaire.Interfaces.IHeaderWithContent, string?>
+
+@{
+    var header = Model.Item1;
+    var submissionDate = Model.Item2;
+}
 
 <div class="recommendation-piece-content">
-    @foreach (var content in Model.Content)
+    @foreach (var content in header.Content)
     {
+        @if (header.SlugifiedLinkText == "overview" && !string.IsNullOrEmpty(submissionDate))
+        {
+            <div class="govuk-inset-text">
+                <p>
+                    The self-assessment for broadband connection was completed on
+                    <strong>@submissionDate</strong>. You can change your answers at any time.
+                </p>
+            </div>
+        }
         <partial name="Components/PageComponentFactory" model="@content" />
     }
 </div>
 
-@if (Model is RecommendationChunk chunk && chunk.CSLink != null)
+@if (header is RecommendationChunk chunk && chunk.CSLink != null)
 {
     <div class="govuk-!-margin-top-3 govuk-!-margin-bottom-9">
         <a class="govuk-body govuk-link govuk-!-font-weight-bold" href=@chunk.CSLink.Url>@chunk.CSLink.LinkText</a>

--- a/src/Dfe.PlanTech.Web/Views/Recommendations/Recommendations.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/Recommendations.cshtml
@@ -37,7 +37,7 @@ and the headers & chunks to have a shared parent for displaying based on anchor 
                         <div class="govuk-grid-column-three-quarters">
                             @if (!headerWithContent.SlugifiedLinkText.Equals("your-self-assessment"))
                             {
-                                <partial name="Content" model="@headerWithContent" />
+                                <partial name="Content" model="@(Tuple.Create(headerWithContent, Model.LatestCompletionDate))" />
                                 
                             }
                             else {

--- a/src/Dfe.PlanTech.Web/Views/Recommendations/YSA.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/YSA.cshtml
@@ -1,4 +1,6 @@
-﻿@model Dfe.PlanTech.Web.Models.RecommendationsViewModel
+﻿@using Dfe.PlanTech.Domain.Helpers
+@using Dfe.PlanTech.Web.Helpers
+@model Dfe.PlanTech.Web.Models.RecommendationsViewModel
 
 <div id="checkYourAnswers-page">
     <p>
@@ -6,18 +8,13 @@
         You can change your answers at any time.
     </p>
 
-@* leaving this static for now to update on the next ticket when we have scope of a newly in-progress submission after completion *@
-    <p>
-        Another self assessment was started on <strong>19 May 2025</strong>.
-        <a href="#">Continue this self-assessment</a>.
-    </p>
-  
     <h2 class="govuk-heading-l">@Model.SectionName</h2>
 
+    <hr class="govuk-section-break govuk-section-break--visible">
+
     <dl class="govuk-summary-list">
-        <hr class="govuk-section-break govuk-section-break--visible">
-            @foreach (var questionWithAnswer in Model.SubmissionResponses)
-            {
+        @foreach (var questionWithAnswer in Model.SubmissionResponses)
+        {
             <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key spacer govuk-!-margin-top-4">
                     @questionWithAnswer.QuestionText
@@ -25,11 +22,12 @@
                 <dd class="govuk-summary-list__value spacer govuk-!-margin-bottom-4">
                     @questionWithAnswer.AnswerText
                 </dd>
-             </div>
-            }
-        </dl>
+            </div>
+        }
+    </dl>
 
-    <a href="check-answers" role="button" draggable="false" class="govuk-button" data-module="govuk-button" data-govuk-button-init="">
+    <a href="/@Model.SectionName.Slugify()/change-answers" role="button" draggable="false"
+       class="govuk-button" data-module="govuk-button" data-govuk-button-init="">
         Change your answers
     </a>
 </div>


### PR DESCRIPTION
## Overview
Added change you answers page with logic

Addresses ticket [#257394](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/257394)

The design for the ticket is based on:
https://lucid.app/lucidspark/4d1a8bac-cc34-46d3-bab1-d2097675ec77/edit?invitationId=inv_82d8b50c-4770-4ed5-995e-d672fdfe35f0&page=0_0#

## Changes
Added change your answers page
Added new submission status to table
Added change your answers logic while maintaining current functionality flow 

## How to review the PR

Run through a submission as normal (make sure to point to local db for testing don't point to dev). Complete submission > navigate to YSA page > Change your answers button at the bottom. Change answers and run through Q&A flow, Submit and view recommendations to see new answers/recommendations.

## Release requirements

Update script to dev db is needed to give completed submissions a new Status (most likely InProgress or CompleteReviewed).
Contentful changes to match prototype content and slug changes e.g. /self-assessment needs changing to /home

Delete any rows that do not apply to the PR.

- [x ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [ ] PR targets development branch
- [ x] Unit tests have been added/updated
- [ ] E2E tests have been added/updated
- [ ] GitHub workflows/actions have been added/updated
- [ ] Terraform has been updated
- [ ] Documentation has been updated where relevant
- [ ] Any Key Vault secrets have been added to the development Key Vault
