### PR TITLE
Merge Feat/257799/home page journey v1 into Development

### DIFF
--- a/src/Dfe.PlanTech.Application/Responses/Commands/ProcessSubmissionResponsesDto.cs
+++ b/src/Dfe.PlanTech.Application/Responses/Commands/ProcessSubmissionResponsesDto.cs
@@ -13,7 +13,7 @@ public class ProcessSubmissionResponsesDto : IProcessSubmissionResponsesCommand
         _getLatestResponseListForSubmissionQuery = getLatestResponseListForSubmissionQuery;
     }
 
-    public async Task<SubmissionResponsesDto?> GetSubmissionResponsesDtoForSection(int establishmentId, ISectionComponent section, CancellationToken cancellationToken = default, bool completed = false)
+    public async Task<SubmissionResponsesDto?> GetSubmissionResponsesDtoForSection(int establishmentId, ISectionComponent section, bool completed = false, CancellationToken cancellationToken = default)
     {
         var submissionResponsesDto = await _getLatestResponseListForSubmissionQuery.GetLatestResponses(establishmentId, section.Sys.Id, completed, cancellationToken);
         if (submissionResponsesDto?.Responses == null || submissionResponsesDto.Responses.Count == 0)

--- a/src/Dfe.PlanTech.Application/Submissions/Queries/SubmissionStatusProcessor.cs
+++ b/src/Dfe.PlanTech.Application/Submissions/Queries/SubmissionStatusProcessor.cs
@@ -45,12 +45,12 @@ public class SubmissionStatusProcessor : ISubmissionStatusProcessor
         User = user;
     }
 
-    public async Task GetJourneyStatusForSection(string sectionSlug, CancellationToken cancellationToken, bool completed)
+    public async Task GetJourneyStatusForSection(string sectionSlug, bool completed, CancellationToken cancellationToken)
     {
         await GetJourneyStatus(sectionSlug, completed, cancellationToken);
     }
 
-    public async Task GetJourneyStatusForSectionRecommendation(string sectionSlug, CancellationToken cancellationToken, bool completed)
+    public async Task GetJourneyStatusForSectionRecommendation(string sectionSlug, bool completed, CancellationToken cancellationToken)
     {
         await GetJourneyStatus(sectionSlug, completed, cancellationToken);
     }

--- a/src/Dfe.PlanTech.Domain/Submissions/Interfaces/IProcessSubmissionResponsesCommand.cs
+++ b/src/Dfe.PlanTech.Domain/Submissions/Interfaces/IProcessSubmissionResponsesCommand.cs
@@ -5,5 +5,5 @@ namespace Dfe.PlanTech.Domain.Submissions.Interfaces;
 
 public interface IProcessSubmissionResponsesCommand
 {
-    public Task<SubmissionResponsesDto?> GetSubmissionResponsesDtoForSection(int establishmentId, ISectionComponent section, CancellationToken cancellationToken = default, bool completed = false);
+    public Task<SubmissionResponsesDto?> GetSubmissionResponsesDtoForSection(int establishmentId, ISectionComponent section, bool completed = false, CancellationToken cancellationToken = default);
 }

--- a/src/Dfe.PlanTech.Domain/Submissions/Interfaces/ISubmissionStatusProcessor.cs
+++ b/src/Dfe.PlanTech.Domain/Submissions/Interfaces/ISubmissionStatusProcessor.cs
@@ -19,6 +19,6 @@ public interface ISubmissionStatusProcessor
     public ISectionComponent Section { get; }
     public SectionStatus? SectionStatus { get; }
 
-    Task GetJourneyStatusForSection(string sectionSlug, CancellationToken cancellationToken, bool completed = false);
-    Task GetJourneyStatusForSectionRecommendation(string sectionSlug, CancellationToken cancellationToken, bool completed = false);
+    Task GetJourneyStatusForSection(string sectionSlug, bool completed = false, CancellationToken cancellationToken = default);
+    Task GetJourneyStatusForSectionRecommendation(string sectionSlug, bool completed = false, CancellationToken cancellationToken = default);
 }

--- a/src/Dfe.PlanTech.Web/Controllers/CheckAnswersController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/CheckAnswersController.cs
@@ -34,7 +34,7 @@ public class CheckAnswersController(ILogger<CheckAnswersController> checkAnswers
 
             var errorMessage = TempData["ErrorMessage"]?.ToString();
 
-            return await checkAnswersValidator.ValidateRoute(sectionSlug, errorMessage, this, cancellationToken, isChangeAnswersFlow);
+            return await checkAnswersValidator.ValidateRoute(sectionSlug, errorMessage, this, isChangeAnswersFlow, cancellationToken);
         }
         catch (UserJourneyMissingContentException userJourneyException)
         {

--- a/src/Dfe.PlanTech.Web/Controllers/QuestionsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/QuestionsController.cs
@@ -140,8 +140,8 @@ public class QuestionsController : BaseController<QuestionsController>
         SubmitAnswerDto submitAnswerDto,
         [FromServices] ISubmitAnswerCommand submitAnswerCommand,
         [FromServices] IGetNextUnansweredQuestionQuery getQuestionQuery,
-        CancellationToken cancellationToken = default,
-        string? returnTo = "")
+        string? returnTo = "",
+        CancellationToken cancellationToken = default)
     {
         if (!ModelState.IsValid)
         {
@@ -224,7 +224,7 @@ public class QuestionsController : BaseController<QuestionsController>
     }
 
     [NonAction]
-    public QuestionViewModel GenerateViewModel(string? sectionSlug, Question question, ISectionComponent? section, string? latestAnswerContentfulId, bool includeCompleted = false)
+    public QuestionViewModel GenerateViewModel(string? sectionSlug, Question question, ISectionComponent? section, string? latestAnswerContentfulId)
     {
         ViewData["Title"] = question.Text;
 

--- a/src/Dfe.PlanTech.Web/Models/RecommendationsViewModel.cs
+++ b/src/Dfe.PlanTech.Web/Models/RecommendationsViewModel.cs
@@ -8,6 +8,8 @@ public class RecommendationsViewModel
 {
     public string SectionName { get; init; } = null!;
 
+    public string SectionSlug { get; init; } = null!;
+
     public RecommendationIntro Intro { get; init; } = null!;
 
     public List<RecommendationChunk> Chunks { get; init; } = null!;

--- a/src/Dfe.PlanTech.Web/Routing/ChangeAnswersRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/ChangeAnswersRouter.cs
@@ -46,7 +46,7 @@ namespace Dfe.PlanTech.Web.Routing
             if (string.IsNullOrEmpty(sectionSlug))
                 throw new ArgumentNullException(nameof(sectionSlug));
 
-            await _router.GetJourneyStatusForSectionRecommendation(sectionSlug, cancellationToken, true);
+            await _router.GetJourneyStatusForSectionRecommendation(sectionSlug, true, cancellationToken);
 
             switch (_router.Status)
             {
@@ -93,9 +93,9 @@ namespace Dfe.PlanTech.Web.Routing
             var establishmentId = await _user.GetEstablishmentId();
 
             var submissionResponsesDto = await _processSubmissionResponsesCommand
-                .GetSubmissionResponsesDtoForSection(establishmentId, _router.Section, cancellationToken, true);
+                .GetSubmissionResponsesDtoForSection(establishmentId, _router.Section, true, cancellationToken);
 
-            await _router.GetJourneyStatusForSectionRecommendation(sectionSlug, cancellationToken, false);
+            await _router.GetJourneyStatusForSectionRecommendation(sectionSlug, false, cancellationToken);
 
             if (submissionResponsesDto?.Responses == null)
                 throw new DatabaseException("Could not retrieve the answered question list");

--- a/src/Dfe.PlanTech.Web/Routing/CheckAnswersRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/CheckAnswersRouter.cs
@@ -30,7 +30,7 @@ public class CheckAnswersRouter : ICheckAnswersRouter
         _router = router;
     }
 
-    public async Task<IActionResult> ValidateRoute(string sectionSlug, string? errorMessage, CheckAnswersController controller, CancellationToken cancellationToken, bool isChangeAnswersFlow = false)
+    public async Task<IActionResult> ValidateRoute(string sectionSlug, string? errorMessage, CheckAnswersController controller, bool isChangeAnswersFlow = false, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrEmpty(sectionSlug))
             throw new ArgumentNullException(nameof(sectionSlug));

--- a/src/Dfe.PlanTech.Web/Routing/CheckAnswersRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/CheckAnswersRouter.cs
@@ -35,22 +35,22 @@ public class CheckAnswersRouter : ICheckAnswersRouter
         if (string.IsNullOrEmpty(sectionSlug))
             throw new ArgumentNullException(nameof(sectionSlug));
 
-        await _router.GetJourneyStatusForSection(sectionSlug, cancellationToken, isChangeAnswersFlow);
+        await _router.GetJourneyStatusForSection(sectionSlug, isChangeAnswersFlow, cancellationToken);
 
         return _router.Status switch
         {
             Status.CompleteNotReviewed => await ProcessCheckAnswers(sectionSlug, errorMessage, controller, cancellationToken),
-            Status.CompleteReviewed when isChangeAnswersFlow => await ProcessCheckAnswers(sectionSlug, errorMessage, controller, cancellationToken, isChangeAnswersFlow),
+            Status.CompleteReviewed when isChangeAnswersFlow => await ProcessCheckAnswers(sectionSlug, errorMessage, controller, cancellationToken),
             Status.NotStarted => PageRedirecter.RedirectToSelfAssessment(controller),
             _ => ProcessQuestionStatus(sectionSlug, controller),
         };
     }
 
-    private async Task<IActionResult> ProcessCheckAnswers(string sectionSlug, string? errorMessage, CheckAnswersController controller, CancellationToken cancellationToken, bool isChangeAnswersFlow = false)
+    private async Task<IActionResult> ProcessCheckAnswers(string sectionSlug, string? errorMessage, CheckAnswersController controller, CancellationToken cancellationToken)
     {
         var establishmentId = await _user.GetEstablishmentId();
 
-        var submissionResponsesDto = await _processSubmissionResponsesCommand.GetSubmissionResponsesDtoForSection(establishmentId, _router.Section, cancellationToken);
+        var submissionResponsesDto = await _processSubmissionResponsesCommand.GetSubmissionResponsesDtoForSection(establishmentId, _router.Section, cancellationToken: cancellationToken);
 
         if (submissionResponsesDto == null || submissionResponsesDto.Responses == null)
             throw new DatabaseException("Could not retrieve the answered question list");

--- a/src/Dfe.PlanTech.Web/Routing/GetQuestionBySlugRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/GetQuestionBySlugRouter.cs
@@ -50,7 +50,7 @@ public class GetQuestionBySlugRouter : IGetQuestionBySlugRouter
         var returnTo = controller.TempData["ReturnTo"]?.ToString();
         var isChangeAnswersFlow = returnTo == FlowConstants.ChangeAnswersFlow;
 
-        await _router.GetJourneyStatusForSection(sectionSlug, cancellationToken, false);
+        await _router.GetJourneyStatusForSection(sectionSlug, false, cancellationToken);
 
         if (IsSlugForNextQuestion(questionSlug))
         {

--- a/src/Dfe.PlanTech.Web/Routing/GetQuestionBySlugRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/GetQuestionBySlugRouter.cs
@@ -54,14 +54,14 @@ public class GetQuestionBySlugRouter : IGetQuestionBySlugRouter
 
         if (IsSlugForNextQuestion(questionSlug))
         {
-            var viewModel = controller.GenerateViewModel(sectionSlug, _router.NextQuestion!, _router.Section, null, isChangeAnswersFlow);
+            var viewModel = controller.GenerateViewModel(sectionSlug, _router.NextQuestion!, _router.Section, null);
             return controller.RenderView(viewModel);
         }
 
         if (SectionIsAtStart)
             return PageRedirecter.RedirectToInterstitialPage(controller, sectionSlug);
 
-        return await ProcessOtherStatuses(sectionSlug, questionSlug, controller, cancellationToken, isChangeAnswersFlow);
+        return await ProcessOtherStatuses(sectionSlug, questionSlug, controller, isChangeAnswersFlow, cancellationToken);
     }
 
     /// <summary>
@@ -82,11 +82,11 @@ public class GetQuestionBySlugRouter : IGetQuestionBySlugRouter
     /// <param name="controller"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    private async Task<IActionResult> ProcessOtherStatuses(string sectionSlug, string questionSlug, QuestionsController controller, CancellationToken cancellationToken, bool isChangeAnswersFlow)
+    private async Task<IActionResult> ProcessOtherStatuses(string sectionSlug, string questionSlug, QuestionsController controller, bool isChangeAnswersFlow, CancellationToken cancellationToken)
     {
         var question = GetQuestionForSlug(questionSlug);
 
-        var responses = await GetLatestResponsesForSection(cancellationToken, isChangeAnswersFlow);
+        var responses = await GetLatestResponsesForSection(isChangeAnswersFlow, cancellationToken);
 
         if (responses is null)
         {
@@ -124,7 +124,7 @@ public class GetQuestionBySlugRouter : IGetQuestionBySlugRouter
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     /// <exception cref="DatabaseException">Thrown if no responses are found</exception>
-    private async Task<List<QuestionWithAnswer>> GetLatestResponsesForSection(CancellationToken cancellationToken, bool completed = false)
+    private async Task<List<QuestionWithAnswer>> GetLatestResponsesForSection(bool completed = false, CancellationToken cancellationToken = default)
     {
         var establishmentId = await _user.GetEstablishmentId();
 

--- a/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
@@ -43,8 +43,8 @@ public class GetRecommendationRouter : IGetRecommendationRouter
         return _router.Status switch
         {
             Status.CompleteReviewed => checklist ?
-                await HandleChecklist(controller, recommendationSlug, cancellationToken) :
-                await HandleCompleteStatus(controller, recommendationSlug, cancellationToken),
+                await HandleChecklist(controller, sectionSlug, recommendationSlug, cancellationToken) :
+                await HandleCompleteStatus(controller, sectionSlug, recommendationSlug, cancellationToken),
             Status.CompleteNotReviewed => controller.RedirectToCheckAnswers(sectionSlug),
             Status.InProgress => HandleQuestionStatus(sectionSlug, controller),
             Status.NotStarted => PageRedirecter.RedirectToSelfAssessment(controller),
@@ -101,7 +101,7 @@ public class GetRecommendationRouter : IGetRecommendationRouter
     /// <summary>
     /// Fetch the model for the recommendation page (if correct recommendation for section + maturity),
     /// </summary>
-    private async Task<RecommendationsViewModel> GetRecommendationViewModel(string recommendationSlug, bool showYSA = false, CancellationToken cancellationToken = default)
+    private async Task<RecommendationsViewModel> GetRecommendationViewModel(string sectionSlug, string recommendationSlug, bool showYSA = false, CancellationToken cancellationToken = default)
     {
         var (subTopicRecommendation, subTopicIntro, subTopicChunks, latestResponses) = await GetSubtopicRecommendation(cancellationToken);
 
@@ -130,6 +130,7 @@ public class GetRecommendationRouter : IGetRecommendationRouter
                                 ? DateTimeFormatter.FormattedDateShort(latestCompletionDate.Value)
                                 : null,
             Slug = recommendationSlug,
+            SectionSlug = sectionSlug,
             SubmissionResponses = latestResponses,
         };
     }
@@ -137,9 +138,9 @@ public class GetRecommendationRouter : IGetRecommendationRouter
     /// <summary>
     /// Render the recommendation page and mark the recommendation as viewed in the database
     /// </summary>
-    private async Task<IActionResult> HandleCompleteStatus(RecommendationsController controller, string recommendationSlug, CancellationToken cancellationToken)
+    private async Task<IActionResult> HandleCompleteStatus(RecommendationsController controller, string sectionSlug, string recommendationSlug, CancellationToken cancellationToken)
     {
-        var viewModel = await GetRecommendationViewModel(recommendationSlug, true, cancellationToken);
+        var viewModel = await GetRecommendationViewModel(sectionSlug, recommendationSlug, true, cancellationToken);
 
         var establishmentId = await _router.User.GetEstablishmentId();
         await _getLatestResponsesQuery.ViewLatestSubmission(establishmentId, _router.Section.Sys.Id);
@@ -150,9 +151,9 @@ public class GetRecommendationRouter : IGetRecommendationRouter
     /// <summary>
     /// Render the share recommendations checklist page
     /// </summary>
-    private async Task<IActionResult> HandleChecklist(RecommendationsController controller, string recommendationSlug, CancellationToken cancellationToken)
+    private async Task<IActionResult> HandleChecklist(RecommendationsController controller, string sectionSlug, string recommendationSlug, CancellationToken cancellationToken)
     {
-        var viewModel = await GetRecommendationViewModel(recommendationSlug, cancellationToken: cancellationToken);
+        var viewModel = await GetRecommendationViewModel(sectionSlug, recommendationSlug, cancellationToken: cancellationToken);
 
         return controller.View("~/Views/Recommendations/RecommendationsChecklist.cshtml", viewModel);
     }

--- a/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
@@ -101,7 +101,7 @@ public class GetRecommendationRouter : IGetRecommendationRouter
     /// <summary>
     /// Fetch the model for the recommendation page (if correct recommendation for section + maturity),
     /// </summary>
-    private async Task<RecommendationsViewModel> GetRecommendationViewModel(string recommendationSlug, CancellationToken cancellationToken, bool showYSA = false)
+    private async Task<RecommendationsViewModel> GetRecommendationViewModel(string recommendationSlug, bool showYSA = false, CancellationToken cancellationToken = default)
     {
         var (subTopicRecommendation, subTopicIntro, subTopicChunks, latestResponses) = await GetSubtopicRecommendation(cancellationToken);
 
@@ -139,7 +139,7 @@ public class GetRecommendationRouter : IGetRecommendationRouter
     /// </summary>
     private async Task<IActionResult> HandleCompleteStatus(RecommendationsController controller, string recommendationSlug, CancellationToken cancellationToken)
     {
-        var viewModel = await GetRecommendationViewModel(recommendationSlug, cancellationToken, true);
+        var viewModel = await GetRecommendationViewModel(recommendationSlug, true, cancellationToken);
 
         var establishmentId = await _router.User.GetEstablishmentId();
         await _getLatestResponsesQuery.ViewLatestSubmission(establishmentId, _router.Section.Sys.Id);
@@ -152,7 +152,7 @@ public class GetRecommendationRouter : IGetRecommendationRouter
     /// </summary>
     private async Task<IActionResult> HandleChecklist(RecommendationsController controller, string recommendationSlug, CancellationToken cancellationToken)
     {
-        var viewModel = await GetRecommendationViewModel(recommendationSlug, cancellationToken);
+        var viewModel = await GetRecommendationViewModel(recommendationSlug, cancellationToken: cancellationToken);
 
         return controller.View("~/Views/Recommendations/RecommendationsChecklist.cshtml", viewModel);
     }

--- a/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
@@ -38,7 +38,7 @@ public class GetRecommendationRouter : IGetRecommendationRouter
         if (string.IsNullOrEmpty(recommendationSlug))
             throw new ArgumentNullException(nameof(recommendationSlug));
 
-        await _router.GetJourneyStatusForSectionRecommendation(sectionSlug, cancellationToken, true);
+        await _router.GetJourneyStatusForSectionRecommendation(sectionSlug, true, cancellationToken);
 
         return _router.Status switch
         {
@@ -57,7 +57,7 @@ public class GetRecommendationRouter : IGetRecommendationRouter
                                                               RecommendationsController controller,
                                                               CancellationToken cancellationToken)
     {
-        await _router.GetJourneyStatusForSectionRecommendation(sectionSlug, cancellationToken);
+        await _router.GetJourneyStatusForSectionRecommendation(sectionSlug, cancellationToken: cancellationToken);
         var recommendation = await _getSubTopicRecommendationQuery.GetSubTopicRecommendation(_router.Section.Sys.Id, cancellationToken) ?? throw new ContentfulDataUnavailableException($"Could not find subtopic recommendation for:  {_router.Section.Name}");
 
         var intro = recommendation.Intros.Find(intro => string.Equals(intro.Maturity, maturity, StringComparison.InvariantCultureIgnoreCase)) ?? recommendation.Intros[0];
@@ -75,7 +75,7 @@ public class GetRecommendationRouter : IGetRecommendationRouter
 
     public async Task<string> GetRecommendationSlugForSection(string sectionSlug, CancellationToken cancellationToken)
     {
-        await _router.GetJourneyStatusForSectionRecommendation(sectionSlug, cancellationToken, true);
+        await _router.GetJourneyStatusForSectionRecommendation(sectionSlug, true, cancellationToken);
         var (_, subTopicIntro, _, _) = await GetSubtopicRecommendation(cancellationToken);
         return subTopicIntro.Slug;
     }

--- a/src/Dfe.PlanTech.Web/Routing/ICheckAnswersRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/ICheckAnswersRouter.cs
@@ -20,6 +20,6 @@ public interface ICheckAnswersRouter
     Task<IActionResult> ValidateRoute(string sectionSlug,
                                       string? errorMessage,
                                       CheckAnswersController controller,
-                                      CancellationToken cancellationToken,
-                                      bool isChangeAnswersFlow = false);
+                                      bool isChangeAnswersFlow = false,
+                                      CancellationToken cancellationToken = default);
 }

--- a/src/Dfe.PlanTech.Web/Views/Recommendations/YSA.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/YSA.cshtml
@@ -26,7 +26,7 @@
         }
     </dl>
 
-    <a href="/@Model.SectionName.Slugify()/change-answers" role="button" draggable="false"
+    <a href="/@Model.SectionSlug/change-answers" role="button" draggable="false"
        class="govuk-button" data-module="govuk-button" data-govuk-button-init="">
         Change your answers
     </a>

--- a/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Commands/SubmissionCommandTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Commands/SubmissionCommandTests.cs
@@ -1,0 +1,78 @@
+﻿using Dfe.PlanTech.Application.Submissions.Commands;
+using Dfe.PlanTech.Application.Persistence.Interfaces;
+using Dfe.PlanTech.Domain.Submissions.Enums;
+using Dfe.PlanTech.Domain.Submissions.Models;
+using NSubstitute;
+public class SubmissionCommandTests
+{
+    private readonly IPlanTechDbContext _db = Substitute.For<IPlanTechDbContext>();
+    private readonly SubmissionCommand _command;
+
+    public SubmissionCommandTests()
+    {
+        _command = new SubmissionCommand(_db);
+    }
+
+    [Fact]
+    public async Task CloneSubmission_Should_Throw_When_Submission_Null()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            _command.CloneSubmission(null, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task CloneSubmission_Should_Clone_Correctly_And_Save()
+    {
+        var existingSubmission = new Submission
+        {
+            SectionId = "section-1",
+            SectionName = "Test Section",
+            EstablishmentId = 1,
+            Maturity = "Medium",
+            Responses = new List<Response>
+            {
+                new Response
+                {
+                    QuestionId = 1,
+                    AnswerId = 1,
+                    UserId = 1,
+                    Maturity = "Medium"
+                }
+            }
+        };
+
+        var newSubmission = await _command.CloneSubmission(existingSubmission, CancellationToken.None);
+
+        Assert.NotNull(newSubmission);
+        Assert.Equal(existingSubmission.SectionId, newSubmission.SectionId);
+        Assert.Equal(existingSubmission.SectionName, newSubmission.SectionName);
+        Assert.Equal(existingSubmission.EstablishmentId, newSubmission.EstablishmentId);
+        Assert.False(newSubmission.Completed);
+        Assert.Equal(SubmissionStatus.InProgress.ToString(), newSubmission.Status);
+        Assert.Single(newSubmission.Responses);
+
+        _db.Received().AddSubmission(newSubmission);
+        await _db.Received().SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task DeleteSubmission_Should_Throw_When_Submission_Not_Found()
+    {
+        _db.Submissions.Find(Arg.Any<int>()).Returns((Submission?)null);
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            _command.DeleteSubmission(42, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task DeleteSubmission_Should_Mark_Status_And_Save()
+    {
+        var submission = new Submission { Id = 1, SectionId = "section-1", SectionName = "Test Section", Status = SubmissionStatus.CompleteReviewed.ToString() };
+        _db.Submissions.Find(1).Returns(submission);
+
+        await _command.DeleteSubmission(1, CancellationToken.None);
+
+        Assert.Equal(SubmissionStatus.Inaccessible.ToString(), submission.Status);
+        await _db.Received().SaveChangesAsync();
+    }
+}

--- a/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/SubmissionStatusProcessorTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Submissions/Queries/SubmissionStatusProcessorTests.cs
@@ -78,7 +78,7 @@ public class SubmissionStatusProcessorTests
         _getSubmissionStatusesQuery.GetSectionSubmissionStatusAsync(Arg.Any<int>(), Arg.Any<Section>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
                                    .Returns(new SectionStatus());
 
-        await processor.GetJourneyStatusForSection(SectionSlug, default, false);
+        await processor.GetJourneyStatusForSection(SectionSlug, false, default);
 
         _failureStatusChecker.Received(1).IsMatchingSubmissionStatus(processor);
         await _failureStatusChecker.DidNotReceive().ProcessSubmission(processor, Arg.Any<CancellationToken>());
@@ -103,7 +103,7 @@ public class SubmissionStatusProcessorTests
         _getSubmissionStatusesQuery.GetSectionSubmissionStatusAsync(Arg.Any<int>(), Arg.Any<Section>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
                                    .Returns(new SectionStatus());
 
-        await Assert.ThrowsAnyAsync<InvalidDataException>(() => processor.GetJourneyStatusForSection(SectionSlug, default, false));
+        await Assert.ThrowsAnyAsync<InvalidDataException>(() => processor.GetJourneyStatusForSection(SectionSlug, false, default));
     }
 
     [Fact]
@@ -120,6 +120,6 @@ public class SubmissionStatusProcessorTests
         _getSectionQuery.GetSectionBySlug(Arg.Any<string>(), Arg.Any<CancellationToken>())
                         .Returns(null as Section);
 
-        await Assert.ThrowsAnyAsync<ContentfulDataUnavailableException>(() => processor.GetJourneyStatusForSection("not matching section slug", default, false));
+        await Assert.ThrowsAnyAsync<ContentfulDataUnavailableException>(() => processor.GetJourneyStatusForSection("not matching section slug", false, default));
     }
 }

--- a/tests/Dfe.PlanTech.Domain.UnitTests/Helpers/SubmissionStatusHelpersTests.cs
+++ b/tests/Dfe.PlanTech.Domain.UnitTests/Helpers/SubmissionStatusHelpersTests.cs
@@ -12,7 +12,6 @@ public class SubmissionStatusHelpersTests
 {
     [Theory]
     [InlineData(true, null, null, "Unable to retrieve status", "Red")]
-    [InlineData(false, true, true, "Completed on", "Blue")] // completed today
     [InlineData(false, true, false, "Completed on", "Blue")] // previously completed
     [InlineData(false, false, null, "Not started", "Grey")] // never completed
     public void GetGroupsSubmissionStatusTag_ShouldReturnCorrectTagBasedOnStatus(
@@ -51,18 +50,6 @@ public class SubmissionStatusHelpersTests
     {
         var result = SubmissionStatusHelpers.LastEditedDate(null, Substitute.For<ISystemTime>());
         Assert.Null(result);
-    }
-
-    [Fact]
-    public void LastEditedDate_ShouldReturnTime_WhenDateIsToday()
-    {
-        var date = DateTime.UtcNow;
-        var systemTime = Substitute.For<ISystemTime>();
-        systemTime.Today.Returns(date.Date);
-
-        var result = SubmissionStatusHelpers.LastEditedDate(date, systemTime);
-
-        Assert.StartsWith("on ", result);
     }
 
     [Fact]

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/CheckAnswersControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/CheckAnswersControllerTests.cs
@@ -56,7 +56,7 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
             await _checkAnswersController.CheckAnswersPage(_sectionSlug, false, _checkAnswersRouter,
                 _userJourneyMissingContentExceptionHandler, default);
             await _checkAnswersRouter.Received()
-                .ValidateRoute(_sectionSlug, null, _checkAnswersController, Arg.Any<CancellationToken>());
+                .ValidateRoute(_sectionSlug, null, _checkAnswersController, cancellationToken: Arg.Any<CancellationToken>());
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
             var exception = new UserJourneyMissingContentException("Exception thrown", new Section());
 
             _checkAnswersRouter.ValidateRoute(Arg.Any<string>(), Arg.Any<string>(), _checkAnswersController,
-                    Arg.Any<CancellationToken>()).Throws(exception);
+                    cancellationToken: Arg.Any<CancellationToken>()).Throws(exception);
 
             await _checkAnswersController.CheckAnswersPage(_sectionSlug, false, _checkAnswersRouter,
                _userJourneyMissingContentExceptionHandler, default);

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/QuestionsControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/QuestionsControllerTests.cs
@@ -248,7 +248,7 @@ public class QuestionsControllerTests
         _controller.ModelState.AddModelError("submitAnswerDto.QuestionId", errorMessages[0]);
         _controller.ModelState.AddModelError("submitAnswerDto.QuestionText", errorMessages[1]);
 
-        var result = await _controller.SubmitAnswer(sectionSlug, questionSlug, submitAnswerDto, submitAnswerCommand, nextUnanswered, cancellationToken);
+        var result = await _controller.SubmitAnswer(sectionSlug, questionSlug, submitAnswerDto, submitAnswerCommand, nextUnanswered, cancellationToken: cancellationToken);
 
         var viewResult = Assert.IsType<ViewResult>(result);
         Assert.Equal("Question", viewResult.ViewName);
@@ -281,7 +281,7 @@ public class QuestionsControllerTests
           .When(x => x.SubmitAnswer(Arg.Any<SubmitAnswerDto>(), Arg.Any<CancellationToken>()))
           .Do(x => throw new Exception("A Dummy exception thrown by the test"));
 
-        var result = await _controller.SubmitAnswer(sectionSlug, questionSlug, submitAnswerDto, submitAnswerCommand, nextUnanswered, cancellationToken);
+        var result = await _controller.SubmitAnswer(sectionSlug, questionSlug, submitAnswerDto, submitAnswerCommand, nextUnanswered, cancellationToken: cancellationToken);
 
         var viewResult = Assert.IsType<ViewResult>(result);
         Assert.Equal("Question", viewResult.ViewName);
@@ -306,7 +306,7 @@ public class QuestionsControllerTests
         submitAnswerCommand.SubmitAnswer(submitAnswerDto, Arg.Any<CancellationToken>())
                           .Returns(1);
 
-        var result = await _controller.SubmitAnswer(SectionSlug, QuestionSlug, submitAnswerDto, submitAnswerCommand, nextUnanswered, cancellationToken);
+        var result = await _controller.SubmitAnswer(SectionSlug, QuestionSlug, submitAnswerDto, submitAnswerCommand, nextUnanswered, cancellationToken: cancellationToken);
 
         var redirectResult = result as RedirectToActionResult;
         Assert.NotNull(redirectResult);

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/QuestionsControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/QuestionsControllerTests.cs
@@ -6,6 +6,7 @@ using Dfe.PlanTech.Domain.Persistence.Models;
 using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 using Dfe.PlanTech.Domain.Questionnaire.Models;
 using Dfe.PlanTech.Domain.Submissions.Interfaces;
+using Dfe.PlanTech.Domain.Submissions.Models;
 using Dfe.PlanTech.Domain.Users.Interfaces;
 using Dfe.PlanTech.Web.Configuration;
 using Dfe.PlanTech.Web.Controllers;
@@ -294,6 +295,78 @@ public class QuestionsControllerTests
     }
 
     [Fact]
+    public async Task SubmitAnswer_Should_Redirect_To_NextUnanswered_When_Not_ChangeAnswersFlow()
+    {
+        var dto = new SubmitAnswerDto();
+        var submitAnswerCommand = Substitute.For<ISubmitAnswerCommand>();
+        var nextUnanswered = Substitute.For<IGetNextUnansweredQuestionQuery>();
+
+        submitAnswerCommand.SubmitAnswer(dto, Arg.Any<CancellationToken>()).Returns(1);
+
+        var result = await _controller.SubmitAnswer(SectionSlug, QuestionSlug, dto, submitAnswerCommand, nextUnanswered);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("GetNextUnansweredQuestion", redirect.ActionName);
+        Assert.Equal(SectionSlug, redirect.RouteValues?["sectionSlug"]);
+    }
+
+    [Fact]
+    public async Task SubmitAnswer_Should_Redirect_To_Next_Answered_Or_Unanswered_When_ChangeAnswersFlow()
+    {
+        var dto = new SubmitAnswerDto();
+        var submitAnswerCommand = Substitute.For<ISubmitAnswerCommand>();
+        var nextUnanswered = Substitute.For<IGetNextUnansweredQuestionQuery>();
+
+        submitAnswerCommand.SubmitAnswer(dto, Arg.Any<CancellationToken>()).Returns(1);
+
+        _user.GetEstablishmentId().Returns(EstablishmentId);
+        _getResponseQuery.GetLatestResponses(EstablishmentId, _validSection.Sys.Id, false, Arg.Any<CancellationToken>())
+            .Returns(new SubmissionResponsesDto
+            {
+                Responses = new List<QuestionWithAnswer>
+                {
+                    new QuestionWithAnswer { QuestionRef = _validQuestion.Sys.Id }
+                }
+            });
+
+        var nextQuestion = new Question { Slug = "next-question" };
+        nextUnanswered.GetNextUnansweredQuestion(EstablishmentId, _validSection, Arg.Any<CancellationToken>())
+            .Returns(nextQuestion);
+
+        var result = await _controller.SubmitAnswer(SectionSlug, QuestionSlug, dto, submitAnswerCommand, nextUnanswered, returnTo: FlowConstants.ChangeAnswersFlow);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("GetQuestionBySlug", redirect.ActionName);
+        Assert.Equal(SectionSlug, redirect.RouteValues?["sectionSlug"]);
+        Assert.Equal("next-question", redirect.RouteValues?["questionSlug"]);
+        Assert.Equal(FlowConstants.ChangeAnswersFlow, redirect.RouteValues?["returnTo"]);
+    }
+
+    [Fact]
+    public async Task SubmitAnswer_Should_Redirect_To_CheckAnswers_When_No_More_Questions_And_ChangeAnswersFlow()
+    {
+        var dto = new SubmitAnswerDto();
+        var submitAnswerCommand = Substitute.For<ISubmitAnswerCommand>();
+        var nextUnanswered = Substitute.For<IGetNextUnansweredQuestionQuery>();
+
+        submitAnswerCommand.SubmitAnswer(dto, Arg.Any<CancellationToken>()).Returns(1);
+
+        _user.GetEstablishmentId().Returns(EstablishmentId);
+        _getResponseQuery.GetLatestResponses(EstablishmentId, _validSection.Sys.Id, false, Arg.Any<CancellationToken>())
+            .Returns(new SubmissionResponsesDto
+            {
+                Responses = new List<QuestionWithAnswer>()
+            });
+
+        var result = await _controller.SubmitAnswer(SectionSlug, QuestionSlug, dto, submitAnswerCommand, nextUnanswered, returnTo: FlowConstants.ChangeAnswersFlow);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("CheckAnswersPage", redirect.ActionName);
+        Assert.Equal("CheckAnswers", redirect.ControllerName);
+    }
+
+
+    [Fact]
     public async Task SubmitAnswer_Should_Redirect_To_NextUnansweredQuestion_When_Success()
     {
         var submitAnswerDto = new SubmitAnswerDto();
@@ -344,5 +417,39 @@ public class QuestionsControllerTests
         Assert.Equal(QuestionSlug, viewModel.Question.Slug);
         Assert.Null(viewModel.SectionSlug);
         Assert.Null(viewModel.AnswerRef);
+    }
+
+    [Fact]
+    public async Task SubmitAnswer_Should_Return_View_When_ModelState_IsInvalid()
+    {
+        _controller.ModelState.AddModelError("QuestionId", "QuestionId is required");
+
+        var dto = new SubmitAnswerDto();
+        var submitAnswerCommand = Substitute.For<ISubmitAnswerCommand>();
+        var nextUnanswered = Substitute.For<IGetNextUnansweredQuestionQuery>();
+
+        var result = await _controller.SubmitAnswer(SectionSlug, QuestionSlug, dto, submitAnswerCommand, nextUnanswered);
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<QuestionViewModel>(viewResult.Model);
+        Assert.Contains("QuestionId is required", model.ErrorMessages);
+    }
+
+    [Fact]
+    public async Task SubmitAnswer_Should_Return_View_With_Error_When_Exception_Thrown()
+    {
+        var dto = new SubmitAnswerDto();
+        var submitAnswerCommand = Substitute.For<ISubmitAnswerCommand>();
+        var nextUnanswered = Substitute.For<IGetNextUnansweredQuestionQuery>();
+
+        submitAnswerCommand
+            .When(cmd => cmd.SubmitAnswer(dto, Arg.Any<CancellationToken>()))
+            .Do(_ => throw new Exception("DB error"));
+
+        var result = await _controller.SubmitAnswer(SectionSlug, QuestionSlug, dto, submitAnswerCommand, nextUnanswered);
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<QuestionViewModel>(viewResult.Model);
+        Assert.Contains("Save failed. Please try again later.", model.ErrorMessages);
     }
 }

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/RecommendationsControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/RecommendationsControllerTests.cs
@@ -95,4 +95,29 @@ public class RecommendationsControllerTests
         await _recommendationsRouter.Received().ValidateRoute(sectionSlug, recommendationSlug, true, _recommendationsController, Arg.Any<CancellationToken>());
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public async Task FromSection_Should_ThrowException_When_SectionSlug_NullOrEmpty(string? sectionSlug)
+    {
+        await Assert.ThrowsAnyAsync<ArgumentNullException>(() =>
+            _recommendationsController.FromSection(sectionSlug!, _recommendationsRouter, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task FromSection_Should_Call_GetRecommendationSlugForSection_And_Redirect()
+    {
+        var sectionSlug = "section-slug";
+        var recommendationSlug = "recommendation-slug";
+
+        _recommendationsRouter.GetRecommendationSlugForSection(sectionSlug, Arg.Any<CancellationToken>())
+                              .Returns(recommendationSlug);
+
+        var result = await _recommendationsController.FromSection(sectionSlug, _recommendationsRouter, CancellationToken.None);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal(RecommendationsController.GetRecommendationAction, redirect.ActionName);
+        Assert.Null(redirect.ControllerName);
+        Assert.Equal(recommendationSlug, redirect.RouteValues?["recommendationSlug"]);
+    }
 }

--- a/tests/Dfe.PlanTech.Web.UnitTests/Routing/ChangeAnswersRouterTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Routing/ChangeAnswersRouterTests.cs
@@ -110,7 +110,7 @@ namespace Dfe.PlanTech.Web.UnitTests.Routing
         {
             _statusProcessor.Status = Status.CompleteNotReviewed;
 
-            _processCommand.GetSubmissionResponsesDtoForSection(_establishmentId, _section, Arg.Any<CancellationToken>(), true)
+            _processCommand.GetSubmissionResponsesDtoForSection(_establishmentId, _section, true, Arg.Any<CancellationToken>())
                            .Returns(_responsesDto);
 
             var result = await _router.ValidateRoute(_sectionSlug, "error", _controller, default);
@@ -207,7 +207,7 @@ namespace Dfe.PlanTech.Web.UnitTests.Routing
 
             _dbContext.GetSubmissions.Returns(new List<Submission> { latestCompletedSubmission }.AsQueryable());
 
-            _processCommand.GetSubmissionResponsesDtoForSection(_establishmentId, _section, Arg.Any<CancellationToken>(), true)
+            _processCommand.GetSubmissionResponsesDtoForSection(_establishmentId, _section, true, Arg.Any<CancellationToken>())
                            .Returns(_responsesDto);
 
             _statusProcessor.User.Returns(_user);
@@ -252,7 +252,7 @@ namespace Dfe.PlanTech.Web.UnitTests.Routing
         {
             _statusProcessor.Status = Status.CompleteNotReviewed;
 
-            _processCommand.GetSubmissionResponsesDtoForSection(_establishmentId, _section, Arg.Any<CancellationToken>(), true)
+            _processCommand.GetSubmissionResponsesDtoForSection(_establishmentId, _section, true, Arg.Any<CancellationToken>())
                            .Returns((SubmissionResponsesDto?)null);
 
             await Assert.ThrowsAsync<DatabaseException>(() =>

--- a/tests/Dfe.PlanTech.Web.UnitTests/Routing/CheckAnswersRouterTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Routing/CheckAnswersRouterTests.cs
@@ -65,7 +65,7 @@ public class CheckAnswersRouterTests
     public CheckAnswersRouterTests()
     {
         _user.GetEstablishmentId().Returns(establishmentId);
-        _checkAnswerCommand.GetSubmissionResponsesDtoForSection(establishmentId, Arg.Any<Section>(), Arg.Any<CancellationToken>())
+        _checkAnswerCommand.GetSubmissionResponsesDtoForSection(establishmentId, Arg.Any<Section>(), cancellationToken: Arg.Any<CancellationToken>())
                             .Returns((callinfo) =>
                             {
                                 var sectionArg = callinfo.ArgAt<ISection>(1);
@@ -105,7 +105,7 @@ public class CheckAnswersRouterTests
             Slug = "next-question"
         };
 
-        _submissionStatusProcessor.When(processor => processor.GetJourneyStatusForSection(sectionSlug, Arg.Any<CancellationToken>()))
+        _submissionStatusProcessor.When(processor => processor.GetJourneyStatusForSection(sectionSlug, cancellationToken : Arg.Any<CancellationToken>()))
         .Do(callInfo =>
         {
             _submissionStatusProcessor.Status = Status.InProgress;
@@ -134,7 +134,7 @@ public class CheckAnswersRouterTests
     {
         var sectionSlug = _section.InterstitialPage?.Slug ?? throw new InvalidOperationException("InterstitialPage cannot be null.");
 
-        _submissionStatusProcessor.When(processor => processor.GetJourneyStatusForSection(sectionSlug, Arg.Any<CancellationToken>()))
+        _submissionStatusProcessor.When(processor => processor.GetJourneyStatusForSection(sectionSlug, cancellationToken: Arg.Any<CancellationToken>()))
                                   .Do(processor =>
                                   {
                                       _submissionStatusProcessor.Status = Status.CompleteNotReviewed;
@@ -175,7 +175,7 @@ public class CheckAnswersRouterTests
 
         var sectionSlug = noneAnsweredSection.InterstitialPage.Slug;
 
-        _submissionStatusProcessor.When(processor => processor.GetJourneyStatusForSection(sectionSlug, Arg.Any<CancellationToken>()))
+        _submissionStatusProcessor.When(processor => processor.GetJourneyStatusForSection(sectionSlug, cancellationToken: Arg.Any<CancellationToken>()))
                                   .Do(processor =>
                                   {
                                       _submissionStatusProcessor.Status = Status.CompleteNotReviewed;

--- a/tests/Dfe.PlanTech.Web.UnitTests/Routing/GetQuestionBySlugRouterTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Routing/GetQuestionBySlugRouterTests.cs
@@ -155,7 +155,7 @@ public class GetQuestionBySlugRouterTests
         var nextQuestion = _section.Questions[0] ?? throw new InvalidOperationException("Next question cannot be null.");
 
         Assert.NotNull(_section.InterstitialPage);
-        _submissionStatusProcessor.When(processor => processor.GetJourneyStatusForSection(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>()))
+        _submissionStatusProcessor.When(processor => processor.GetJourneyStatusForSection(_section.InterstitialPage.Slug, cancellationToken: Arg.Any<CancellationToken>()))
                                   .Do(callinfo =>
                                   {
                                       _submissionStatusProcessor.NextQuestion = nextQuestion;
@@ -191,7 +191,7 @@ public class GetQuestionBySlugRouterTests
                          .Returns(_responses);
         Assert.NotNull(_section.InterstitialPage);
 
-        _submissionStatusProcessor.When(processor => processor.GetJourneyStatusForSection(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>()))
+        _submissionStatusProcessor.When(processor => processor.GetJourneyStatusForSection(_section.InterstitialPage.Slug, cancellationToken: Arg.Any<CancellationToken>()))
                                   .Do(callinfo =>
                                   {
                                       _submissionStatusProcessor.NextQuestion = secondQuestion;
@@ -229,7 +229,7 @@ public class GetQuestionBySlugRouterTests
                          .Returns(_responses);
         Assert.NotNull(_section.InterstitialPage);
 
-        _submissionStatusProcessor.When(processor => processor.GetJourneyStatusForSection(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>()))
+        _submissionStatusProcessor.When(processor => processor.GetJourneyStatusForSection(_section.InterstitialPage.Slug, cancellationToken: Arg.Any<CancellationToken>()))
                                   .Do(callinfo =>
                                   {
                                       _submissionStatusProcessor.NextQuestion = thirdQuestion;
@@ -270,7 +270,7 @@ public class GetQuestionBySlugRouterTests
 
         Assert.NotNull(_section.InterstitialPage);
 
-        _submissionStatusProcessor.When(processor => processor.GetJourneyStatusForSection(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>()))
+        _submissionStatusProcessor.When(processor => processor.GetJourneyStatusForSection(_section.InterstitialPage.Slug, cancellationToken: Arg.Any<CancellationToken>()))
                                   .Do(callinfo =>
                                   {
                                       _submissionStatusProcessor.Status = Status.CompleteNotReviewed;
@@ -296,7 +296,7 @@ public class GetQuestionBySlugRouterTests
     public async Task Should_Throw_Exception_When_Question_NoLonger_In_Section()
     {
         Assert.NotNull(_section.InterstitialPage);
-        _submissionStatusProcessor.When(processor => processor.GetJourneyStatusForSection(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>()))
+        _submissionStatusProcessor.When(processor => processor.GetJourneyStatusForSection(_section.InterstitialPage.Slug, cancellationToken: Arg.Any<CancellationToken>()))
                                     .Do(callinfo =>
                                     {
                                         _submissionStatusProcessor.Status = Status.CompleteNotReviewed;
@@ -313,7 +313,7 @@ public class GetQuestionBySlugRouterTests
     public async Task Should_Throw_Exception_When_No_Responses_Returned()
     {
         Assert.NotNull(_section.InterstitialPage);
-        _submissionStatusProcessor.When(processor => processor.GetJourneyStatusForSection(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>()))
+        _submissionStatusProcessor.When(processor => processor.GetJourneyStatusForSection(_section.InterstitialPage.Slug, cancellationToken: Arg.Any<CancellationToken>()))
                                 .Do(callinfo =>
                                 {
                                     _submissionStatusProcessor.Status = Status.CompleteNotReviewed;
@@ -335,7 +335,7 @@ public class GetQuestionBySlugRouterTests
         _getResponseQuery.GetLatestResponses(Arg.Any<int>(), _section.Sys.Id, false, Arg.Any<CancellationToken>())
                          .Returns(_responses);
 
-        _submissionStatusProcessor.When(processor => processor.GetJourneyStatusForSection(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>()))
+        _submissionStatusProcessor.When(processor => processor.GetJourneyStatusForSection(_section.InterstitialPage.Slug, cancellationToken: Arg.Any<CancellationToken>()))
                                   .Do(callinfo =>
                                   {
                                       _submissionStatusProcessor.Status = Status.CompleteNotReviewed;

--- a/tests/Dfe.PlanTech.Web.UnitTests/Routing/GetRecommendationRouterTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Routing/GetRecommendationRouterTests.cs
@@ -279,7 +279,7 @@ public class GetRecommendationRouterTests
         };
 
         _submissionStatusProcessor.When(processor =>
-                processor.GetJourneyStatusForSectionRecommendation(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>(), true))
+                processor.GetJourneyStatusForSectionRecommendation(_section.InterstitialPage.Slug, true, Arg.Any<CancellationToken>()))
             .Do((callinfo) =>
             {
                 _submissionStatusProcessor.Status = Status.InProgress;
@@ -321,7 +321,7 @@ public class GetRecommendationRouterTests
         };
 
         _submissionStatusProcessor.When(processor =>
-                processor.GetJourneyStatusForSectionRecommendation(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>()))
+                processor.GetJourneyStatusForSectionRecommendation(_section.InterstitialPage.Slug, cancellationToken: Arg.Any<CancellationToken>()))
             .Do((callinfo) =>
             {
                 _submissionStatusProcessor.Status = Status.NotStarted;
@@ -350,7 +350,7 @@ public class GetRecommendationRouterTests
     {
         Assert.NotNull(_section.InterstitialPage);
         _submissionStatusProcessor.When(processor =>
-                processor.GetJourneyStatusForSectionRecommendation(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>(), true))
+                processor.GetJourneyStatusForSectionRecommendation(_section.InterstitialPage.Slug, true, Arg.Any<CancellationToken>()))
             .Do((callinfo) =>
             {
                 _submissionStatusProcessor.Status = Status.CompleteReviewed;
@@ -370,7 +370,7 @@ public class GetRecommendationRouterTests
     public async Task Should_Throw_Exception_When_Recommendation_Not_In_Section(bool checklist)
     {
         Assert.NotNull(_section.InterstitialPage);
-        _submissionStatusProcessor.When(processor => processor.GetJourneyStatusForSectionRecommendation(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>(), true))
+        _submissionStatusProcessor.When(processor => processor.GetJourneyStatusForSectionRecommendation(_section.InterstitialPage.Slug, true, Arg.Any<CancellationToken>()))
             .Do((callinfo) =>
             {
                 _submissionStatusProcessor.Status = Status.CompleteReviewed;
@@ -395,7 +395,7 @@ public class GetRecommendationRouterTests
     {
         Assert.NotNull(_section.InterstitialPage);
         _submissionStatusProcessor.When(processor =>
-                processor.GetJourneyStatusForSectionRecommendation(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>(), true))
+                processor.GetJourneyStatusForSectionRecommendation(_section.InterstitialPage.Slug, true, Arg.Any<CancellationToken>()))
             .Do((callinfo) =>
             {
                 _submissionStatusProcessor.Status = Status.CompleteReviewed;
@@ -576,7 +576,7 @@ public class GetRecommendationRouterTests
     private void Setup_Valid_Recommendation(List<QuestionWithAnswer>? responses = null, string maturity = "High", bool isCompleted = true)
     {
         Assert.NotNull(_section.InterstitialPage);
-        _submissionStatusProcessor.When(processor => processor.GetJourneyStatusForSectionRecommendation(_section.InterstitialPage.Slug, Arg.Any<CancellationToken>(), isCompleted))
+        _submissionStatusProcessor.When(processor => processor.GetJourneyStatusForSectionRecommendation(_section.InterstitialPage.Slug, isCompleted, Arg.Any<CancellationToken>()))
             .Do(_ =>
             {
                 _submissionStatusProcessor.Status = Status.CompleteReviewed;


### PR DESCRIPTION
## Overview

Addresses ticket [#257799](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/257799)

Tile home page and onward journey v1

The design for the ticket is based on:
https://plantech.herokuapp.com/sprint14/homepage/homepage

## Changes

- Updated home/topics page to use tiles
- Added YSA (your self-assessment) chunk on recommendations
- Added change your answers page
- Updated code logic to support the ability to submit and change completed submissions while retaining core functionality
- Removed/Added appropriate UI layout based on the prototype
- Added unit tests to support logic

## How to review the PR

run v1 feature branch locally, smoke test journey flows as expected. Submissions/changing answers works and allows you to keep submitting to update recommendations

## Release requirements

Database update script to support new submission status column in the DB and release and normal.

## Additional notes

Date completed banner was added to the 'overview' chunk in recommendations which is also seen on the YSA chunk.

## Checklist

Delete any rows that do not apply to the PR.

- [x ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x ] PR targets development branch
- [ x] Unit tests have been added/updated
- [ ] E2E tests have been added/updated
- [ ] GitHub workflows/actions have been added/updated
- [ ] Terraform has been updated
- [ ] Documentation has been updated where relevant
- [ ] Any Key Vault secrets have been added to the development Key Vault
