### PR TITLE
fix(265049): unbold submission date on recommendations

### DIFF
--- a/src/Dfe.PlanTech.Web/Views/Recommendations/Content.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/Content.cshtml
@@ -17,7 +17,7 @@
             <div class="govuk-inset-text">
                 <p>
                     The self-assessment for @sectionName.ToLower() was completed on
-                    <strong>@submissionDate</strong>. You can <a href="#your-self-assessment" class="govuk-link">change your answers at any time</a>.
+                    @submissionDate. You can <a href="#your-self-assessment" class="govuk-link">change your answers at any time</a>.
                 </p>
             </div>
         }

--- a/src/Dfe.PlanTech.Web/Views/Recommendations/Content.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/Content.cshtml
@@ -17,7 +17,7 @@
             <div class="govuk-inset-text">
                 <p>
                     The self-assessment for @sectionName.ToLower() was completed on
-                    <strong>@submissionDate</strong>. You can change your answers at any time.
+                    <strong>@submissionDate</strong>. You can <a href="#your-self-assessment" class="govuk-link">change your answers at any time</a>.
                 </p>
             </div>
         }

--- a/src/Dfe.PlanTech.Web/Views/Recommendations/YSA.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/YSA.cshtml
@@ -4,7 +4,7 @@
 
 <div id="checkYourAnswers-page">
     <p>
-        The self-assessment for @Model.SectionName.ToLower() was completed on <strong>@Model.LatestCompletionDate</strong>.
+        The self-assessment for @Model.SectionName.ToLower() was completed on @Model.LatestCompletionDate.
         You can change your answers at any time.
     </p>
 


### PR DESCRIPTION
## Overview

Addresses ticket [#265049](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/265049)

Removes bolding of date of last submission on the recommendation overview and your self assessment.


## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch