### PR TITLE
Story(253522): SQL Admin change to Entra security group and add firewall rules

### DIFF
--- a/.github/workflows/infrastructure-deploy.yml
+++ b/.github/workflows/infrastructure-deploy.yml
@@ -7,6 +7,7 @@ on:
         type: string
         description: "The environment to run infrastructure deployment on:"
         required: true
+  push:
 
 env:
   DOTNET_VERSION: ${{ vars.DOTNET_VERSION }}

--- a/.github/workflows/infrastructure-deploy.yml
+++ b/.github/workflows/infrastructure-deploy.yml
@@ -7,7 +7,6 @@ on:
         type: string
         description: "The environment to run infrastructure deployment on:"
         required: true
-  push:
 
 env:
   DOTNET_VERSION: ${{ vars.DOTNET_VERSION }}

--- a/terraform/container-app/locals.tf
+++ b/terraform/container-app/locals.tf
@@ -53,6 +53,7 @@ locals {
   az_sql_sku                    = var.az_sql_sku
   az_sql_max_pool_size          = var.az_sql_max_pool_size
   az_sql_max_size_gb            = local.az_sql_sku == "Basic" ? null : 10
+  az_mssql_ipv4_allow_list      = var.az_mssql_ipv4_allow_list
 
   az_sql_vnet = {
     dns_zone_name = "privatelink.database.windows.net"

--- a/terraform/container-app/main-hosting.tf
+++ b/terraform/container-app/main-hosting.tf
@@ -42,6 +42,7 @@ module "main_hosting" {
   mssql_managed_identity_assign_role = false
   mssql_sku_name                     = local.az_sql_sku
   mssql_max_size_gb                  = local.az_sql_max_size_gb
+  mssql_firewall_ipv4_allow_list     = local.az_mssql_ipv4_allow_list
 
   ##############
   # Networking #

--- a/terraform/container-app/variables.tf
+++ b/terraform/container-app/variables.tf
@@ -74,7 +74,7 @@ variable "az_mssql_ipv4_allow_list" {
     start_ip_range : string,
     end_ip_range : optional(string, "")
   }))
-  default     = {}
+  default = {}
 }
 
 #####################

--- a/terraform/container-app/variables.tf
+++ b/terraform/container-app/variables.tf
@@ -68,6 +68,15 @@ variable "az_sql_max_pool_size" {
   default     = 100
 }
 
+variable "az_mssql_ipv4_allow_list" {
+  description = "IPv4 allow list for SQL DB"
+  type = map(object({
+    start_ip_range : string,
+    end_ip_range : optional(string, "")
+  }))
+  default     = {}
+}
+
 #####################
 # Azure Redis Cache #
 #####################


### PR DESCRIPTION
## Overview

Addresses ticket [253522](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/253522)
and
Addresses ticket [253518](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/253518)

Change the linked Entra ID to be that of a separate security group rather than the terraform service principal for security reasons. Also made a change to source the SQL Server firewall rules from the terraform variables key vault.
Have updated the key vault with the new security group Object ID and also added the firewall rules (as they were setup in the existing SQL Server resource).

## Changes

### Major

- Changed SQL Admin linked Entra ID to be that of the separate security group (change in key vault secret value)
- Make use of the SQL Server firewall rules (also a value in the key vault secret)

## Release requirements

Had to remove some manually added Firewall rules before running the deployment so that the existing resource didn't conflict with what is in the terraform state. Can do imports into the state to resolve this but instead just deleted the existing rules and allowed the deployment to re-add them and update the state.
This will need to happen in each environment before the deployment occurs. Also, from a previous PR, had to remove a CDN rule that has also been manually added but this does not seem to exist in prod so shouldn't be an issue.

### Release requirement one title

Release requirement one description

- Step one
- Step two
- ...

## Additional notes

Any additional notes, comments, etc. that might be required here.

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [x] Terraform has been updated
- [x] Any Key Vault secrets have been added to the development Key Vault
