### PR TITLE
docs: Update URLs in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Overview
 
-Addresses ticket [#TICKET-NUMBER](www.ticket-link.com)
+Addresses ticket [#TICKET-NUMBER](example.com)
 
 High level overview of changes; one or two sentences.
 
@@ -58,7 +58,7 @@ Any additional notes, comments, etc. that might be required here.
 
 Delete any rows that do not apply to the PR.
 
-- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
+- [ ] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
 - [ ] PR targets development branch
 - [ ] Unit tests have been added/updated
 - [ ] E2E tests have been added/updated


### PR DESCRIPTION
## Overview

Currently the README links to `v1.0.0-beta.4` of the conventional commits spec.
This has been updated to `v1.0.0`

Additionally, I have switched the placeholder ticket link to `example.com` (to avoid accidental links to "real" placeholder domains).

Note the changes between the pre-release beta version 4 and the full release do not seem to be substantive / impactful - mostly relating to how breaking changes are defined/set.

<img width="1189" height="1134" alt="image" src="https://github.com/user-attachments/assets/73d318d5-214d-4703-a4b3-c5628163475d" />


## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
