### PR TITLE
Story(253521): Disable public network access for Redis cache

### DIFF
--- a/terraform/container-app/redis.tf
+++ b/terraform/container-app/redis.tf
@@ -7,4 +7,5 @@ resource "azurerm_redis_cache" "redis" {
   sku_name            = local.redis_sku_name
   minimum_tls_version = local.redis_tls_version
   tags                = local.tags
+  public_network_access_enabled = false
 }


### PR DESCRIPTION
## Overview

Addresses ticket [253521](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/253521)

Disable public network access for Redis Cache in all Environment. There is already a private endpoint set up and therefore public access is not required (in such cases it is advisable to turn it off).
This is just a single line change in the Redis cache resource terraform.

## Changes

### Major

- Disable public network access for Redis resources in all environments.

## Testing

Deploy to development and verify that the public network access flag is false. I have checked this in its current 'enabled' state in the development environment. Should also test in the development environment by attempting to access and perform actions on the Redis cache not via the private endpoint.

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
- [x] PR targets development branch
- [x] Terraform has been updated
