### PR TITLE
story(264996): update routing to incorporate category slug

### DIFF
--- a/src/Dfe.PlanTech.Web/Controllers/ChangeAnswersController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/ChangeAnswersController.cs
@@ -29,8 +29,9 @@ namespace Dfe.PlanTech.Web.Controllers
             _user = user;
         }
 
-        [HttpGet("{sectionSlug}/change-answers")]
+        [HttpGet("{categorySlug}/{sectionSlug}/change-answers")]
         public async Task<IActionResult> ChangeAnswersPage(
+            string categorySlug,
             string sectionSlug,
             [FromServices] IChangeAnswersRouter changeAnswersValidator,
             [FromServices] IUserJourneyMissingContentExceptionHandler userJourneyMissingContentExceptionHandler,
@@ -38,32 +39,17 @@ namespace Dfe.PlanTech.Web.Controllers
         {
             try
             {
+                ArgumentNullException.ThrowIfNullOrEmpty(categorySlug);
                 ArgumentNullException.ThrowIfNullOrEmpty(sectionSlug);
 
                 var errorMessage = TempData["ErrorMessage"]?.ToString();
 
-                return await changeAnswersValidator.ValidateRoute(sectionSlug, errorMessage, this, cancellationToken);
+                return await changeAnswersValidator.ValidateRoute(categorySlug, sectionSlug, errorMessage, this, cancellationToken);
             }
             catch (UserJourneyMissingContentException userJourneyException)
             {
                 return await userJourneyMissingContentExceptionHandler.Handle(this, userJourneyException, cancellationToken);
             }
-        }
-
-        [HttpGet("recommendations/from-section/{sectionSlug}")]
-        public async Task<IActionResult> RedirectToRecommendation(
-            string sectionSlug,
-            [FromServices] IGetRecommendationRouter getRecommendationRouter,
-            CancellationToken cancellationToken = default)
-        {
-
-            var recommendationSlug = await getRecommendationRouter.GetRecommendationSlugForSection(sectionSlug, cancellationToken);
-
-            return RedirectToAction(
-                  RecommendationsController.GetRecommendationAction,
-                  RecommendationsController.ControllerName,
-                  new { sectionSlug, recommendationSlug }
-              );
         }
     }
 }

--- a/src/Dfe.PlanTech.Web/Controllers/CheckAnswersController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/CheckAnswersController.cs
@@ -51,7 +51,6 @@ public class CheckAnswersController(ILogger<CheckAnswersController> checkAnswers
         string sectionSlug,
         int submissionId,
         string sectionName,
-        string redirectOption,
         [FromServices] ICalculateMaturityCommand calculateMaturityCommand,
         [FromServices] IGetRecommendationRouter getRecommendationRouter,
         [FromServices] IMarkSubmissionAsReviewedCommand markSubmissionAsReviewedCommand,

--- a/src/Dfe.PlanTech.Web/Controllers/QuestionsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/QuestionsController.cs
@@ -78,6 +78,8 @@ public class QuestionsController : BaseController<QuestionsController>
     {
         if (string.IsNullOrEmpty(categorySlug))
             throw new ArgumentNullException(nameof(categorySlug));
+        if (string.IsNullOrEmpty(sectionSlug))
+            throw new ArgumentNullException(nameof(sectionSlug));
 
         var interstitialPage = await _getPageQuery.GetPageBySlug(sectionSlug)
             ?? throw new ContentfulDataUnavailableException($"Could not find interstitial page for section: {sectionSlug}");

--- a/src/Dfe.PlanTech.Web/Controllers/QuestionsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/QuestionsController.cs
@@ -60,6 +60,8 @@ public class QuestionsController : BaseController<QuestionsController>
                                                     [FromServices] IGetQuestionBySlugRouter router,
                                                     CancellationToken cancellationToken = default)
     {
+        if (string.IsNullOrEmpty(categorySlug))
+            throw new ArgumentNullException(nameof(categorySlug));
         if (string.IsNullOrEmpty(sectionSlug))
             throw new ArgumentNullException(nameof(sectionSlug));
         if (string.IsNullOrEmpty(questionSlug))
@@ -109,6 +111,8 @@ public class QuestionsController : BaseController<QuestionsController>
                                                                 [FromServices] IDeleteCurrentSubmissionCommand deleteCurrentSubmissionCommand,
                                                                 CancellationToken cancellationToken = default)
     {
+        if (string.IsNullOrEmpty(categorySlug))
+            throw new ArgumentNullException(nameof(categorySlug));
         if (string.IsNullOrEmpty(sectionSlug))
             throw new ArgumentNullException(nameof(sectionSlug));
 

--- a/src/Dfe.PlanTech.Web/Controllers/QuestionsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/QuestionsController.cs
@@ -121,7 +121,7 @@ public class QuestionsController : BaseController<QuestionsController>
             var nextQuestion = await getQuestionQuery.GetNextUnansweredQuestion(establishmentId, section, cancellationToken);
 
             if (nextQuestion == null)
-                return this.RedirectToCheckAnswers(sectionSlug);
+                return this.RedirectToCheckAnswers(categorySlug, sectionSlug);
 
             return RedirectToAction(nameof(GetQuestionBySlug), new { categorySlug, sectionSlug, questionSlug = nextQuestion.Slug });
         }
@@ -198,7 +198,7 @@ public class QuestionsController : BaseController<QuestionsController>
 
             if (submissionResponsesDto?.Responses == null)
             {
-                return this.RedirectToCheckAnswers(sectionSlug, isChangeAnswersFlow);
+                return this.RedirectToCheckAnswers(categorySlug, sectionSlug, isChangeAnswersFlow);
             }
 
             // Check answered questions
@@ -219,7 +219,7 @@ public class QuestionsController : BaseController<QuestionsController>
             }
 
             // No next questions so check answers
-            return this.RedirectToCheckAnswers(sectionSlug, isChangeAnswersFlow);
+            return this.RedirectToCheckAnswers(categorySlug, sectionSlug, isChangeAnswersFlow);
         }
 
         return RedirectToAction(nameof(GetNextUnansweredQuestion), new { categorySlug, sectionSlug });

--- a/src/Dfe.PlanTech.Web/Controllers/RecommendationsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/RecommendationsController.cs
@@ -21,25 +21,6 @@ public class RecommendationsController(ILogger<RecommendationsController> logger
     public const string GetRecommendationAction = "GetRecommendation";
     public const string GetSingleRecommendationAction = "GetSingleRecommendation";
 
-    [HttpGet("{categorySlug}/{sectionSlug}/recommendation/{recommendationSlug}", Name = GetRecommendationAction)]
-    public async Task<IActionResult> GetRecommendation(string categorySlug,
-                                                       string sectionSlug,
-                                                       string recommendationSlug,
-                                                       [FromServices] IGetRecommendationRouter getRecommendationValidator,
-                                                       CancellationToken cancellationToken)
-    {
-        if (string.IsNullOrEmpty(sectionSlug))
-            throw new ArgumentNullException(nameof(sectionSlug));
-        if (string.IsNullOrEmpty(recommendationSlug))
-            throw new ArgumentNullException(nameof(recommendationSlug));
-
-        return await getRecommendationValidator.ValidateRoute(categorySlug,
-          sectionSlug,
-          false,
-          this,
-          cancellationToken);
-    }
-
     [HttpGet("{categorySlug}/{sectionSlug}/recommendations/{chunkSlug}", Name = GetSingleRecommendationAction)]
     public async Task<IActionResult> GetSingleRecommendation(string categorySlug,
                                                          string sectionSlug,

--- a/src/Dfe.PlanTech.Web/Controllers/RecommendationsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/RecommendationsController.cs
@@ -40,7 +40,7 @@ public class RecommendationsController(ILogger<RecommendationsController> logger
           cancellationToken);
     }
 
-    [HttpGet("{categorySlug}/{sectionSlug}/{chunkSlug}", Name = GetSingleRecommendationAction)]
+    [HttpGet("{categorySlug}/{sectionSlug}/recommendations/{chunkSlug}", Name = GetSingleRecommendationAction)]
     public async Task<IActionResult> GetSingleRecommendation(string categorySlug,
                                                          string sectionSlug,
                                                          string chunkSlug,
@@ -100,7 +100,7 @@ public class RecommendationsController(ILogger<RecommendationsController> logger
         return await getRecommendationRouter.GetRecommendationPreview(sectionSlug, maturity, this, cancellationToken);
     }
 
-    [HttpGet("{categorySlug}/{sectionSlug}/print", Name = "GetRecommendationChecklist")]
+    [HttpGet("{categorySlug}/{sectionSlug}/recommendations/print", Name = "GetRecommendationChecklist")]
     public async Task<IActionResult> GetRecommendationChecklist(string categorySlug,
                                                                 string sectionSlug,
                                                                 [FromServices] IGetRecommendationRouter getRecommendationValidator,

--- a/src/Dfe.PlanTech.Web/Controllers/RecommendationsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/RecommendationsController.cs
@@ -114,18 +114,5 @@ public class RecommendationsController(ILogger<RecommendationsController> logger
             this,
             cancellationToken);
     }
-
-    [HttpGet("from-section/{sectionSlug}")]
-    public async Task<IActionResult> FromSection(
-        string sectionSlug,
-        [FromServices] IGetRecommendationRouter getRecommendationRouter,
-        CancellationToken cancellationToken)
-    {
-        if (string.IsNullOrEmpty(sectionSlug))
-            throw new ArgumentNullException(nameof(sectionSlug));
-
-        var recommendationSlug = await getRecommendationRouter.GetRecommendationSlugForSection(sectionSlug, cancellationToken);
-        return RedirectToAction(nameof(GetRecommendation), new { recommendationSlug });
-    }
 }
 

--- a/src/Dfe.PlanTech.Web/Controllers/RecommendationsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/RecommendationsController.cs
@@ -40,10 +40,10 @@ public class RecommendationsController(ILogger<RecommendationsController> logger
           cancellationToken);
     }
 
-    [HttpGet("{categorySlug}/{sectionSlug}/{recommendationSlug}", Name = GetSingleRecommendationAction)]
+    [HttpGet("{categorySlug}/{sectionSlug}/{chunkSlug}", Name = GetSingleRecommendationAction)]
     public async Task<IActionResult> GetSingleRecommendation(string categorySlug,
                                                          string sectionSlug,
-                                                         string recommendationSlug,
+                                                         string chunkSlug,
                                                          [FromServices] IGetRecommendationRouter getRecommendationRouter,
                                                          [FromServices] IGetPageQuery getPageQuery,
                                                          CancellationToken cancellationToken)
@@ -52,13 +52,13 @@ public class RecommendationsController(ILogger<RecommendationsController> logger
             throw new ArgumentNullException(nameof(categorySlug));
         if (string.IsNullOrEmpty(sectionSlug))
             throw new ArgumentNullException(nameof(sectionSlug));
-        if (string.IsNullOrEmpty(recommendationSlug))
-            throw new ArgumentNullException(nameof(recommendationSlug));
+        if (string.IsNullOrEmpty(chunkSlug))
+            throw new ArgumentNullException(nameof(chunkSlug));
 
         var categoryLandingPage = await getPageQuery.GetPageBySlug(categorySlug);
         var category = categoryLandingPage?.Content[0] as Category ?? throw new ContentfulDataUnavailableException($"No category landing page found for slug: {categorySlug}");
 
-        var (section, currentChunk, allChunks) = await getRecommendationRouter.GetSingleRecommendation(sectionSlug, recommendationSlug, this, cancellationToken);
+        var (section, currentChunk, allChunks) = await getRecommendationRouter.GetSingleRecommendation(sectionSlug, chunkSlug, this, cancellationToken);
         var currentChunkIndex = allChunks.IndexOf(currentChunk);
         var previousChunk = currentChunkIndex > 0
                             ? allChunks[currentChunkIndex - 1]

--- a/src/Dfe.PlanTech.Web/Helpers/PageRedirecter.cs
+++ b/src/Dfe.PlanTech.Web/Helpers/PageRedirecter.cs
@@ -9,8 +9,8 @@ public static class PageRedirecter
     public static RedirectToActionResult RedirectToHomepage(this Controller controller)
     => RedirectToPage(controller, UrlConstants.HomePage);
 
-    public static RedirectToActionResult RedirectToCheckAnswers(this Controller controller, string sectionSlug, bool isChangeAnswersFlow = false)
-      => controller.RedirectToAction(CheckAnswersController.CheckAnswersAction, CheckAnswersController.ControllerName, new { sectionSlug, isChangeAnswersFlow });
+    public static RedirectToActionResult RedirectToCheckAnswers(this Controller controller, string categorySlug, string sectionSlug, bool isChangeAnswersFlow = false)
+      => controller.RedirectToAction(CheckAnswersController.CheckAnswersAction, CheckAnswersController.ControllerName, new { categorySlug, sectionSlug, isChangeAnswersFlow });
 
     public static RedirectToActionResult RedirectToInterstitialPage(this Controller controller, string sectionSlug)
     => RedirectToPage(controller, sectionSlug);
@@ -20,5 +20,9 @@ public static class PageRedirecter
 
     public static RedirectToActionResult RedirectToRecommendation(this Controller controller, string sectionSlug, string recommendationSlug)
     => controller.RedirectToAction(RecommendationsController.GetRecommendationAction, RecommendationsController.ControllerName, new { sectionSlug, recommendationSlug });
+
+    public static RedirectToActionResult RedirectToCategoryLandingPage(this Controller controller, string categorySlug)
+        => controller.RedirectToAction(PagesController.GetPageByRouteAction, PagesController.ControllerName, new { route = categorySlug });
+
 }
 

--- a/src/Dfe.PlanTech.Web/Helpers/PageRedirecter.cs
+++ b/src/Dfe.PlanTech.Web/Helpers/PageRedirecter.cs
@@ -18,11 +18,7 @@ public static class PageRedirecter
     private static RedirectToActionResult RedirectToPage(this Controller controller, string route)
     => controller.RedirectToAction(PagesController.GetPageByRouteAction, PagesController.ControllerName, new { route });
 
-    public static RedirectToActionResult RedirectToRecommendation(this Controller controller, string sectionSlug, string recommendationSlug)
-    => controller.RedirectToAction(RecommendationsController.GetRecommendationAction, RecommendationsController.ControllerName, new { sectionSlug, recommendationSlug });
-
     public static RedirectToActionResult RedirectToCategoryLandingPage(this Controller controller, string categorySlug)
         => controller.RedirectToAction(PagesController.GetPageByRouteAction, PagesController.ControllerName, new { route = categorySlug });
-
 }
 

--- a/src/Dfe.PlanTech.Web/Models/ChangeAnswersViewModel.cs
+++ b/src/Dfe.PlanTech.Web/Models/ChangeAnswersViewModel.cs
@@ -22,4 +22,6 @@ public class ChangeAnswersViewModel
     public string? Slug { get; init; } = null;
 
     public string? ErrorMessage { get; set; } = null;
+
+    public string? CategorySlug { get; init; }
 }

--- a/src/Dfe.PlanTech.Web/Models/CheckAnswersViewModel.cs
+++ b/src/Dfe.PlanTech.Web/Models/CheckAnswersViewModel.cs
@@ -25,4 +25,6 @@ public class CheckAnswersViewModel
     public string? Slug { get; init; } = null;
 
     public string? ErrorMessage { get; set; } = null;
+
+    public string? CategorySlug { get; init; }
 }

--- a/src/Dfe.PlanTech.Web/Models/QuestionViewModel.cs
+++ b/src/Dfe.PlanTech.Web/Models/QuestionViewModel.cs
@@ -17,4 +17,6 @@ public class QuestionViewModel
     public string? SectionSlug { get; init; }
 
     public string? SectionId { get; init; }
+
+    public string? CategorySlug { get; init; }
 }

--- a/src/Dfe.PlanTech.Web/Models/RecommendationsViewModel.cs
+++ b/src/Dfe.PlanTech.Web/Models/RecommendationsViewModel.cs
@@ -11,22 +11,11 @@ public class RecommendationsViewModel
 
     public string SectionSlug { get; init; } = null!;
 
-//    public RecommendationIntro Intro { get; init; } = null!;
-
     public List<RecommendationChunk> Chunks { get; init; } = null!;
 
     public string? LatestCompletionDate { get; init; } = null!;
 
-//    public IEnumerable<IHeaderWithContent> AllContent => GetAllContent();
-
     public string? Slug { get; init; } = null;
 
-    //private IEnumerable<IHeaderWithContent> GetAllContent()
-    //{
-    //    foreach (var chunk in Chunks)
-    //    {
-    //        yield return chunk;
-    //    }
-    //}
     public IEnumerable<QuestionWithAnswer> SubmissionResponses { get; init; } = null!;
 }

--- a/src/Dfe.PlanTech.Web/Models/RecommendationsViewModel.cs
+++ b/src/Dfe.PlanTech.Web/Models/RecommendationsViewModel.cs
@@ -1,4 +1,3 @@
-using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 using Dfe.PlanTech.Domain.Questionnaire.Models;
 using Dfe.PlanTech.Domain.Submissions.Models;
 
@@ -6,27 +5,28 @@ namespace Dfe.PlanTech.Web.Models;
 
 public class RecommendationsViewModel
 {
+    public string CategoryName { get; init; } = null!;
+
     public string SectionName { get; init; } = null!;
 
     public string SectionSlug { get; init; } = null!;
 
-    public RecommendationIntro Intro { get; init; } = null!;
+//    public RecommendationIntro Intro { get; init; } = null!;
 
     public List<RecommendationChunk> Chunks { get; init; } = null!;
 
     public string? LatestCompletionDate { get; init; } = null!;
 
-    public IEnumerable<IHeaderWithContent> AllContent => GetAllContent();
+//    public IEnumerable<IHeaderWithContent> AllContent => GetAllContent();
 
-    public string Slug { get; init; } = null!;
+    public string? Slug { get; init; } = null;
 
-    private IEnumerable<IHeaderWithContent> GetAllContent()
-    {
-        yield return Intro;
-        foreach (var chunk in Chunks)
-        {
-            yield return chunk;
-        }
-    }
+    //private IEnumerable<IHeaderWithContent> GetAllContent()
+    //{
+    //    foreach (var chunk in Chunks)
+    //    {
+    //        yield return chunk;
+    //    }
+    //}
     public IEnumerable<QuestionWithAnswer> SubmissionResponses { get; init; } = null!;
 }

--- a/src/Dfe.PlanTech.Web/Models/SingleRecommendationViewModel.cs
+++ b/src/Dfe.PlanTech.Web/Models/SingleRecommendationViewModel.cs
@@ -1,0 +1,25 @@
+﻿using Dfe.PlanTech.Domain.Questionnaire.Models;
+
+namespace Dfe.PlanTech.Web.Models
+{
+    public class SingleRecommendationViewModel
+    {
+        public string CategorySlug { get; set; } = "";
+
+        public string CategoryName { get; set; } = "";
+
+        public Section Section { get; set; } = null!;
+
+        public List<RecommendationChunk> Chunks { get; set; } = [];
+
+        public RecommendationChunk CurrentChunk { get; set; } = null!;
+
+        public RecommendationChunk? PreviousChunk { get; set; } = null!;
+
+        public RecommendationChunk? NextChunk { get; set; } = null!;
+
+        public int CurrentChunkPosition { get; set; }
+
+        public int TotalChunks { get; set; }
+    }
+}

--- a/src/Dfe.PlanTech.Web/Models/SingleRecommendationViewModel.cs
+++ b/src/Dfe.PlanTech.Web/Models/SingleRecommendationViewModel.cs
@@ -4,9 +4,9 @@ namespace Dfe.PlanTech.Web.Models
 {
     public class SingleRecommendationViewModel
     {
-        public string CategorySlug { get; set; } = "";
-
         public string CategoryName { get; set; } = "";
+
+        public string CategorySlug { get; set; } = "";
 
         public Section Section { get; set; } = null!;
 

--- a/src/Dfe.PlanTech.Web/Models/StatusLinkViewModel.cs
+++ b/src/Dfe.PlanTech.Web/Models/StatusLinkViewModel.cs
@@ -4,6 +4,8 @@ namespace Dfe.PlanTech.Web.Models
 {
     public class StatusLinkViewModel
     {
+        public string CategorySlug { get; set; } = null!;
+
         public CategoryLandingSection Section { get; set; } = null!;
 
         public string Context { get; set; } = null!;

--- a/src/Dfe.PlanTech.Web/Routing/ChangeAnswersRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/ChangeAnswersRouter.cs
@@ -44,6 +44,8 @@ namespace Dfe.PlanTech.Web.Routing
             ChangeAnswersController controller,
             CancellationToken cancellationToken)
         {
+            if (string.IsNullOrEmpty(categorySlug))
+                throw new ArgumentNullException(nameof(categorySlug));
             if (string.IsNullOrEmpty(sectionSlug))
                 throw new ArgumentNullException(nameof(sectionSlug));
 

--- a/src/Dfe.PlanTech.Web/Routing/ChangeAnswersRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/ChangeAnswersRouter.cs
@@ -38,6 +38,7 @@ namespace Dfe.PlanTech.Web.Routing
         }
 
         public async Task<IActionResult> ValidateRoute(
+            string categorySlug,
             string sectionSlug,
             string? errorMessage,
             ChangeAnswersController controller,
@@ -51,7 +52,7 @@ namespace Dfe.PlanTech.Web.Routing
             switch (_router.Status)
             {
                 case Status.CompleteNotReviewed:
-                    return await ProcessChangeAnswers(sectionSlug, errorMessage, controller, cancellationToken);
+                    return await ProcessChangeAnswers(categorySlug, sectionSlug, errorMessage, controller, cancellationToken);
 
                 case Status.CompleteReviewed:
                 {
@@ -73,7 +74,7 @@ namespace Dfe.PlanTech.Web.Routing
                     var clonedSubmission = await _submissionCommand.CloneSubmission(
                         latestSubmission, cancellationToken);
 
-                    return await ProcessChangeAnswers(sectionSlug, errorMessage, controller, cancellationToken);
+                    return await ProcessChangeAnswers(categorySlug, sectionSlug, errorMessage, controller, cancellationToken);
                 }
 
                 case Status.NotStarted:
@@ -85,6 +86,7 @@ namespace Dfe.PlanTech.Web.Routing
         }
 
         private async Task<IActionResult> ProcessChangeAnswers(
+            string categorySlug,
             string sectionSlug,
             string? errorMessage,
             ChangeAnswersController controller,
@@ -108,7 +110,8 @@ namespace Dfe.PlanTech.Web.Routing
                 SectionSlug = sectionSlug,
                 SubmissionId = submissionResponsesDto.SubmissionId,
                 Slug = ChangeAnswersController.ChangeAnswersPageSlug,
-                ErrorMessage = errorMessage
+                ErrorMessage = errorMessage,
+                CategorySlug = categorySlug
             };
 
             return controller.View(ChangeAnswersController.ChangeAnswersViewName, model);

--- a/src/Dfe.PlanTech.Web/Routing/GetQuestionBySlugRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/GetQuestionBySlugRouter.cs
@@ -90,12 +90,6 @@ public class GetQuestionBySlugRouter : IGetQuestionBySlugRouter
 
         var responses = await GetLatestResponsesForSection(isChangeAnswersFlow, cancellationToken);
 
-        if (responses is null)
-        {
-            throw new InvalidOperationException(
-                $"No responses were found for section '{_router.Section.Sys.Id}'");
-        }
-
         var isAttachedQuestion = IsQuestionAttached(responses, question);
 
         if (!isAttachedQuestion)

--- a/src/Dfe.PlanTech.Web/Routing/GetQuestionBySlugRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/GetQuestionBySlugRouter.cs
@@ -97,7 +97,7 @@ public class GetQuestionBySlugRouter : IGetQuestionBySlugRouter
         var isAttachedQuestion = IsQuestionAttached(responses, question);
 
         if (!isAttachedQuestion)
-            return HandleNotAttachedQuestion(sectionSlug, controller);
+            return HandleNotAttachedQuestion(categorySlug, sectionSlug, controller);
 
         var latestResponseForQuestion = GetLatestResponseForQuestion(responses, question);
 
@@ -170,10 +170,10 @@ public class GetQuestionBySlugRouter : IGetQuestionBySlugRouter
     /// <param name="controller"></param>
     /// <returns></returns>
     /// <exception cref="InvalidDataException"></exception>
-    private IActionResult HandleNotAttachedQuestion(string sectionSlug, QuestionsController controller)
+    private IActionResult HandleNotAttachedQuestion(string categorySlug, string sectionSlug, QuestionsController controller)
     => _router.Status switch
     {
-        Status.CompleteNotReviewed => controller.RedirectToCheckAnswers(sectionSlug),
+        Status.CompleteNotReviewed => controller.RedirectToCheckAnswers(categorySlug, sectionSlug),
         Status.InProgress => QuestionsController.RedirectToQuestionBySlug(sectionSlug, _router.NextQuestion?.Slug ?? throw new InvalidDataException("NextQuestion is null"), controller),
         _ => throw new InvalidDataException("Should not be here"),
     };

--- a/src/Dfe.PlanTech.Web/Routing/GetQuestionBySlugRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/GetQuestionBySlugRouter.cs
@@ -42,6 +42,8 @@ public class GetQuestionBySlugRouter : IGetQuestionBySlugRouter
     /// <exception cref="ArgumentNullException"></exception>
     public async Task<IActionResult> ValidateRoute(string categorySlug, string sectionSlug, string questionSlug, QuestionsController controller, CancellationToken cancellationToken)
     {
+        if (string.IsNullOrEmpty(categorySlug))
+            throw new ArgumentNullException(nameof(categorySlug));
         if (string.IsNullOrEmpty(sectionSlug))
             throw new ArgumentNullException(nameof(sectionSlug));
         if (string.IsNullOrEmpty(questionSlug))

--- a/src/Dfe.PlanTech.Web/Routing/GetQuestionBySlugRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/GetQuestionBySlugRouter.cs
@@ -40,7 +40,7 @@ public class GetQuestionBySlugRouter : IGetQuestionBySlugRouter
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     /// <exception cref="ArgumentNullException"></exception>
-    public async Task<IActionResult> ValidateRoute(string sectionSlug, string questionSlug, QuestionsController controller, CancellationToken cancellationToken)
+    public async Task<IActionResult> ValidateRoute(string categorySlug, string sectionSlug, string questionSlug, QuestionsController controller, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(sectionSlug))
             throw new ArgumentNullException(nameof(sectionSlug));
@@ -54,14 +54,14 @@ public class GetQuestionBySlugRouter : IGetQuestionBySlugRouter
 
         if (IsSlugForNextQuestion(questionSlug))
         {
-            var viewModel = controller.GenerateViewModel(sectionSlug, _router.NextQuestion!, _router.Section, null);
+            var viewModel = controller.GenerateViewModel(categorySlug, sectionSlug, _router.NextQuestion!, _router.Section, null);
             return controller.RenderView(viewModel);
         }
 
         if (SectionIsAtStart)
             return PageRedirecter.RedirectToInterstitialPage(controller, sectionSlug);
 
-        return await ProcessOtherStatuses(sectionSlug, questionSlug, controller, isChangeAnswersFlow, cancellationToken);
+        return await ProcessOtherStatuses(categorySlug, sectionSlug, questionSlug, controller, isChangeAnswersFlow, cancellationToken);
     }
 
     /// <summary>
@@ -82,7 +82,7 @@ public class GetQuestionBySlugRouter : IGetQuestionBySlugRouter
     /// <param name="controller"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    private async Task<IActionResult> ProcessOtherStatuses(string sectionSlug, string questionSlug, QuestionsController controller, bool isChangeAnswersFlow, CancellationToken cancellationToken)
+    private async Task<IActionResult> ProcessOtherStatuses(string categorySlug, string sectionSlug, string questionSlug, QuestionsController controller, bool isChangeAnswersFlow, CancellationToken cancellationToken)
     {
         var question = GetQuestionForSlug(questionSlug);
 
@@ -101,7 +101,8 @@ public class GetQuestionBySlugRouter : IGetQuestionBySlugRouter
 
         var latestResponseForQuestion = GetLatestResponseForQuestion(responses, question);
 
-        var viewModel = controller.GenerateViewModel(sectionSlug,
+        var viewModel = controller.GenerateViewModel(categorySlug,
+                                                     sectionSlug,
                                                      question,
                                                      _router.Section,
                                                      latestResponseForQuestion.AnswerRef);

--- a/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
@@ -54,7 +54,7 @@ public class GetRecommendationRouter : IGetRecommendationRouter
             Status.CompleteReviewed => checklist ?
                 await HandleChecklist(controller, categorySlug, sectionSlug, cancellationToken) :
                 await HandleCompleteStatus(controller, categorySlug, sectionSlug, cancellationToken),
-            Status.CompleteNotReviewed => controller.RedirectToCheckAnswers(sectionSlug),
+            Status.CompleteNotReviewed => controller.RedirectToCheckAnswers(categorySlug, sectionSlug),
             Status.InProgress => HandleQuestionStatus(sectionSlug, controller),
             Status.NotStarted => PageRedirecter.RedirectToHomepage(controller),
             _ => throw new InvalidOperationException($"Invalid journey status - {_router.Status}"),

--- a/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
@@ -104,7 +104,7 @@ public class GetRecommendationRouter : IGetRecommendationRouter
         return (subTopicRecommendation, subTopicIntro, subTopicChunks, latestResponses);
     }
 
-    public async Task<(Section, RecommendationChunk, List<RecommendationChunk>)> GetSingleRecommendation(string sectionSlug, string recommendationSlug, RecommendationsController controller, CancellationToken cancellationToken)
+    public async Task<(Section, RecommendationChunk, List<RecommendationChunk>)> GetSingleRecommendation(string sectionSlug, string chunkSlug, RecommendationsController controller, CancellationToken cancellationToken)
     {
         var section = await _getSectionQuery.GetSectionBySlug(sectionSlug)
             ?? throw new ContentfulDataUnavailableException($"Could not find section with slug: {sectionSlug}");
@@ -115,8 +115,8 @@ public class GetRecommendationRouter : IGetRecommendationRouter
             ?? throw new ContentfulDataUnavailableException($"Could not find subtopic recommendation for:  {section.Name}");
         var allChunks = subTopicRecommendation.Section.GetRecommendationChunksByAnswerIds(latestResponses.Select(answer => answer.AnswerRef))
             ?? throw new ContentfulDataUnavailableException($"Could not find recommendation chunks for section: {section.Name}");
-        var currentChunk = allChunks.FirstOrDefault(chunk => chunk.SlugifiedLinkText == recommendationSlug)
-            ?? throw new ContentfulDataUnavailableException($"No recommendation chunk found with slug mathing: {recommendationSlug}");
+        var currentChunk = allChunks.FirstOrDefault(chunk => chunk.SlugifiedLinkText == chunkSlug)
+            ?? throw new ContentfulDataUnavailableException($"No recommendation chunk found with slug mathing: {chunkSlug}");
 
         return (section, currentChunk, allChunks);
     }

--- a/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
@@ -111,14 +111,17 @@ public class GetRecommendationRouter : IGetRecommendationRouter
         var section = await _getSectionQuery.GetSectionBySlug(sectionSlug)
             ?? throw new ContentfulDataUnavailableException($"Could not find section with slug: {sectionSlug}");
         var submissionResponses = await _getLatestResponsesQuery.GetLatestResponses(await _user.GetEstablishmentId(), section.Sys.Id, true)
-            ?? throw new DatabaseException($"Could not find users answers for:  {section.Name}");
+            ?? throw new DatabaseException($"Could not find users answers for: {section.Name}");
         var latestResponses = section.GetOrderedResponsesForJourney(submissionResponses.Responses).ToList();
         var subTopicRecommendation = await _getSubTopicRecommendationQuery.GetSubTopicRecommendation(section.Sys.Id)
-            ?? throw new ContentfulDataUnavailableException($"Could not find subtopic recommendation for:  {section.Name}");
-        var allChunks = subTopicRecommendation.Section.GetRecommendationChunksByAnswerIds(latestResponses.Select(answer => answer.AnswerRef))
-            ?? throw new ContentfulDataUnavailableException($"Could not find recommendation chunks for section: {section.Name}");
+            ?? throw new ContentfulDataUnavailableException($"Could not find subtopic recommendation for: {section.Name}");
+        var allChunks = subTopicRecommendation.Section.GetRecommendationChunksByAnswerIds(latestResponses.Select(answer => answer.AnswerRef));
+
+        if (allChunks.Count == 0)
+            throw new ContentfulDataUnavailableException($"Could not find recommendation chunks for section: {section.Name}");
+
         var currentChunk = allChunks.FirstOrDefault(chunk => chunk.SlugifiedLinkText == chunkSlug)
-            ?? throw new ContentfulDataUnavailableException($"No recommendation chunk found with slug mathing: {chunkSlug}");
+            ?? throw new ContentfulDataUnavailableException($"No recommendation chunk found with slug matching: {chunkSlug}");
 
         return (section, currentChunk, allChunks);
     }

--- a/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
@@ -44,6 +44,8 @@ public class GetRecommendationRouter : IGetRecommendationRouter
         RecommendationsController controller,
         CancellationToken cancellationToken)
     {
+        if (string.IsNullOrEmpty(categorySlug))
+            throw new ArgumentNullException(nameof(categorySlug));
         if (string.IsNullOrEmpty(sectionSlug))
             throw new ArgumentNullException(nameof(sectionSlug));
 

--- a/src/Dfe.PlanTech.Web/Routing/IChangeAnswersRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/IChangeAnswersRouter.cs
@@ -17,7 +17,8 @@ public interface IChangeAnswersRouter
     /// <param name="controller"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    Task<IActionResult> ValidateRoute(string sectionSlug,
+    Task<IActionResult> ValidateRoute(string categorySlug,
+                                      string sectionSlug,
                                       string? errorMessage,
                                       ChangeAnswersController controller,
                                       CancellationToken cancellationToken);

--- a/src/Dfe.PlanTech.Web/Routing/IChangeAnswersRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/IChangeAnswersRouter.cs
@@ -12,6 +12,7 @@ public interface IChangeAnswersRouter
     /// Gets current user journey status, then either returns Change Answers page (if appropriate), 
     /// or redirects to correct next part of user journey
     /// </summary>
+    /// <param name="categorySlug"></param>
     /// <param name="sectionSlug"></param>
     /// <param name="errorMessage"></param>
     /// <param name="controller"></param>

--- a/src/Dfe.PlanTech.Web/Routing/ICheckAnswersRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/ICheckAnswersRouter.cs
@@ -12,12 +12,14 @@ public interface ICheckAnswersRouter
     /// Gets current user journey status, then either returns Check Answers page (if appropriate), 
     /// or redirects to correct next part of user journey
     /// </summary>
+    /// <param name="categorySlug"></param>
     /// <param name="sectionSlug"></param>
     /// <param name="errorMessage"></param>
     /// <param name="controller"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    Task<IActionResult> ValidateRoute(string sectionSlug,
+    Task<IActionResult> ValidateRoute(string categorySlug,
+                                      string sectionSlug,
                                       string? errorMessage,
                                       CheckAnswersController controller,
                                       bool isChangeAnswersFlow = false,

--- a/src/Dfe.PlanTech.Web/Routing/IGetQuestionBySlugRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/IGetQuestionBySlugRouter.cs
@@ -12,12 +12,14 @@ public interface IGetQuestionBySlugRouter
     /// Gets current user journey status, then either returns Question page for question slug (if appropriate), 
     /// or redirects to correct next part of user journey
     /// </summary>
+    /// <param name="categorySlug"></param>
     /// <param name="sectionSlug"></param>
     /// <param name="questionSlug"></param>
     /// <param name="controller"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public Task<IActionResult> ValidateRoute(string sectionSlug,
+    public Task<IActionResult> ValidateRoute(string categorySlug,
+                                             string sectionSlug,
                                              string questionSlug,
                                              QuestionsController controller,
                                              CancellationToken cancellationToken);

--- a/src/Dfe.PlanTech.Web/Routing/IGetRecommendationRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/IGetRecommendationRouter.cs
@@ -13,14 +13,15 @@ public interface IGetRecommendationRouter
     /// Gets current user journey status, then either returns Recommendation page for slug (if appropriate), 
     /// or redirects to correct next part of user journey
     /// </summary>
+    /// <param name="categorySlug"></param>
     /// <param name="sectionSlug"></param>
     /// <param name="recommendationSlug"></param>
     /// <param name="checklist"></param>
     /// <param name="controller"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public Task<IActionResult> ValidateRoute(string sectionSlug,
-                                             string recommendationSlug,
+    public Task<IActionResult> ValidateRoute(string categorySlug,
+                                             string sectionSlug,
                                              bool checklist,
                                              RecommendationsController controller,
                                              CancellationToken cancellationToken);

--- a/src/Dfe.PlanTech.Web/Routing/IGetRecommendationRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/IGetRecommendationRouter.cs
@@ -58,7 +58,7 @@ public interface IGetRecommendationRouter
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     public Task<(Section, RecommendationChunk, List<RecommendationChunk>)> GetSingleRecommendation(string sectionSlug,
-                                                                                          string recommendationSlug,
+                                                                                          string chunkSlug,
                                                                                           RecommendationsController controller,
                                                                                           CancellationToken cancellationToken);
 }

--- a/src/Dfe.PlanTech.Web/Routing/IGetRecommendationRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/IGetRecommendationRouter.cs
@@ -1,3 +1,4 @@
+using Dfe.PlanTech.Domain.Questionnaire.Models;
 using Dfe.PlanTech.Web.Controllers;
 using Microsoft.AspNetCore.Mvc;
 
@@ -45,4 +46,18 @@ public interface IGetRecommendationRouter
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     public Task<string> GetRecommendationSlugForSection(string sectionSlug, CancellationToken cancellationToken);
+
+
+    /// <summary>
+    /// Get a single recommendation chunk for a completed section by section slug and slugified chunk header
+    /// </summary>
+    /// <param name="sectionSlug"></param>
+    /// <param name="recommendationSlug"></param>
+    /// <param name="controller"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public Task<(Section, RecommendationChunk, List<RecommendationChunk>)> GetSingleRecommendation(string sectionSlug,
+                                                                                          string recommendationSlug,
+                                                                                          RecommendationsController controller,
+                                                                                          CancellationToken cancellationToken);
 }

--- a/src/Dfe.PlanTech.Web/Views/ChangeAnswers/ChangeAnswers.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/ChangeAnswers/ChangeAnswers.cshtml
@@ -32,6 +32,7 @@
                         <a asp-controller="Questions" asp-action="GetQuestionBySlug"
                            asp-route-questionSlug="@questionWithAnswer.QuestionSlug"
                            asp-route-sectionSlug="@Model.SectionSlug"
+                           asp-route-categorySlug="@Model.CategorySlug"
                            asp-route-returnTo="ChangeAnswers"
                            title="@questionWithAnswer.QuestionText"
                            class="govuk-link">
@@ -48,7 +49,7 @@
             <input type="hidden" name="sectionName" value="@Model.SectionName">
             <input type="hidden" name="sectionSlug" value="@Model.SectionSlug">
 
-            <a href="@($"{UrlConstants.RecommendationsPage}/from-section/{Model.SectionSlug}")" role="button" draggable="false"
+            <a href="@($"/{Model.CategorySlug}")" role="button" draggable="false"
                class="govuk-button govuk-button--secondary" data-module="govuk-button">
                 Back to recommendations
             </a>

--- a/src/Dfe.PlanTech.Web/Views/CheckAnswers/CheckAnswers.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/CheckAnswers/CheckAnswers.cshtml
@@ -28,6 +28,7 @@
                     </dd>
                     <dd class="noprint govuk-summary-list__actions spacer">
                         <a asp-controller="Questions" asp-action="GetQuestionBySlug"
+                           asp-route-categorySlug="@Model.CategorySlug"
                            asp-route-questionSlug="@questionWithAnswer.QuestionSlug"
                            asp-route-sectionSlug="@Model.SectionSlug" class="govuk-link"
                            title="@questionWithAnswer.QuestionText">
@@ -42,6 +43,7 @@
             <input type="hidden" name="submissionId" value="@Model.SubmissionId"/>
             <input type="hidden" name="sectionName" value="@Model.SectionName">
             <input type="hidden" name="sectionSlug" value="@Model.SectionSlug">
+            <input type="hidden" name="categorySlug" value="@Model.CategorySlug" />
 
             @{
                 foreach (var content in Model.Content)
@@ -50,7 +52,7 @@
                 }
             }
 
-            <govuk-button class="govuk-!-margin-right-5" type="submit" name="redirectOption" value="@RecommendationsController.GetRecommendationAction">Submit and view recommendations</govuk-button>
+            <govuk-button class="govuk-!-margin-right-5" type="submit">Submit and view recommendations</govuk-button>
 
             @if (Model.ErrorMessage != null)
             {

--- a/src/Dfe.PlanTech.Web/Views/Questions/Question.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Questions/Question.cshtml
@@ -7,7 +7,7 @@
     }
 }
 
-<form asp-controller="Questions" asp-action="SubmitAnswer" asp-route-sectionSlug=@Model.SectionSlug
+<form asp-controller="Questions" asp-action="SubmitAnswer" asp-route-categorySlug=@Model.CategorySlug asp-route-sectionSlug=@Model.SectionSlug
       asp-route-questionSlug=@Model.Question.Slug method="post">
     <input id="QuestionText" type="hidden" value="@Model.Question.Text" name="QuestionText"/>
     <input id="QuestionId" type="hidden" value=@Model.Question.Sys.Id name="QuestionId"/>

--- a/src/Dfe.PlanTech.Web/Views/Recommendations/Print.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/Print.cshtml
@@ -1,5 +1,5 @@
 @model Dfe.PlanTech.Web.Models.RecommendationsViewModel
 
 <p class="govuk-body-s">
-    <a class="govuk-link" href="@Model.Slug/print">Print all recommendations for @Model.SectionName.ToLower()</a>
+    <a class="govuk-link" href="print">Print all recommendations for @Model.SectionName.ToLower()</a>
 </p>

--- a/src/Dfe.PlanTech.Web/Views/Recommendations/RecommendationPrintContent.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/RecommendationPrintContent.cshtml
@@ -3,9 +3,8 @@
 @{
     <div>
         <span class="govuk-caption-xl">How to meet the standard</span>
-        <!-- we dont have this title yet we will need to grab it when the new topic page is made -->
         <h1 class="govuk-heading-xl">
-            Digital leadership and governance
+            @Model.CategoryName
         </h1>
         <h2 class="govuk-heading-l">@Model.SectionName</h2>
         <p>
@@ -16,12 +15,12 @@
     </div>
     <h5 class="govuk-!-margin-bottom-4">Recommendations</h5>
     <ul class="govuk-task-list">
-        @foreach (var headerWithContent in Model.AllContent)
+        @foreach (var chunk in Model.Chunks)
         {
             <li class="govuk-task-list__item govuk-task-list__item--with-link">
                 <div class="govuk-task-list__name-and-hint custom-height">
                     <p class="govuk-!-margin-bottom-0">
-                        @headerWithContent.HeaderText
+                        @chunk.Header
                     </p>
                 </div>
             </li>
@@ -29,20 +28,20 @@
     </ul>
 
     <h2 class="govuk-heading-l">Recommendations</h2>
-    foreach (var headerWithContent in Model.AllContent)
+    foreach (var chunk in Model.Chunks)
     {
         <div class="recommendation-action-header">
             <div class="recommendation-piece-header">
-                <h1 class="govuk-heading-m">@headerWithContent.HeaderText</h1>
+                <h1 class="govuk-heading-m">@chunk.Header</h1>
             </div>
         </div>
         <div class="recommendation-action-content govuk-!-margin-bottom-4">
-            @foreach (var content in headerWithContent.Content)
+            @foreach (var content in chunk.Content)
             {
                 await Html.RenderPartialAsync("Components/PageComponentFactory", content);
                 <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
             }
-            @{ ViewData["RecommendationsActionsHeader"] = headerWithContent.SlugifiedLinkText; }
+            @{ ViewData["RecommendationsActionsHeader"] = chunk.SlugifiedLinkText; }
         </div>
     }
 }   

--- a/src/Dfe.PlanTech.Web/Views/Recommendations/Recommendations.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/Recommendations.cshtml
@@ -25,7 +25,7 @@ and the headers & chunks to have a shared parent for displaying based on anchor 
 }
     <div class="recommendation-content">
             @{
-                var allContent = Model.AllContent.ToArray();
+                var allContent = Model.Chunks.ToArray();
             } 
 
             @for (var x = 0; x < allContent.Length; x++)

--- a/src/Dfe.PlanTech.Web/Views/Recommendations/SingleRecommendation.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/SingleRecommendation.cshtml
@@ -5,11 +5,10 @@
     Layout = "_RecommendationsLayout";
 }
 
-@* placeholder link text until we have the category name *@
 @section BeforeContent {
     <govuk-back-link id="nonjs-back-button-link" href="@UrlConstants.HomePage" class="noprint non-js-only govuk-back-link">Home</govuk-back-link>
     <govuk-back-link id="back-button-link" href="@Model.CategorySlug" class="noprint js-only">
-        Back to digital leadership and governances
+        Back to @Model.CategoryName.ToLower()
     </govuk-back-link>
 }
 
@@ -20,7 +19,7 @@
 @{
     var recommendation = Model.CurrentChunk;
     var categorySlug = Model.CategorySlug;
-    var sectionSlug = Model.Section.InterstitialPage.Slug;
+    var sectionSlug = Model.Section.InterstitialPage?.Slug;
 
     <div class="recommendation-content">
         <div class="recommendation-piece-container" id="@recommendation.SlugifiedLinkText">
@@ -32,7 +31,7 @@
                         <a href="/@sectionSlug/change-answers">View or update your self-assessment for @Model.Section.Name.ToLower()</a>
                     </p>
                     <p class="govuk-body-s">
-                        <a class="govuk-link" href="@Model.Section.InterstitialPage.Slug/print">Print all recommendations for @Model.Section.Name.ToLower()</a>
+                        <a class="govuk-link" href="print">Print all recommendations for @Model.Section.Name.ToLower()</a>
                     </p>
                 </div>
                 <div class="govuk-grid-column-two-thirds">

--- a/src/Dfe.PlanTech.Web/Views/Recommendations/SingleRecommendation.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/SingleRecommendation.cshtml
@@ -1,0 +1,75 @@
+﻿@using Dfe.PlanTech.Application.Constants
+@model Dfe.PlanTech.Web.Models.SingleRecommendationViewModel
+
+@{
+    Layout = "_RecommendationsLayout";
+}
+
+@* placeholder link text until we have the category name *@
+@section BeforeContent {
+    <govuk-back-link id="nonjs-back-button-link" href="@UrlConstants.HomePage" class="noprint non-js-only govuk-back-link">Home</govuk-back-link>
+    <govuk-back-link id="back-button-link" href="@Model.CategorySlug" class="noprint js-only">
+        Back to digital leadership and governances
+    </govuk-back-link>
+}
+
+@section Header {
+    <link rel="stylesheet" as="style" href="~/css/step-by-step.css">
+}
+
+@{
+    var recommendation = Model.CurrentChunk;
+    var categorySlug = Model.CategorySlug;
+    var sectionSlug = Model.Section.InterstitialPage.Slug;
+
+    <div class="recommendation-content">
+        <div class="recommendation-piece-container" id="@recommendation.SlugifiedLinkText">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-one-third govuk-float-right">
+                    <hr class="govuk-section-break govuk-section-break--visible govuk-section-break govuk-section-break--visible custom-hr-blue">
+                    <h2 class="govuk-heading-m govuk-!-padding-top-4">Related actions</h2>
+                    <p class="govuk-body-s">
+                        <a href="/@sectionSlug/change-answers">View or update your self-assessment for @Model.Section.Name.ToLower()</a>
+                    </p>
+                    <p class="govuk-body-s">
+                        <a class="govuk-link" href="@Model.Section.InterstitialPage.Slug/print">Print all recommendations for @Model.Section.Name.ToLower()</a>
+                    </p>
+                </div>
+                <div class="govuk-grid-column-two-thirds">
+                    <div class="recommendation-piece-content">
+                        <span class="govuk-caption-xl">Recommendation @Model.CurrentChunkPosition of @Model.TotalChunks</span>
+                        <h1 class="govuk-heading-xl">@recommendation.Header</h1>
+
+                        @foreach (var content in recommendation.Content)
+                        {
+                            <partial name="Components/PageComponentFactory" model="@content" />
+                        }
+                    </div>
+
+                    @if (recommendation.CSLink != null)
+                    {
+                        <div class="govuk-!-margin-top-3 govuk-!-margin-bottom-9">
+                            <a class="govuk-body govuk-link govuk-!-font-weight-bold" href=@recommendation.CSLink.Url>@recommendation.CSLink.LinkText</a>
+                        </div>
+                    }
+
+                    <div>
+                        <govuk-pagination>
+                            @if (Model.PreviousChunk != null)
+                            {
+                                <govuk-pagination-previous href="/@categorySlug/@sectionSlug/@Model.PreviousChunk.SlugifiedLinkText" label-text="@Model.PreviousChunk.LinkText"
+                                                           class="govuk-link--no-visited-state" />
+                            }
+
+                            @if (Model.NextChunk != null)
+                            {
+                                <govuk-pagination-next href="/@categorySlug/@sectionSlug/@Model.NextChunk.SlugifiedLinkText" label-text="@Model.NextChunk.LinkText"
+                                                       class="govuk-link--no-visited-state" />
+                            }
+                        </govuk-pagination>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+}

--- a/src/Dfe.PlanTech.Web/Views/Recommendations/SingleRecommendation.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/SingleRecommendation.cshtml
@@ -28,7 +28,7 @@
                     <hr class="govuk-section-break govuk-section-break--visible govuk-section-break govuk-section-break--visible custom-hr-blue">
                     <h2 class="govuk-heading-m govuk-!-padding-top-4">Related actions</h2>
                     <p class="govuk-body-s">
-                        <a href="/@sectionSlug/change-answers">View or update your self-assessment for @Model.Section.Name.ToLower()</a>
+                        <a href="/@categorySlug/@sectionSlug/change-answers">View or update your self-assessment for @Model.Section.Name.ToLower()</a>
                     </p>
                     <p class="govuk-body-s">
                         <a class="govuk-link" href="print">Print all recommendations for @Model.Section.Name.ToLower()</a>
@@ -56,14 +56,12 @@
                         <govuk-pagination>
                             @if (Model.PreviousChunk != null)
                             {
-                                <govuk-pagination-previous href="/@categorySlug/@sectionSlug/@Model.PreviousChunk.SlugifiedLinkText" label-text="@Model.PreviousChunk.LinkText"
-                                                           class="govuk-link--no-visited-state" />
+                                <govuk-pagination-previous href="/@categorySlug/@sectionSlug/recommendations/@Model.PreviousChunk.SlugifiedLinkText" label-text="@Model.PreviousChunk.LinkText" class="govuk-link--no-visited-state" />
                             }
 
                             @if (Model.NextChunk != null)
                             {
-                                <govuk-pagination-next href="/@categorySlug/@sectionSlug/@Model.NextChunk.SlugifiedLinkText" label-text="@Model.NextChunk.LinkText"
-                                                       class="govuk-link--no-visited-state" />
+                                <govuk-pagination-next href="/@categorySlug/@sectionSlug/recommendations/@Model.NextChunk.SlugifiedLinkText" label-text="@Model.NextChunk.LinkText" class="govuk-link--no-visited-state" />
                             }
                         </govuk-pagination>
                     </div>

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/ButtonWithEntryReference.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/ButtonWithEntryReference.cshtml
@@ -7,6 +7,8 @@
 @{
     var sectionSlug = Context.GetRouteData().Values.First(value => value.Key == "sectionSlug" || value.Key == "route").Value
     as string;
+    var categorySlug = Context.GetRouteData().Values.First(value => value.Key == "categorySlug" || value.Key == "route").Value
+    as string;
 }
 
 @{
@@ -25,8 +27,7 @@
             }
         case Question _:
             {
-                <govuk-button-link asp-controller="Questions" asp-action="GetNextUnansweredQuestion" asp-route-sectionSlug=@sectionSlug
-                    class="govuk-link">
+                <govuk-button-link asp-controller="Questions" asp-action="GetNextUnansweredQuestion" asp-route-sectionSlug=@sectionSlug asp-route-categorySlug=@categorySlug class="govuk-link">
                     @Model.Button.Value
                 </govuk-button-link>
                 break;

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/CategoryLanding/Default.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/CategoryLanding/Default.cshtml
@@ -28,7 +28,7 @@
 
             foreach (var topic in Model.CategoryLandingSections)
             {
-                <partial name="Components/CategoryLanding/SectionAssessmentLink" model='new StatusLinkViewModel { Section = topic, Context = "Default" }' />
+                <partial name="Components/CategoryLanding/SectionAssessmentLink" model='new StatusLinkViewModel { CategorySlug = @Model.CategorySlug, Section = topic, Context = "Default" }' />
             }
         }
     }

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/CategoryLanding/SectionAssessmentLink.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/CategoryLanding/SectionAssessmentLink.cshtml
@@ -6,8 +6,6 @@
     string linkText;
     string? controller = null;
     string? action = null;
-    Dictionary<string, string>
-    ? routeValues = null;
 
     var topic = Model.Section;
     var topicName = topic.Name.ToLower().Trim();

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/CategoryLanding/SectionAssessmentLink.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/CategoryLanding/SectionAssessmentLink.cshtml
@@ -12,6 +12,7 @@
     var topic = Model.Section;
     var topicName = topic.Name.ToLower().Trim();
     var topicSlug = topic.Slug ?? string.Empty;
+    var categorySlug = Model.CategorySlug;
 
     switch (topic.ProgressStatus)
     {
@@ -20,42 +21,31 @@
             linkText = $"Continue your self-assessment for {topicName}";
             controller = "Questions";
             action = "GetNextUnansweredQuestion";
-            routeValues = new Dictionary<string, string>
-            {
-                ["sectionSlug"] = $"{topicSlug}"
-            };
                 break;
         case SectionProgressStatus.Completed:
             statusText = $"The self-assessment for {topicName} was completed on {topic.LastCompletionDate}.";
             linkText = $"View or update your self-assessment for {topicName}";
             controller = "ChangeAnswers";
             action = "ChangeAnswersPage";
-            routeValues = new Dictionary<string, string>
-            {
-                ["sectionSlug"] = $"{topicSlug}"
-            };
                 break;
         default:
             statusText = "";
             linkText = $"Go to self-assessment for {topicName}";
-            controller = "Pages";
-            action = "GetByRoute";
-            routeValues = new Dictionary<string, string>
-            {
-                ["route"] = $"{topicSlug}"
-            };
+            controller = "Questions";
+            action = "GetInterstitialPage";
                 break;
     }
 
     if (Model.Context == "Sections")
     {
+
         if (topic.ProgressStatus == SectionProgressStatus.Completed)
         {
             <p>
                 @statusText
             </p>
             <p>
-                <a asp-controller="@controller" asp-action="@action" asp-all-route-data="@routeValues"
+                <a asp-controller="@controller" asp-action="@action" asp-route-categorySlug="@categorySlug" asp-route-sectionSlug="@topicSlug"
                     class="govuk-link">@linkText</a> at any time.
             </p>
         }
@@ -63,14 +53,14 @@
         {
             <p>
                 @statusText
-                <a asp-controller="@controller" asp-action="@action" asp-all-route-data="@routeValues"
+                <a asp-controller="@controller" asp-action="@action" asp-route-categorySlug="@categorySlug" asp-route-sectionSlug="@topicSlug"
                    class="govuk-link">@linkText</a>
             </p>
         }
         else
         {
             <p>
-                <a asp-controller="@controller" asp-action="@action" asp-all-route-data="@routeValues"
+                <a asp-controller="@controller" asp-action="@action" asp-route-categorySlug="@categorySlug" asp-route-sectionSlug="@topicSlug"
                    class="govuk-link">@linkText</a>
             </p>
         }
@@ -80,8 +70,8 @@
         if (topic.ProgressStatus != SectionProgressStatus.Completed)
         {
             <p>
-                <a asp-controller="@controller" asp-action="@action" asp-all-route-data="@routeValues"
-                    class="govuk-link">@linkText</a>
+                <a asp-controller="@controller" asp-action="@action" asp-route-categorySlug="@categorySlug" asp-route-sectionSlug="@topicSlug"
+                   class="govuk-link">@linkText</a>
             </p>
         }
     }

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/CategoryLanding/Sections.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/CategoryLanding/Sections.cshtml
@@ -26,7 +26,7 @@
                         <a href=@Url.RouteUrl("GetSingleRecommendation", new {
                             categorySlug = Model.CategorySlug,
                             sectionSlug = topic.Slug,
-                            recommendationSlug = chunk.SlugifiedLinkText
+                            chunkSlug = chunk.SlugifiedLinkText
                         }) class="govuk-link">@chunk.LinkText</a>
                     </div>
                 </li>

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/CategoryLanding/Sections.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/CategoryLanding/Sections.cshtml
@@ -17,9 +17,17 @@
             </li>
             @foreach (var chunk in topic.Recommendations.Chunks)
             {
+                var routeValues = new Dictionary<string, string>
+                {
+                    ["route"] = $"{Model.CategorySlug}/{topic.Slug}/{chunk.SlugifiedLinkText}"
+                };
                 <li class="govuk-task-list__item govuk-task-list__item--with-link">
                     <div class="govuk-task-list__name-and-hint landing-page-list__name-and-hint">
-                        <a class="govuk-link govuk-task-list__link" href="/@Model.CategorySlug/@topic.Slug/@chunk.SlugifiedLinkText">@chunk.LinkText</a>
+                        <a href=@Url.RouteUrl("GetSingleRecommendation", new {
+                            categorySlug = Model.CategorySlug,
+                            sectionSlug = topic.Slug,
+                            recommendationSlug = chunk.SlugifiedLinkText
+                        }) class="govuk-link">@chunk.LinkText</a>
                     </div>
                 </li>
             }

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/CategoryLanding/Sections.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/CategoryLanding/Sections.cshtml
@@ -5,7 +5,7 @@
     <h2 class="govuk-heading-l">@topic.Name</h2>
     <p>@topic.ShortDescription</p>
 
-    <partial name="Components/CategoryLanding/SectionAssessmentLink" model='new StatusLinkViewModel { Section = topic, Context = "Sections" }' />
+    <partial name="Components/CategoryLanding/SectionAssessmentLink" model='new StatusLinkViewModel { CategorySlug = Model.CategorySlug, Section = topic, Context = "Sections" }' />
 
     @if (!string.IsNullOrEmpty(topic.LastCompletionDate))
     {
@@ -17,10 +17,10 @@
             </li>
             @foreach (var chunk in topic.Recommendations.Chunks)
             {
-                var routeValues = new Dictionary<string, string>
+                @* var routeValues = new Dictionary<string, string>
                 {
                     ["route"] = $"{Model.CategorySlug}/{topic.Slug}/{chunk.SlugifiedLinkText}"
-                };
+                }; *@
                 <li class="govuk-task-list__item govuk-task-list__item--with-link">
                     <div class="govuk-task-list__name-and-hint landing-page-list__name-and-hint">
                         <a href=@Url.RouteUrl("GetSingleRecommendation", new {

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/ChangeAnswersControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/ChangeAnswersControllerTests.cs
@@ -17,11 +17,10 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
         private readonly ChangeAnswersController _controller;
         private readonly IChangeAnswersRouter _changeAnswersRouter;
         private readonly IUserJourneyMissingContentExceptionHandler _exceptionHandler;
-        private readonly IGetRecommendationRouter _recommendationRouter;
         private readonly IUser _user;
 
+        private readonly string _categorySlug = "test-category";
         private readonly string _sectionSlug = "test-section";
-        private readonly string _recommendationSlug = "rec-123";
 
         public ChangeAnswersControllerTests()
         {
@@ -34,29 +33,42 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
 
             _changeAnswersRouter = Substitute.For<IChangeAnswersRouter>();
             _exceptionHandler = Substitute.For<IUserJourneyMissingContentExceptionHandler>();
-            _recommendationRouter = Substitute.For<IGetRecommendationRouter>();
         }
 
         [Fact]
         public async Task ChangeAnswersPage_Should_Throw_ArgumentNullException_When_SectionSlug_IsNull()
         {
             await Assert.ThrowsAsync<ArgumentNullException>(() =>
-                _controller.ChangeAnswersPage(null!, _changeAnswersRouter, _exceptionHandler));
+                _controller.ChangeAnswersPage(_categorySlug, null!, _changeAnswersRouter, _exceptionHandler));
         }
 
         [Fact]
         public async Task ChangeAnswersPage_Should_Throw_ArgumentException_When_SectionSlug_IsEmpty()
         {
             await Assert.ThrowsAsync<ArgumentException>(() =>
-                _controller.ChangeAnswersPage("", _changeAnswersRouter, _exceptionHandler));
+                _controller.ChangeAnswersPage(_categorySlug, "", _changeAnswersRouter, _exceptionHandler));
+        }
+
+        [Fact]
+        public async Task ChangeAnswersPage_Should_Throw_ArgumentNullException_When_CategorySlug_IsNull()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                _controller.ChangeAnswersPage(null!, _sectionSlug, _changeAnswersRouter, _exceptionHandler));
+        }
+
+        [Fact]
+        public async Task ChangeAnswersPage_Should_Throw_ArgumentException_When_CategorySlug_IsEmpty()
+        {
+            await Assert.ThrowsAsync<ArgumentException>(() =>
+                _controller.ChangeAnswersPage("", _sectionSlug, _changeAnswersRouter, _exceptionHandler));
         }
 
         [Fact]
         public async Task ChangeAnswersPage_Should_Call_ValidateRoute_With_Correct_Parameters()
         {
-            var result = await _controller.ChangeAnswersPage(_sectionSlug, _changeAnswersRouter, _exceptionHandler);
+            var result = await _controller.ChangeAnswersPage(_categorySlug, _sectionSlug, _changeAnswersRouter, _exceptionHandler);
 
-            await _changeAnswersRouter.Received().ValidateRoute(_sectionSlug, null, _controller, Arg.Any<CancellationToken>());
+            await _changeAnswersRouter.Received().ValidateRoute(_categorySlug, _sectionSlug, null, _controller, Arg.Any<CancellationToken>());
         }
 
         [Fact]
@@ -64,27 +76,23 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
         {
             var exception = new UserJourneyMissingContentException("fail", Substitute.For<ISectionComponent>());
 
-            _changeAnswersRouter.ValidateRoute(Arg.Any<string>(), Arg.Any<string>(), _controller, Arg.Any<CancellationToken>())
+            _changeAnswersRouter.ValidateRoute(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), _controller, Arg.Any<CancellationToken>())
                 .Throws(exception);
 
-            await _controller.ChangeAnswersPage(_sectionSlug, _changeAnswersRouter, _exceptionHandler);
+            await _controller.ChangeAnswersPage(_categorySlug, _sectionSlug, _changeAnswersRouter, _exceptionHandler);
 
             await _exceptionHandler.Received().Handle(_controller, exception, Arg.Any<CancellationToken>());
         }
 
         [Fact]
-        public async Task RedirectToRecommendation_Should_Redirect_To_Expected_Route()
+        public void RedirectToRecommendation_Should_Redirect_To_Expected_Route()
         {
-            _recommendationRouter.GetRecommendationSlugForSection(_sectionSlug, Arg.Any<CancellationToken>())
-                                 .Returns(_recommendationSlug);
-
-            var result = await _controller.RedirectToRecommendation(_sectionSlug, _recommendationRouter);
+            var result = _controller.RedirectToCategoryLandingPage(_categorySlug);
 
             var redirect = Assert.IsType<RedirectToActionResult>(result);
-            Assert.Equal(RecommendationsController.ControllerName, redirect.ControllerName);
-            Assert.Equal(RecommendationsController.GetRecommendationAction, redirect.ActionName);
-            Assert.Equal(_sectionSlug, redirect.RouteValues?["sectionSlug"]);
-            Assert.Equal(_recommendationSlug, redirect.RouteValues?["recommendationSlug"]);
+            Assert.Equal(PagesController.ControllerName, redirect.ControllerName);
+            Assert.Equal(PagesController.GetPageByRouteAction, redirect.ActionName);
+            Assert.Equal(_categorySlug, redirect.RouteValues?["categorySlug"]);
         }
     }
 }

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/ChangeAnswersControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/ChangeAnswersControllerTests.cs
@@ -92,7 +92,7 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
             var redirect = Assert.IsType<RedirectToActionResult>(result);
             Assert.Equal(PagesController.ControllerName, redirect.ControllerName);
             Assert.Equal(PagesController.GetPageByRouteAction, redirect.ActionName);
-            Assert.Equal(_categorySlug, redirect.RouteValues?["categorySlug"]);
+            Assert.Equal(_categorySlug, redirect.RouteValues?["route"]);
         }
     }
 }

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/GroupsControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/GroupsControllerTests.cs
@@ -22,10 +22,6 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
         private readonly IUser _user;
         private readonly IGetGroupSelectionQuery _getGroupSelectionQuery;
         private readonly IGetPageQuery _getPageQuery;
-        private readonly IGetSectionQuery _getSectionQuery;
-        private readonly IGetSubTopicRecommendationQuery _getSubTopicRecommendationQuery;
-        private readonly IOptions<ContactOptions> _contactOptions;
-        private readonly IGetNavigationQuery _getNavigationQuery;
 
         private readonly GroupsController _controller;
 
@@ -35,8 +31,6 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
             _user = Substitute.For<IUser>();
             _getGroupSelectionQuery = Substitute.For<IGetGroupSelectionQuery>();
             _getPageQuery = Substitute.For<IGetPageQuery>();
-            _getSectionQuery = Substitute.For<IGetSectionQuery>();
-            _getSubTopicRecommendationQuery = Substitute.For<IGetSubTopicRecommendationQuery>();
 
             _controller = new GroupsController(
                 logger,

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/PagesControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/PagesControllerTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Security.Claims;
 using System.Text.Json;
 using Dfe.PlanTech.Application.Exceptions;
@@ -8,7 +7,6 @@ using Dfe.PlanTech.Domain.Cookie;
 using Dfe.PlanTech.Domain.Cookie.Interfaces;
 using Dfe.PlanTech.Domain.Establishments.Models;
 using Dfe.PlanTech.Domain.Questionnaire.Models;
-using Dfe.PlanTech.Domain.Submissions.Models;
 using Dfe.PlanTech.Domain.Users.Interfaces;
 using Dfe.PlanTech.Web.Configuration;
 using Dfe.PlanTech.Web.Controllers;
@@ -142,7 +140,7 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers
         }
 
         [Fact]
-        public async Task ShouldThrowException_WhenIsLandingPage_And_CategoryIsNull()
+        public void ShouldThrowException_WhenIsLandingPage_And_CategoryIsNull()
         {
             var action = () => _controller.GetByRoute(null, userSubstitute);
 

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/QuestionsControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/QuestionsControllerTests.cs
@@ -159,9 +159,10 @@ public class QuestionsControllerTests
         _getQuestionBySlugRouter.ValidateRoute(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<QuestionsController>(), Arg.Any<CancellationToken>())
                                 .Returns((callinfo) =>
                                 {
-                                    sectionSlug = callinfo.ArgAt<string>(0);
-                                    questionSlug = callinfo.ArgAt<string>(1);
-                                    controller = callinfo.ArgAt<QuestionsController>(2);
+                                    categorySlug = callinfo.ArgAt<string>(0);
+                                    sectionSlug = callinfo.ArgAt<string>(1);
+                                    questionSlug = callinfo.ArgAt<string>(2);
+                                    controller = callinfo.ArgAt<QuestionsController>(3);
 
                                     return new AcceptedResult();
                                 });

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/RecommendationsControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/RecommendationsControllerTests.cs
@@ -26,9 +26,17 @@ public class RecommendationsControllerTests
     [Theory]
     [InlineData("")]
     [InlineData(null)]
+    public async Task RecommendationsPagePage_Should_ThrowException_When_CategorySlug_NullOrEmpty(string? category)
+    {
+        await Assert.ThrowsAnyAsync<ArgumentNullException>(() => _recommendationsController.GetRecommendation(category!, "section-slug", "recommendation", _recommendationsRouter, default));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
     public async Task RecommendationsPagePage_Should_ThrowException_When_SectionSlug_NullOrEmpty(string? section)
     {
-        await Assert.ThrowsAnyAsync<ArgumentNullException>(() => _recommendationsController.GetRecommendation(section!, "recommendation", _recommendationsRouter, default));
+        await Assert.ThrowsAnyAsync<ArgumentNullException>(() => _recommendationsController.GetRecommendation("category-slug", section!, "recommendation", _recommendationsRouter, default));
     }
 
 
@@ -37,18 +45,19 @@ public class RecommendationsControllerTests
     [InlineData(null)]
     public async Task RecommendationsPagePage_Should_ThrowException_When_RecommendationSlug_NullOrEmpty(string? recommendation)
     {
-        await Assert.ThrowsAnyAsync<ArgumentNullException>(() => _recommendationsController.GetRecommendation("section slug", recommendation!, _recommendationsRouter, default));
+        await Assert.ThrowsAnyAsync<ArgumentNullException>(() => _recommendationsController.GetRecommendation("category-slug", "section slug", recommendation!, _recommendationsRouter, default));
     }
 
     [Fact]
     public async Task RecommendationsPagePage_Should_Call_RecommendationsRouter_When_Args_Valid()
     {
+        string categorySlug = "categorySlug";
         string sectionSlug = "section-slug";
         string recommendationSlug = "recommendation-slug";
 
-        await _recommendationsController.GetRecommendation(sectionSlug, recommendationSlug, _recommendationsRouter, default);
+        await _recommendationsController.GetRecommendation(categorySlug, sectionSlug, recommendationSlug, _recommendationsRouter, default);
 
-        await _recommendationsRouter.Received().ValidateRoute(sectionSlug, recommendationSlug, false, _recommendationsController, Arg.Any<CancellationToken>());
+        await _recommendationsRouter.Received().ValidateRoute(categorySlug, sectionSlug, false, _recommendationsController, Arg.Any<CancellationToken>());
     }
 
     [Theory]
@@ -87,11 +96,11 @@ public class RecommendationsControllerTests
     [Fact]
     public async Task RecommendationsPagePageChecklist_Should_Call_RecommendationsRouter_When_Args_Valid()
     {
+        string categorySlug = "category-slug";
         string sectionSlug = "section-slug";
-        string recommendationSlug = "recommendation-slug";
 
-        await _recommendationsController.GetRecommendationChecklist(sectionSlug, recommendationSlug, _recommendationsRouter, default);
+        await _recommendationsController.GetRecommendationChecklist(categorySlug, sectionSlug, _recommendationsRouter, default);
 
-        await _recommendationsRouter.Received().ValidateRoute(sectionSlug, recommendationSlug, true, _recommendationsController, Arg.Any<CancellationToken>());
+        await _recommendationsRouter.Received().ValidateRoute(categorySlug, sectionSlug, true, _recommendationsController, Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/RecommendationsControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/RecommendationsControllerTests.cs
@@ -1,4 +1,6 @@
+using System.Data;
 using Dfe.PlanTech.Application.Constants;
+using Dfe.PlanTech.Domain.Content.Interfaces;
 using Dfe.PlanTech.Domain.Persistence.Models;
 using Dfe.PlanTech.Web.Controllers;
 using Dfe.PlanTech.Web.Routing;
@@ -12,6 +14,7 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers;
 public class RecommendationsControllerTests
 {
     private readonly IGetRecommendationRouter _recommendationsRouter;
+    private readonly IGetPageQuery _getPageQuery;
 
     private readonly RecommendationsController _recommendationsController;
 
@@ -21,41 +24,42 @@ public class RecommendationsControllerTests
 
         var loggerSubstitute = Substitute.For<ILogger<RecommendationsController>>();
         _recommendationsController = new RecommendationsController(loggerSubstitute);
+        _getPageQuery = Substitute.For<IGetPageQuery>();
     }
 
     [Theory]
     [InlineData("")]
     [InlineData(null)]
-    public async Task RecommendationsPagePage_Should_ThrowException_When_CategorySlug_NullOrEmpty(string? category)
+    public async Task GetSingleRecommendation_Should_ThrowException_When_CategorySlug_NullOrEmpty(string? category)
     {
-        await Assert.ThrowsAnyAsync<ArgumentNullException>(() => _recommendationsController.GetRecommendation(category!, "section-slug", "recommendation", _recommendationsRouter, default));
+        await Assert.ThrowsAnyAsync<ArgumentNullException>(() => _recommendationsController.GetSingleRecommendation(category!, "section-slug", "recommendation", _recommendationsRouter, _getPageQuery, default));
     }
 
     [Theory]
     [InlineData("")]
     [InlineData(null)]
-    public async Task RecommendationsPagePage_Should_ThrowException_When_SectionSlug_NullOrEmpty(string? section)
+    public async Task GetSingleRecommendation_Should_ThrowException_When_SectionSlug_NullOrEmpty(string? section)
     {
-        await Assert.ThrowsAnyAsync<ArgumentNullException>(() => _recommendationsController.GetRecommendation("category-slug", section!, "recommendation", _recommendationsRouter, default));
+        await Assert.ThrowsAnyAsync<ArgumentNullException>(() => _recommendationsController.GetSingleRecommendation("category-slug", section!, "recommendation", _recommendationsRouter, _getPageQuery, default));
     }
 
 
     [Theory]
     [InlineData("")]
     [InlineData(null)]
-    public async Task RecommendationsPagePage_Should_ThrowException_When_RecommendationSlug_NullOrEmpty(string? recommendation)
+    public async Task GetSingleRecommendation_Should_ThrowException_When_RecommendationSlug_NullOrEmpty(string? recommendation)
     {
-        await Assert.ThrowsAnyAsync<ArgumentNullException>(() => _recommendationsController.GetRecommendation("category-slug", "section slug", recommendation!, _recommendationsRouter, default));
+        await Assert.ThrowsAnyAsync<ArgumentNullException>(() => _recommendationsController.GetSingleRecommendation("category-slug", "section slug", recommendation!, _recommendationsRouter, _getPageQuery, default));
     }
 
     [Fact]
-    public async Task RecommendationsPagePage_Should_Call_RecommendationsRouter_When_Args_Valid()
+    public async Task GetSingleRecommendation_Should_Call_RecommendationsRouter_When_Args_Valid()
     {
         string categorySlug = "categorySlug";
         string sectionSlug = "section-slug";
         string recommendationSlug = "recommendation-slug";
 
-        await _recommendationsController.GetRecommendation(categorySlug, sectionSlug, recommendationSlug, _recommendationsRouter, default);
+        await _recommendationsController.GetSingleRecommendation(categorySlug, sectionSlug, recommendationSlug, _recommendationsRouter, _getPageQuery, default);
 
         await _recommendationsRouter.Received().ValidateRoute(categorySlug, sectionSlug, false, _recommendationsController, Arg.Any<CancellationToken>());
     }

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/RecommendationsControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/RecommendationsControllerTests.cs
@@ -94,30 +94,4 @@ public class RecommendationsControllerTests
 
         await _recommendationsRouter.Received().ValidateRoute(sectionSlug, recommendationSlug, true, _recommendationsController, Arg.Any<CancellationToken>());
     }
-
-    [Theory]
-    [InlineData("")]
-    [InlineData(null)]
-    public async Task FromSection_Should_ThrowException_When_SectionSlug_NullOrEmpty(string? sectionSlug)
-    {
-        await Assert.ThrowsAnyAsync<ArgumentNullException>(() =>
-            _recommendationsController.FromSection(sectionSlug!, _recommendationsRouter, CancellationToken.None));
-    }
-
-    [Fact]
-    public async Task FromSection_Should_Call_GetRecommendationSlugForSection_And_Redirect()
-    {
-        var sectionSlug = "section-slug";
-        var recommendationSlug = "recommendation-slug";
-
-        _recommendationsRouter.GetRecommendationSlugForSection(sectionSlug, Arg.Any<CancellationToken>())
-                              .Returns(recommendationSlug);
-
-        var result = await _recommendationsController.FromSection(sectionSlug, _recommendationsRouter, CancellationToken.None);
-
-        var redirect = Assert.IsType<RedirectToActionResult>(result);
-        Assert.Equal(RecommendationsController.GetRecommendationAction, redirect.ActionName);
-        Assert.Null(redirect.ControllerName);
-        Assert.Equal(recommendationSlug, redirect.RouteValues?["recommendationSlug"]);
-    }
 }

--- a/tests/Dfe.PlanTech.Web.UnitTests/Models/ComponentBuilder.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Models/ComponentBuilder.cs
@@ -68,12 +68,9 @@ namespace Dfe.PlanTech.Web.UnitTests.Models
         public static RecommendationsViewModel BuildRecommendationViewModel(List<QuestionWithAnswer>? submission = null)
         => new()
         {
-            Intro = BuildRecommendationIntro("intro"),
             Chunks = [BuildRecommendationChunk("First", "Title one"), BuildRecommendationChunk("Second", "Title two"), BuildRecommendationChunk("Third", "Title three")],
             SubmissionResponses = submission ?? BuildSubmissionResponses()
         };
-
-        public static RecommendationIntro BuildRecommendationIntro(string header) => new() { Header = new Header() { Text = header } };
 
         public static RecommendationChunk BuildRecommendationChunk(string header, string title = "Title") => new() { Header = header };
 

--- a/tests/Dfe.PlanTech.Web.UnitTests/Models/ComponentModelTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Models/ComponentModelTests.cs
@@ -94,28 +94,6 @@ character
         }
 
         [Theory]
-        [InlineData("Random test Topic")]
-        [InlineData("Y867as ()&ycj Cool Thing")]
-        public void RecommendationIntro_Should_Return_Correct_Header_And_Title(string header)
-        {
-            var recommendationIntro = ComponentBuilder.BuildRecommendationIntro(header);
-
-            Assert.Equal(header, recommendationIntro.Header.Text);
-            Assert.Equal(header, recommendationIntro.HeaderText);
-        }
-
-        [Theory]
-        [InlineData("Random test Topic", "overview")]
-        [InlineData("Pasdw!345      dsdoiu()=2 Yo ", "overview")]
-        public void RecommendationIntro_Should_Return_Correct_LinkText(string header, string expectedResult)
-        {
-            var recommendationIntro = ComponentBuilder.BuildRecommendationIntro(header);
-
-            Assert.Equal("Overview", recommendationIntro.LinkText);
-            Assert.Equal(expectedResult, recommendationIntro.SlugifiedLinkText);
-        }
-
-        [Theory]
         [InlineData("Random test Topic", "random-test-topic")]
         [InlineData("Y867as ()&ycj Cool Thing", "y867as-ycj-cool-thing")]
         public void RecommendationChunk_Should_Return_Correct_Header_Title_And_LinkText(string header, string expectedResult)
@@ -125,21 +103,6 @@ character
             Assert.Equal(header, recommendationChunk.HeaderText);
             Assert.Equal(header, recommendationChunk.LinkText);
             Assert.Equal(expectedResult, recommendationChunk.SlugifiedLinkText);
-        }
-
-        [Fact]
-        public void RecommendationViewModel_Should_Return_All_Content()
-        {
-            var recommendationViewModel = ComponentBuilder.BuildRecommendationViewModel();
-
-            var allContent = recommendationViewModel.AllContent.ToList();
-
-            Assert.Contains(recommendationViewModel.Intro, allContent);
-
-            foreach (var chunk in recommendationViewModel.Chunks)
-            {
-                Assert.Contains(chunk, allContent);
-            }
         }
 
         [Fact]

--- a/tests/Dfe.PlanTech.Web.UnitTests/Routing/CheckAnswersRouterTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Routing/CheckAnswersRouterTests.cs
@@ -104,45 +104,6 @@ public class CheckAnswersRouterTests
     }
 
     [Fact]
-    public async Task Should_Redirect_To_NextQuestion_When_Status_InProgresss()
-    {
-        var categorySlug = "category-slug";
-        var sectionSlug = "section-slug";
-
-        var nextQuestion = new Question()
-        {
-            Slug = "next-question"
-        };
-
-        _submissionStatusProcessor.When(processor => processor.GetJourneyStatusForSection(sectionSlug, cancellationToken: Arg.Any<CancellationToken>()))
-        .Do(callInfo =>
-        {
-            _submissionStatusProcessor.Status = Status.InProgress;
-            _submissionStatusProcessor.NextQuestion = nextQuestion;
-        });
-
-        var result = await _router.ValidateRoute(categorySlug, sectionSlug, null, _controller, default);
-
-        var redirectResult = result as RedirectToActionResult;
-
-        Assert.NotNull(redirectResult);
-        Assert.Equal(QuestionsController.Controller, redirectResult.ControllerName);
-        Assert.Equal(QuestionsController.GetQuestionBySlugActionName, redirectResult.ActionName);
-
-        var categorySlugValue = redirectResult.RouteValues?["categorySlug"];
-        Assert.NotNull(categorySlugValue);
-        Assert.Equal(categorySlug, categorySlugValue);
-
-        var sectionSlugValue = redirectResult.RouteValues?["sectionSlug"];
-        Assert.NotNull(sectionSlugValue);
-        Assert.Equal(sectionSlug, sectionSlugValue);
-
-        var questionSlugValue = redirectResult.RouteValues?["questionSlug"];
-        Assert.NotNull(questionSlugValue);
-        Assert.Equal(nextQuestion.Slug, questionSlugValue);
-    }
-
-    [Fact]
     public async Task Should_Return_CheckAnswersPage_When_Status_Is_CheckAnswers()
     {
         var categorySlug = "category-slug";

--- a/tests/Dfe.PlanTech.Web.UnitTests/Routing/GetQuestionBySlugRouterTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Routing/GetQuestionBySlugRouterTests.cs
@@ -217,14 +217,11 @@ public class GetQuestionBySlugRouterTests
         Assert.Equal(QuestionsController.Controller, redirectResult.ControllerName);
         Assert.Equal(QuestionsController.GetQuestionBySlugActionName, redirectResult.ActionName);
 
-        var categorySlug = redirectResult.RouteValues?["categorySlug"];
         var sectionSlug = redirectResult.RouteValues?["sectionSlug"];
         var questionSlug = redirectResult.RouteValues?["questionSlug"];
 
-        Assert.NotNull(categorySlug);
         Assert.NotNull(sectionSlug);
         Assert.NotNull(questionSlug);
-        Assert.Equal("category-slug", categorySlug);
         Assert.Equal(_section.InterstitialPage.Slug, sectionSlug);
         Assert.Equal(secondQuestion.Slug, questionSlug);
     }

--- a/tests/Dfe.PlanTech.Web.UnitTests/Routing/GetRecommendationRouterTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Routing/GetRecommendationRouterTests.cs
@@ -306,13 +306,10 @@ public class GetRecommendationRouterTests
         Assert.Equal(QuestionsController.GetQuestionBySlugActionName, redirectResult.ActionName);
 
         var section = redirectResult.RouteValues?["sectionSlug"];
-        var category = redirectResult.RouteValues?["categorySlug"];
 
-        Assert.NotNull(category);
         Assert.NotNull(section);
         Assert.NotNull(_section.InterstitialPage);
         Assert.Equal(_section.InterstitialPage.Slug, section);
-        Assert.Equal("category-slug", category);
 
         var questionSlug = redirectResult.RouteValues?["questionSlug"];
 
@@ -430,9 +427,23 @@ public class GetRecommendationRouterTests
     [Fact]
     public async Task Should_Show_RecommendationPage_When_Status_Is_Recommendation_And_All_Valid()
     {
+        var categoryLandingPage = new Page()
+        {
+            Slug = "test-category",
+            Content = new List<ContentComponent>()
+            {
+                new Category()
+                {
+                    Header = new Header(){ Text = "Test category" }
+                }
+            }
+        };
+
+        _getPageQuery.GetPageBySlug(categoryLandingPage.Slug).Returns(categoryLandingPage);
+
         Assert.NotNull(_section.InterstitialPage);
         Setup_Valid_Recommendation();
-        var result = await _router.ValidateRoute("category-slug", _section.InterstitialPage.Slug, false, _controller, default);
+        var result = await _router.ValidateRoute("test-category", _section.InterstitialPage.Slug, false, _controller, default);
 
         var viewResult = result as ViewResult;
 
@@ -487,7 +498,21 @@ public class GetRecommendationRouterTests
 
         Setup_Valid_Recommendation(responses);
 
-        var result = await _router.ValidateRoute("category-slug", _section.InterstitialPage.Slug, true, _controller, default);
+        var categoryLandingPage = new Page()
+        {
+            Slug = "test-category",
+            Content = new List<ContentComponent>()
+            {
+                new Category()
+                {
+                    Header = new Header(){ Text = "Test category" }
+                }
+            }
+        };
+
+        _getPageQuery.GetPageBySlug(categoryLandingPage.Slug).Returns(categoryLandingPage);
+
+        var result = await _router.ValidateRoute("test-category", _section.InterstitialPage.Slug, true, _controller, default);
 
         var viewResult = result as ViewResult;
 


### PR DESCRIPTION
## Overview

Addresses ticket [#257806](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/264996)

Adds a category slug (for categories aligned to standards) as a prefix to existing routes across the service and moves recommendations to a single-recommendation route to support the page-per-recommendation approach

The design for the ticket is based on [this iteration of the prototype](https://plantech.herokuapp.com/sprint17/landing).

## Changes

### Major

- Adds categorySlug at start of all routes related to self-assessment and recommendations
- Moves recommendations to individual routes and adds GET method

### Minor

- Updates page redirector
- Removes redundant method for retrieving recommendations
- Removes redundant method for routing back from change-answers

### Non-functional changes (e.g. documentation)

- Updated/added/removed unit tests

## How to review the PR

Contentful changes need to be in place to make routes work (this is done on Dev so far)
Start from Category Landing pages - manually navigate to digital-leadership-governance and filtering-and-monitoring to access assessments in different states to check routing for interstitial, question, check answers and change answers flows.
Check links from inset text on landing page, topic sections on landing page and from navigation pane on single recommendation page

## Release requirements

Contentful updates as detailed on previous (Category Landing page) PR, full details will be put on PR for feature branch to Dev

## Additional notes

Routes vary slightly from those specified in the spreadsheet linked on the ticket - discussed with PM and agreed to nest recommendations within /recommendations to avoid route conflicts. Still need agreement on approach to single-topic standards (eg wireless-network/wireless-network) - my suggestion is to fix this conflict with a content approach (ie make the slugs unique)

## Checklist

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] PR targets development branch
- [x] Unit tests have been added/updated