### PR TITLE
story(272939): single topic landing page

### DIFF
--- a/src/Dfe.PlanTech.Web/Views/Questions/Question.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Questions/Question.cshtml
@@ -7,8 +7,8 @@
     }
 }
 
-<form asp-controller="Questions" asp-action="SubmitAnswer" asp-route-categorySlug=@Model.CategorySlug asp-route-sectionSlug=@Model.SectionSlug
-      asp-route-questionSlug=@Model.Question.Slug method="post">
+<form asp-controller="Questions" asp-action="SubmitAnswer" asp-route-categorySlug="@Model.CategorySlug" asp-route-sectionSlug="@Model.SectionSlug"
+      asp-route-questionSlug="@Model.Question.Slug" method="post">
     <input id="QuestionText" type="hidden" value="@Model.Question.Text" name="QuestionText"/>
     <input id="QuestionId" type="hidden" value=@Model.Question.Sys.Id name="QuestionId"/>
     <input id="SectionId" type="hidden" value="@Model.SectionId" name="SectionId"/>

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/ButtonWithEntryReference.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/ButtonWithEntryReference.cshtml
@@ -27,7 +27,7 @@
             }
         case Question _:
             {
-                <govuk-button-link asp-controller="Questions" asp-action="GetNextUnansweredQuestion" asp-route-sectionSlug=@sectionSlug asp-route-categorySlug=@categorySlug class="govuk-link">
+                <govuk-button-link asp-controller="Questions" asp-action="GetNextUnansweredQuestion" asp-route-sectionSlug="@sectionSlug" asp-route-categorySlug="@categorySlug" class="govuk-link">
                     @Model.Button.Value
                 </govuk-button-link>
                 break;

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/CategoryLanding/Default.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/CategoryLanding/Default.cshtml
@@ -24,26 +24,29 @@
     </div>
 }
 
-<div class="govuk-inset-text">
-    @{
-        if (!Model.AnySectionsCompleted)
-        {
-            <p>You have not completed any self-assessments for the @Model.CategoryName.ToLower() standard. Complete self-assessments to view all recommendations.</p>
-        }
-        else if (Model.AllSectionsCompleted)
-        {
-            <p>You have completed all self-assessments for the @Model.CategoryName.ToLower() standard.</p>
-        }
-        else
-        {
-            <p>Complete the remaining self-assessments to get recommendations for your school's @Model.CategoryName.ToLower().</p>
-
-            foreach (var topic in Model.CategoryLandingSections)
+@if (Model.CategoryLandingSections.Count != 1)
+{
+    <div class="govuk-inset-text">
+        @{
+            if (!Model.AnySectionsCompleted)
             {
-                <partial name="Components/CategoryLanding/SectionAssessmentLink" model='new StatusLinkViewModel { CategorySlug = @Model.CategorySlug, Section = topic, Context = "Default" }' />
+                <p>You have not completed any self-assessments for the @Model.CategoryName.ToLower() standard. Complete self-assessments to view all recommendations.</p>
+            }
+            else if (Model.AllSectionsCompleted)
+            {
+                <p>You have completed all self-assessments for the @Model.CategoryName.ToLower() standard.</p>
+            }
+            else
+            {
+                <p>Complete the remaining self-assessments to get recommendations for your school's @Model.CategoryName.ToLower().</p>
+
+                foreach (var topic in Model.CategoryLandingSections)
+                {
+                    <partial name="Components/CategoryLanding/SectionAssessmentLink" model='new StatusLinkViewModel { CategorySlug = @Model.CategorySlug, Section = topic, Context = "Default" }' />
+                }
             }
         }
-    }
-</div>
+    </div>
+}
 
 <partial name="Components/CategoryLanding/Sections" model="@Model" />

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/CategoryLanding/Sections.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/CategoryLanding/Sections.cshtml
@@ -2,7 +2,10 @@
 
 @foreach (var topic in Model.CategoryLandingSections)
 {
-    <h2 class="govuk-heading-l">@topic.Name</h2>
+    if (Model.CategoryLandingSections.Count != 1)
+    { 
+        <h2 class="govuk-heading-l">@topic.Name</h2>
+    }
     <p>@topic.ShortDescription</p>
 
     <partial name="Components/CategoryLanding/SectionAssessmentLink" model='new StatusLinkViewModel { CategorySlug = Model.CategorySlug, Section = topic, Context = "Sections" }' />
@@ -17,10 +20,6 @@
             </li>
             @foreach (var chunk in topic.Recommendations.Chunks)
             {
-                @* var routeValues = new Dictionary<string, string>
-                {
-                    ["route"] = $"{Model.CategorySlug}/{topic.Slug}/{chunk.SlugifiedLinkText}"
-                }; *@
                 <li class="govuk-task-list__item govuk-task-list__item--with-link">
                     <div class="govuk-task-list__name-and-hint landing-page-list__name-and-hint">
                         <a href=@Url.RouteUrl("GetSingleRecommendation", new {


### PR DESCRIPTION
## Overview

Addresses ticket [#272939](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/272939)

Hides landing page elements for categories with only one topic

## Changes

### Minor

Adds condition to inset text and header on Category landing page to hide them when there is only one topic in the section

### Non-functional changes (e.g. documentation)

- Added quotes to attributes for consistency

## How to review the PR

Navigate to single-topic category from home (wireless network available on Dev). Display is different for different assessment states (not started/in progress/completed) so easiest to do with local db

## Release requirements

Contentful updates (completed in WIP for feature branch, no additional ones required)

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] PR targets development branch