### PR TITLE
Bug fix - duplicate beta header on MAT View

### DIFF
--- a/src/Dfe.PlanTech.Web/Views/Recommendations/SingleRecommendation.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Recommendations/SingleRecommendation.cshtml
@@ -2,10 +2,10 @@
 @model Dfe.PlanTech.Web.Models.SingleRecommendationViewModel
 
 @{
-    Layout = "_RecommendationsLayout";
+    Layout = "_SingleRecommendationLayout";
 }
 
-@section BeforeContent {  
+@section BeforeContent {
     <govuk-back-link id="nonjs-back-button-link" href="@UrlConstants.HomePage" class="noprint non-js-only govuk-back-link">Home</govuk-back-link>
     <govuk-back-link id="nonjs-back-button-link" href="@($"/{Model.CategorySlug}")" class="noprint js-only">
         Back to @Model.CategoryName.ToLower()

--- a/src/Dfe.PlanTech.Web/Views/Shared/_SingleRecommendationLayout.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/_SingleRecommendationLayout.cshtml
@@ -16,6 +16,7 @@
 }
 
 @section BeforeContent {
+    <partial name="BetaHeader" />
     <partial name="_BeforeContent" />
     @await RenderSectionAsync("BeforeContent", required: false)
 }


### PR DESCRIPTION
RecommendationsLayout has been split to SingleRecommendationsLayout. Fixes a bug where a duplicate beta header partial was being displayed at the bottom of the recommendations page on the MAT View.