### PR TITLE
fix(274402): slow loading of progress tracking content

### DIFF
--- a/src/Dfe.PlanTech.Application/Constants/UrlConstants.cs
+++ b/src/Dfe.PlanTech.Application/Constants/UrlConstants.cs
@@ -21,4 +21,6 @@ public static class UrlConstants
     public const string GroupsSelectionPageSlug = "select-a-school";
 
     public const string GroupsDashboardSlug = "dashboard";
+
+    public const string AutomatedTestingHomePage = "/self-assessment-testing";
 }

--- a/src/Dfe.PlanTech.Application/Questionnaire/Queries/GetCategoryQuery.cs
+++ b/src/Dfe.PlanTech.Application/Questionnaire/Queries/GetCategoryQuery.cs
@@ -1,0 +1,49 @@
+﻿using Dfe.PlanTech.Application.Core;
+using Dfe.PlanTech.Application.Exceptions;
+using Dfe.PlanTech.Application.Persistence.Interfaces;
+using Dfe.PlanTech.Application.Persistence.Models;
+using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
+using Dfe.PlanTech.Domain.Questionnaire.Models;
+using Dfe.PlanTech.Infrastructure.Application.Models;
+
+namespace Dfe.PlanTech.Application.Questionnaire.Queries;
+
+public class GetCategoryQuery : ContentRetriever, IGetCategoryQuery
+{
+    public const string SlugFieldPath = "fields.landingPage.fields.slug";
+
+    public GetCategoryQuery(IContentRepository repository) : base(repository)
+    {
+    }
+
+    public async Task<Category?> GetCategoryBySlug(string categorySlug, CancellationToken cancellationToken = default)
+    {
+        var options = new GetEntitiesOptions()
+        {
+            Include = 5,
+            Queries =
+            [
+                new ContentQueryEquals()
+                {
+                    Field = SlugFieldPath,
+                    Value = categorySlug
+                },
+                new ContentQueryEquals()
+                {
+                    Field = "fields.landingPage.sys.contentType.sys.id",
+                    Value = "page"
+                }
+            ]
+        };
+
+        try
+        {
+            var categories = await repository.GetEntities<Category>(options, cancellationToken);
+            return categories.FirstOrDefault();
+        }
+        catch (Exception ex)
+        {
+            throw new ContentfulDataUnavailableException($"Error getting category with slug {categorySlug} from Contentful", ex);
+        }
+    }
+}

--- a/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IGetCategoryQuery.cs
+++ b/src/Dfe.PlanTech.Domain/Questionnaire/Interfaces/IGetCategoryQuery.cs
@@ -1,0 +1,8 @@
+﻿using Dfe.PlanTech.Domain.Questionnaire.Models;
+
+namespace Dfe.PlanTech.Domain.Questionnaire.Interfaces;
+
+public interface IGetCategoryQuery
+{
+    public Task<Category?> GetCategoryBySlug(string categorySlug, CancellationToken cancellationToken = default);
+}

--- a/src/Dfe.PlanTech.Web/Controllers/PagesController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/PagesController.cs
@@ -89,13 +89,27 @@ public class PagesController(
     => View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });
 
     [HttpGet("{categorySlug}/{sectionSlug}/{*path}")]
-    public IActionResult HandleUnknownRoutes(string path)
+    public async Task<IActionResult> HandleUnknownRoutes(string path)
     {
-        throw new KeyNotFoundException(path);
+        var viewModel = await BuildNotFoundViewModel();
+
+        return View("NotFoundError", viewModel);
     }
 
     [HttpGet(UrlConstants.NotFound, Name = UrlConstants.NotFound)]
     public async Task<IActionResult> NotFoundError()
+    {
+        var viewModel = await BuildNotFoundViewModel();
+
+        return View(viewModel);
+    }
+
+    private async Task<INavigationLink?> GetContactLinkAsync()
+    {
+        return await getNavigationQuery.GetLinkById(_contactOptions.LinkId);
+    }
+
+    private async Task<NotFoundViewModel> BuildNotFoundViewModel()
     {
         var contactLink = await GetContactLinkAsync();
 
@@ -104,11 +118,6 @@ public class PagesController(
             ContactLinkHref = contactLink?.Href
         };
 
-        return View(viewModel);
-    }
-
-    private async Task<INavigationLink?> GetContactLinkAsync()
-    {
-        return await getNavigationQuery.GetLinkById(_contactOptions.LinkId);
+        return viewModel;
     }
 }

--- a/src/Dfe.PlanTech.Web/Controllers/PagesController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/PagesController.cs
@@ -4,7 +4,7 @@ using Dfe.PlanTech.Application.Exceptions;
 using Dfe.PlanTech.Domain.Content.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Domain.Establishments.Models;
-using Dfe.PlanTech.Domain.Questionnaire.Models;
+using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 using Dfe.PlanTech.Domain.Users.Interfaces;
 using Dfe.PlanTech.Web.Authorisation;
 using Dfe.PlanTech.Web.Binders;
@@ -22,6 +22,7 @@ namespace Dfe.PlanTech.Web.Controllers;
 public class PagesController(
     ILogger<PagesController> logger,
     IGetNavigationQuery getNavigationQuery,
+    IGetCategoryQuery getCategoryQuery,
     IOptions<ContactOptions> contactOptions,
     IOptions<ErrorPages> errorPages) : BaseController<PagesController>(logger)
 {
@@ -32,7 +33,7 @@ public class PagesController(
 
     [Authorize(Policy = PageModelAuthorisationPolicy.PolicyName)]
     [HttpGet("{route?}", Name = "GetPage")]
-    public IActionResult GetByRoute([ModelBinder(typeof(PageModelBinder))] Page? page, [FromServices] IUser user)
+    public async Task<IActionResult> GetByRoute([ModelBinder(typeof(PageModelBinder))] Page? page, [FromServices] IUser user)
     {
         if (page == null)
         {
@@ -42,7 +43,7 @@ public class PagesController(
 
         if (page.IsLandingPage == true)
         {
-            var category = page.Content[0] as Category;
+            var category = await getCategoryQuery.GetCategoryBySlug(page.Slug);
 
             if (category == null)
             {

--- a/src/Dfe.PlanTech.Web/Controllers/RecommendationsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/RecommendationsController.cs
@@ -2,7 +2,7 @@ using Dfe.PlanTech.Application.Constants;
 using Dfe.PlanTech.Application.Exceptions;
 using Dfe.PlanTech.Domain.Content.Interfaces;
 using Dfe.PlanTech.Domain.Persistence.Models;
-using Dfe.PlanTech.Domain.Questionnaire.Models;
+using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 using Dfe.PlanTech.Web.Helpers;
 using Dfe.PlanTech.Web.Models;
 using Dfe.PlanTech.Web.Routing;
@@ -26,7 +26,7 @@ public class RecommendationsController(ILogger<RecommendationsController> logger
                                                          string sectionSlug,
                                                          string chunkSlug,
                                                          [FromServices] IGetRecommendationRouter getRecommendationRouter,
-                                                         [FromServices] IGetPageQuery getPageQuery,
+                                                         [FromServices] IGetCategoryQuery getCategoryQuery,
                                                          CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(categorySlug))
@@ -36,8 +36,7 @@ public class RecommendationsController(ILogger<RecommendationsController> logger
         if (string.IsNullOrEmpty(chunkSlug))
             throw new ArgumentNullException(nameof(chunkSlug));
 
-        var categoryLandingPage = await getPageQuery.GetPageBySlug(categorySlug, cancellationToken);
-        var category = categoryLandingPage?.Content[0] as Category ?? throw new ContentfulDataUnavailableException($"No category landing page found for slug: {categorySlug}");
+        var category = await getCategoryQuery.GetCategoryBySlug(categorySlug) ?? throw new ContentfulDataUnavailableException($"Unable to retrieve category with slug {categorySlug}");
 
         var (section, currentChunk, allChunks) = await getRecommendationRouter.GetSingleRecommendation(sectionSlug, chunkSlug, this, cancellationToken);
         var currentChunkIndex = allChunks.IndexOf(currentChunk);

--- a/src/Dfe.PlanTech.Web/Controllers/RecommendationsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/RecommendationsController.cs
@@ -1,6 +1,5 @@
 using Dfe.PlanTech.Application.Constants;
 using Dfe.PlanTech.Application.Exceptions;
-using Dfe.PlanTech.Domain.Content.Interfaces;
 using Dfe.PlanTech.Domain.Persistence.Models;
 using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 using Dfe.PlanTech.Web.Helpers;

--- a/src/Dfe.PlanTech.Web/ProgramExtensions.cs
+++ b/src/Dfe.PlanTech.Web/ProgramExtensions.cs
@@ -156,6 +156,7 @@ public static class ProgramExtensions
         services.AddTransient<IGetNavigationQuery, GetNavigationQuery>();
         services.AddTransient<IGetNextUnansweredQuestionQuery, GetNextUnansweredQuestionQuery>();
         services.AddTransient<IGetSectionQuery, GetSectionQuery>();
+        services.AddTransient<IGetCategoryQuery, GetCategoryQuery>();
         services.AddTransient<IGetSubmissionStatusesQuery, GetSubmissionStatusesQuery>();
         services.AddTransient<IGetUserIdQuery, GetUserIdQuery>();
         services.AddTransient<IProcessSubmissionResponsesCommand, ProcessSubmissionResponsesDto>();

--- a/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
@@ -20,13 +20,13 @@ public class GetRecommendationRouter : IGetRecommendationRouter
     private readonly IGetSubTopicRecommendationQuery _getSubTopicRecommendationQuery;
     private readonly IGetSectionQuery _getSectionQuery;
     private readonly IUser _user;
-    private readonly IGetPageQuery _getPageQuery;
+    private readonly IGetCategoryQuery _getCategoryQuery;
 
     public GetRecommendationRouter(ISubmissionStatusProcessor router,
                                    IGetLatestResponsesQuery getLatestResponsesQuery,
                                    IGetSubTopicRecommendationQuery getSubTopicRecommendationQuery,
                                    IGetSectionQuery getSectionQuery,
-                                   IGetPageQuery getPageQuery,
+                                   IGetCategoryQuery getCategoryQuery,
                                    IUser user)
     {
         _router = router;
@@ -34,7 +34,7 @@ public class GetRecommendationRouter : IGetRecommendationRouter
         _getSubTopicRecommendationQuery = getSubTopicRecommendationQuery;
         _getSectionQuery = getSectionQuery;
         _user = user;
-        _getPageQuery = getPageQuery;
+        _getCategoryQuery = getCategoryQuery;
     }
 
     public async Task<IActionResult> ValidateRoute(
@@ -132,8 +132,7 @@ public class GetRecommendationRouter : IGetRecommendationRouter
     private async Task<RecommendationsViewModel> GetRecommendationViewModel(string categorySlug, string sectionSlug, bool isChecklist = false, CancellationToken cancellationToken = default)
     {
         var (subTopicRecommendation, subTopicIntro, subTopicChunks, latestResponses) = await GetSubtopicRecommendation(cancellationToken);
-        var categoryLandingPage = await _getPageQuery.GetPageBySlug(categorySlug, cancellationToken);
-        var category = categoryLandingPage?.Content[0] as Category ?? throw new ContentfulDataUnavailableException($"No category landing page found for slug: {categorySlug}");
+        var category = await _getCategoryQuery.GetCategoryBySlug(categorySlug);
 
         var latestCompletionDate = new DateTime?();
 

--- a/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
+++ b/src/Dfe.PlanTech.Web/Routing/GetRecommendationRouter.cs
@@ -132,7 +132,7 @@ public class GetRecommendationRouter : IGetRecommendationRouter
     private async Task<RecommendationsViewModel> GetRecommendationViewModel(string categorySlug, string sectionSlug, bool isChecklist = false, CancellationToken cancellationToken = default)
     {
         var (subTopicRecommendation, subTopicIntro, subTopicChunks, latestResponses) = await GetSubtopicRecommendation(cancellationToken);
-        var category = await _getCategoryQuery.GetCategoryBySlug(categorySlug);
+        var category = await _getCategoryQuery.GetCategoryBySlug(categorySlug) ?? throw new ContentfulDataUnavailableException($"Unable to retrieve category with slug {categorySlug}");
 
         var latestCompletionDate = new DateTime?();
 

--- a/src/Dfe.PlanTech.Web/Views/Pages/Page.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Pages/Page.cshtml
@@ -78,9 +78,10 @@ else
     }
 
     var isHomeCategoryPage = Model.Page.Slug == UrlConstants.HomePage.Replace("/", "");
+    var isAutomatedTestingHomePage = Model.Page.Slug == UrlConstants.AutomatedTestingHomePage.Replace("/", "");
     var categories = Model.Page.Content.OfType<Dfe.PlanTech.Domain.Questionnaire.Models.Category>().ToList();
 
-    @if (isHomeCategoryPage && categories.Any())
+    @if ((isHomeCategoryPage || isAutomatedTestingHomePage) && categories.Any())
     {
         <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">

--- a/tests/Dfe.PlanTech.Application.UnitTests/Questionnaire/Queries/GetCategoryQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Questionnaire/Queries/GetCategoryQueryTests.cs
@@ -1,0 +1,109 @@
+﻿using Dfe.PlanTech.Application.Exceptions;
+using Dfe.PlanTech.Application.Persistence.Interfaces;
+using Dfe.PlanTech.Application.Persistence.Models;
+using Dfe.PlanTech.Application.Questionnaire.Queries;
+using Dfe.PlanTech.Domain.Content.Models;
+using Dfe.PlanTech.Domain.Questionnaire.Models;
+using Dfe.PlanTech.Infrastructure.Application.Models;
+using NSubstitute;
+
+namespace Dfe.PlanTech.Application.UnitTests.Questionnaire.Queries;
+
+public class GetCategoryQueryTests
+{
+    private readonly static Section _firstSection = new()
+    {
+        Name = "First section",
+        InterstitialPage = new Page()
+        {
+            Slug = "first"
+        },
+        Sys = new SystemDetails()
+        {
+            Id = "1"
+        }
+    };
+
+    private readonly static Section _secondSection = new()
+    {
+        Name = "Second section",
+        InterstitialPage = new Page()
+        {
+            Slug = "second"
+        },
+        Sys = new SystemDetails()
+        {
+            Id = "2"
+        }
+    };
+
+    private readonly static Category _category = new()
+    {
+        LandingPage = new Page()
+        {
+            Slug = "category-one"
+        },
+        Sections = new List<Section> { _firstSection, _secondSection }
+    };
+
+    private readonly static Category _categoryTwo = new()
+    {
+        LandingPage = new Page()
+        {
+            Slug = "category-two",
+        },
+        Sections = new List<Section>() { _firstSection, _secondSection }
+    };
+
+    private readonly Category[] _categories = new[] { _category, _categoryTwo };
+
+    [Fact]
+    public async Task GetCategoryBySlug_Returns_Category_From_Repository()
+    {
+        Assert.NotNull(_category.LandingPage);
+        var categorySlug = _category.LandingPage.Slug;
+        var cancellationToken = CancellationToken.None;
+
+        var repository = Substitute.For<IContentRepository>();
+        
+        repository.GetEntities<Category>(Arg.Any<GetEntitiesOptions>(), Arg.Any<CancellationToken>())
+        .Returns(callInfo =>
+        {
+            var options = callInfo.ArgAt<GetEntitiesOptions>(0);
+
+            var slugQuery = (options.Queries?.FirstOrDefault(query =>
+                query is ContentQueryEquals equalsQuery &&
+                equalsQuery.Field == GetCategoryQuery.SlugFieldPath) as ContentQueryEquals)
+                ?? throw new InvalidOperationException("Missing query for slug");
+
+            return _categories.Where(category => category.LandingPage?.Slug == slugQuery.Value);
+        });
+
+
+        var getCategoryQuery = new GetCategoryQuery(repository);
+        await getCategoryQuery.GetCategoryBySlug(categorySlug, cancellationToken);
+
+        Assert.Equal(_category.LandingPage.Slug, categorySlug);
+
+        await repository.Received(1).GetEntities<Category>(Arg.Any<GetEntitiesOptions>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetCategoryBySlug_ThrowsExceptionOnRepositoryError()
+    {
+        var categorySlug = "test-category";
+        var cancellationToken = CancellationToken.None;
+
+        var repository = Substitute.For<IContentRepository>();
+        repository
+            .When(repo => repo.GetEntities<Category>(Arg.Any<GetEntitiesOptions>(), cancellationToken))
+            .Throw(new Exception("Dummy Exception"));
+
+        var getCategoryQuery = new GetCategoryQuery(repository);
+
+        await Assert.ThrowsAsync<ContentfulDataUnavailableException>(
+            async () => await getCategoryQuery.GetCategoryBySlug(categorySlug, cancellationToken)
+        );
+    }
+}
+

--- a/tests/Dfe.PlanTech.Application.UnitTests/Questionnaire/Queries/GetCategoryQueryTests.cs
+++ b/tests/Dfe.PlanTech.Application.UnitTests/Questionnaire/Queries/GetCategoryQueryTests.cs
@@ -65,7 +65,7 @@ public class GetCategoryQueryTests
         var cancellationToken = CancellationToken.None;
 
         var repository = Substitute.For<IContentRepository>();
-        
+
         repository.GetEntities<Category>(Arg.Any<GetEntitiesOptions>(), Arg.Any<CancellationToken>())
         .Returns(callInfo =>
         {

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/RecommendationsControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/RecommendationsControllerTests.cs
@@ -1,7 +1,7 @@
 using Dfe.PlanTech.Application.Constants;
-using Dfe.PlanTech.Domain.Content.Interfaces;
 using Dfe.PlanTech.Domain.Content.Models;
 using Dfe.PlanTech.Domain.Persistence.Models;
+using Dfe.PlanTech.Domain.Questionnaire.Interfaces;
 using Dfe.PlanTech.Domain.Questionnaire.Models;
 using Dfe.PlanTech.Web.Controllers;
 using Dfe.PlanTech.Web.Routing;
@@ -15,7 +15,7 @@ namespace Dfe.PlanTech.Web.UnitTests.Controllers;
 public class RecommendationsControllerTests
 {
     private readonly IGetRecommendationRouter _recommendationsRouter;
-    private readonly IGetPageQuery _getPageQuery;
+    private readonly IGetCategoryQuery _getCategoryQuery;
 
     private readonly RecommendationsController _recommendationsController;
 
@@ -25,7 +25,7 @@ public class RecommendationsControllerTests
 
         var loggerSubstitute = Substitute.For<ILogger<RecommendationsController>>();
         _recommendationsController = new RecommendationsController(loggerSubstitute);
-        _getPageQuery = Substitute.For<IGetPageQuery>();
+        _getCategoryQuery = Substitute.For<IGetCategoryQuery>();
     }
 
     [Theory]
@@ -33,7 +33,7 @@ public class RecommendationsControllerTests
     [InlineData(null)]
     public async Task GetSingleRecommendation_Should_ThrowException_When_CategorySlug_NullOrEmpty(string? category)
     {
-        await Assert.ThrowsAnyAsync<ArgumentNullException>(() => _recommendationsController.GetSingleRecommendation(category!, "section-slug", "recommendation", _recommendationsRouter, _getPageQuery, default));
+        await Assert.ThrowsAnyAsync<ArgumentNullException>(() => _recommendationsController.GetSingleRecommendation(category!, "section-slug", "recommendation", _recommendationsRouter, _getCategoryQuery, default));
     }
 
     [Theory]
@@ -41,7 +41,7 @@ public class RecommendationsControllerTests
     [InlineData(null)]
     public async Task GetSingleRecommendation_Should_ThrowException_When_SectionSlug_NullOrEmpty(string? section)
     {
-        await Assert.ThrowsAnyAsync<ArgumentNullException>(() => _recommendationsController.GetSingleRecommendation("category-slug", section!, "recommendation", _recommendationsRouter, _getPageQuery, default));
+        await Assert.ThrowsAnyAsync<ArgumentNullException>(() => _recommendationsController.GetSingleRecommendation("category-slug", section!, "recommendation", _recommendationsRouter, _getCategoryQuery, default));
     }
 
 
@@ -50,7 +50,7 @@ public class RecommendationsControllerTests
     [InlineData(null)]
     public async Task GetSingleRecommendation_Should_ThrowException_When_RecommendationSlug_NullOrEmpty(string? recommendation)
     {
-        await Assert.ThrowsAnyAsync<ArgumentNullException>(() => _recommendationsController.GetSingleRecommendation("category-slug", "section slug", recommendation!, _recommendationsRouter, _getPageQuery, default));
+        await Assert.ThrowsAnyAsync<ArgumentNullException>(() => _recommendationsController.GetSingleRecommendation("category-slug", "section slug", recommendation!, _recommendationsRouter, _getCategoryQuery, default));
     }
 
     [Fact]
@@ -60,16 +60,9 @@ public class RecommendationsControllerTests
         string sectionSlug = "section-slug";
         string chunkSlug = "test-chunk-one";
 
-        var categoryLandingPage = new Page()
+        var category = new Category()
         {
-            Slug = categorySlug,
-            Content = new List<ContentComponent>()
-            {
-                new Category()
-                {
-                    Header = new Header(){ Text = "Test category" }
-                }
-            }
+            Header = new Header(){ Text = "Test category" }
         };
 
         var section = new Section() { InterstitialPage = new Page() { Slug = sectionSlug } };
@@ -78,12 +71,12 @@ public class RecommendationsControllerTests
         var testChunk3 = new RecommendationChunk() { Header = "Test chunk three" };
         var allTestChunks = new List<RecommendationChunk> { testChunk1, testChunk2, testChunk3 };
 
-        _getPageQuery.GetPageBySlug(categorySlug).Returns(categoryLandingPage);
+        _getCategoryQuery.GetCategoryBySlug(categorySlug).Returns(category);
         _recommendationsRouter.GetSingleRecommendation(sectionSlug, chunkSlug, _recommendationsController, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult((section, testChunk1, allTestChunks)));
 
         var result = await _recommendationsController.GetSingleRecommendation(
-            categorySlug, sectionSlug, chunkSlug, _recommendationsRouter, _getPageQuery, CancellationToken.None);
+            categorySlug, sectionSlug, chunkSlug, _recommendationsRouter, _getCategoryQuery, CancellationToken.None);
 
         await _recommendationsRouter.Received().GetSingleRecommendation(
             sectionSlug, chunkSlug, _recommendationsController, Arg.Any<CancellationToken>());

--- a/tests/Dfe.PlanTech.Web.UnitTests/Routing/GetRecommendationRouterTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Routing/GetRecommendationRouterTests.cs
@@ -28,7 +28,7 @@ public class GetRecommendationRouterTests
 
     private readonly IGetLatestResponsesQuery _getLatestResponsesQuery;
     private readonly IGetSubTopicRecommendationQuery _getSubTopicRecommendationQuery;
-    private readonly IGetPageQuery _getPageQuery;
+    private readonly IGetCategoryQuery _getCategoryQuery;
     private readonly IGetSectionQuery _getSectionQuery;
 
     private readonly IUser _user;
@@ -244,12 +244,12 @@ public class GetRecommendationRouterTests
         _submissionStatusProcessor = Substitute.For<ISubmissionStatusProcessor>();
         _getLatestResponsesQuery = Substitute.For<IGetLatestResponsesQuery>();
         _getSubTopicRecommendationQuery = Substitute.For<IGetSubTopicRecommendationQuery>();
-        _getPageQuery = Substitute.For<IGetPageQuery>();
+        _getCategoryQuery = Substitute.For<IGetCategoryQuery>();
         _getSectionQuery = Substitute.For<IGetSectionQuery>();
         _user = Substitute.For<IUser>();
 
         _controller = new RecommendationsController(new NullLogger<RecommendationsController>());
-        _router = new GetRecommendationRouter(_submissionStatusProcessor, _getLatestResponsesQuery, _getSubTopicRecommendationQuery, _getSectionQuery, _getPageQuery, _user);
+        _router = new GetRecommendationRouter(_submissionStatusProcessor, _getLatestResponsesQuery, _getSubTopicRecommendationQuery, _getSectionQuery, _getCategoryQuery, _user);
     }
 
     [Theory]
@@ -427,19 +427,12 @@ public class GetRecommendationRouterTests
     [Fact]
     public async Task Should_Show_RecommendationPage_When_Status_Is_Recommendation_And_All_Valid()
     {
-        var categoryLandingPage = new Page()
+        var category = new Category()
         {
-            Slug = "test-category",
-            Content = new List<ContentComponent>()
-            {
-                new Category()
-                {
-                    Header = new Header(){ Text = "Test category" }
-                }
-            }
+            Header = new Header(){ Text = "Test category" }
         };
 
-        _getPageQuery.GetPageBySlug(categoryLandingPage.Slug).Returns(categoryLandingPage);
+        _getCategoryQuery.GetCategoryBySlug("test-category").Returns(category);
 
         Assert.NotNull(_section.InterstitialPage);
         Setup_Valid_Recommendation();
@@ -498,19 +491,12 @@ public class GetRecommendationRouterTests
 
         Setup_Valid_Recommendation(responses);
 
-        var categoryLandingPage = new Page()
+        var category = new Category()
         {
-            Slug = "test-category",
-            Content = new List<ContentComponent>()
-            {
-                new Category()
-                {
-                    Header = new Header(){ Text = "Test category" }
-                }
-            }
+            Header = new Header() { Text = "Test category" }
         };
-
-        _getPageQuery.GetPageBySlug(categoryLandingPage.Slug).Returns(categoryLandingPage);
+          
+        _getCategoryQuery.GetCategoryBySlug("test-category").Returns(category);
 
         var result = await _router.ValidateRoute("test-category", _section.InterstitialPage.Slug, true, _controller, default);
 


### PR DESCRIPTION
## Overview

Addresses ticket [#274402](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/274402)

Refactor to facilitate removing the Category from the content field of the Category Landing page, as this was creating an infinite loop and causing hanging and 504 errors

## Changes

- Create new GetCategoryQuery and interface
- Refactor PagesController, RecommendationsController and GetRecommendationsRouter to use new query instead of getting Category from the landing page

### Non-functional changes (e.g. documentation)

- Updated unit tests

## How to review the PR

- Content is set up on the dev environment in Contentful, flush cache if using local Redis
- Load category landing pages and individual recommendation , check performance

## Release requirements

Remove the Category from the content fields of the Category Landing pages in WIP Contentful environment. This field needs a value, so we can create an 'Empty textbody' element to replace it. This content won't be rendered because there is nothing in the View that renders it, but we may want to explore another replacement in future (or wait and see if CDs decide to add any text at the top of the page in future releases).

## Additional notes

Started getting a KeyNotFoundException when opening dev tools during this work - unsure if this is to do with the changes made or a me problem

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] PR targets development branch
- [x] Unit tests have been added/updated
- [x] E2E tests have been added/updated (content updated for E2E)
