### PR TITLE
Deal with the sonar warnings about deprecated config options, incorrect checkout depth, etc.

### DIFF
--- a/.github/workflows/code-pr-check.yml
+++ b/.github/workflows/code-pr-check.yml
@@ -2,18 +2,20 @@ name: Code PR Check
 
 on:
   push:
-    branches: ["main", "development"]
-    paths:
-      - "src/**"
-      - "tests/**"
-  pull_request:
-    branches: ["main", "development"]
     paths:
       - "src/**"
       - "tests/**"
       - ".github/workflows/code-pr-check.yml"
       - ".github/actions/build-dotnet-app/action.yml"
       - ".github/actions/run-unit-tests/action.yml"
+  pull_request:
+    paths:
+      - "src/**"
+      - "tests/**"
+      - ".github/workflows/code-pr-check.yml"
+      - ".github/actions/build-dotnet-app/action.yml"
+      - ".github/actions/run-unit-tests/action.yml"
+  workflow_dispatch: # Enables manual triggering
 
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
@@ -38,6 +40,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # The ref is specifically needed here to ensure the PR branch is checked out,
+          # allowing linting changes to be committed and pushed back (otherwise is a detached HEAD state).
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Set up .NET
@@ -72,6 +76,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        # Fetch depth 0 required for Sonar to do full analysis
+        with:
+          fetch-depth: 0
 
       - name: Cache SonarCloud packages
         uses: actions/cache@v4
@@ -97,7 +104,7 @@ jobs:
           dotnet-sonarscanner begin \
           /k:"DFE-Digital_plan-technology-for-your-school" \
           /o:"dfe-digital" \
-          /d:sonar.login="${{ secrets.SONAR_TOKEN }}" \
+          /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
           /d:sonar.host.url="https://sonarcloud.io" \
           /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml \
           /d:sonar.coverage.exclusions=**/Program.cs,**/gulpfile.js,**/wwwroot/**,**/Dfe.PlanTech.Web.SeedTestData/** \
@@ -121,7 +128,7 @@ jobs:
         run: dotnet-coverage merge -f xml -o "coverage.xml" -s "coverage.settings.xml" -r coverage.cobertura.xml
 
       - name: End SonarCloud Scanner
-        run: dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
+        run: dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
 
       - name: Archive code coverage results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Also, trigger the checks (incl. sonar) on more than just branches+PRs on main / development branches.