### PR TITLE
fix(277271): mat dashboard missing statuses and links to recommendations

### DIFF
--- a/src/Dfe.PlanTech.Web/ViewBuilders/BaseViewBuilder.cs
+++ b/src/Dfe.PlanTech.Web/ViewBuilders/BaseViewBuilder.cs
@@ -59,6 +59,7 @@ public class BaseViewBuilder(
                 RecommendationSlug = recommendationIntro.Slug,
                 RecommendationDisplayName = recommendationIntro.Header.Text,
                 SectionSlug = section.InterstitialPage?.Slug,
+                SectionName = section.Name,
                 Viewed = sectionStatus.HasBeenViewed
             };
         }

--- a/src/Dfe.PlanTech.Web/ViewBuilders/GroupsDashboardViewComponentViewBuilder.cs
+++ b/src/Dfe.PlanTech.Web/ViewBuilders/GroupsDashboardViewComponentViewBuilder.cs
@@ -57,7 +57,7 @@ public class GroupsDashboardViewComponentViewBuilder(
         return new GroupsDashboardViewComponentViewModel
         {
             Description = description,
-            GroupsCategorySections = await GetGroupsCategorySectionViewModel(category, sectionStatuses, progressRetrievalErrorMessage is null).ToListAsync(),
+            GroupsCategorySections = await GetGroupsCategorySectionViewModel(category, sectionStatuses, progressRetrievalErrorMessage is not null).ToListAsync(),
             ProgressRetrievalErrorMessage = progressRetrievalErrorMessage,
         };
     }


### PR DESCRIPTION
## Overview

Addresses ticket [#277271](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/277271)

Fixes missing section names and recommendation links on MAT dashboard for sections with recommendations available and shows correct section statuses instead of retrieval error.

## How to review the PR

Log in as MAT, select a school, check statuses and links are all in place. 

## Release requirements

Merge in [school selection PR](https://github.com/DFE-Digital/sts-plan-technology-for-your-school/pull/1197) first to avoid merge conflicts - resolved on that branch

## Checklist

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Unit tests have been added/updated
- [ ] E2E tests have been added/updated