### PR TITLE
(bug:277592) - Added slash to redirect url in service exception middleware

### DIFF
--- a/src/Dfe.PlanTech.Web/Middleware/ServiceExceptionHandlerMiddleWare.cs
+++ b/src/Dfe.PlanTech.Web/Middleware/ServiceExceptionHandlerMiddleWare.cs
@@ -32,7 +32,7 @@ public class ServiceExceptionHandlerMiddleware(
         var exception = exceptionHandlerPathFeature?.Error;
 
         string redirectUrl = GetRedirectUrlForException(internalErrorSlug, exception);
-        context.Response.Redirect(redirectUrl);
+        context.Response.Redirect($"/{redirectUrl}");
     }
 
     private static string GetRedirectUrlForException(string internalErrorSlug, Exception? exception) =>


### PR DESCRIPTION
## Overview

Addresses ticket [#277592](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/277592)

## Changes

### Minor

- Added slash in service-exception-middleware where we redirect to service-unavailable.



- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0/)

