### PR TITLE
277969 Add continue self-assessment page

### DIFF
--- a/src/Dfe.PlanTech.Core/Models/SubmissionResponsesModel.cs
+++ b/src/Dfe.PlanTech.Core/Models/SubmissionResponsesModel.cs
@@ -9,6 +9,8 @@ namespace Dfe.PlanTech.Core.Models
 
         public DateTime? DateCompleted { get; init; }
 
+        public DateTime? DateCreated { get; init; }
+
         public string? Maturity { get; set; }
 
         public List<QuestionWithAnswerModel> Responses { get; set; }
@@ -25,6 +27,7 @@ namespace Dfe.PlanTech.Core.Models
         {
             SubmissionId = submission.Id;
             DateCompleted = submission.DateCompleted;
+            DateCreated = submission.DateCreated;
             Maturity = submission.Maturity;
             Responses = submission.Responses
                 .Select(response => new QuestionWithAnswerModel(response, section))

--- a/src/Dfe.PlanTech.Web/Controllers/QuestionsController.cs
+++ b/src/Dfe.PlanTech.Web/Controllers/QuestionsController.cs
@@ -61,6 +61,16 @@ public class QuestionsController : BaseController<QuestionsController>
         return await _questionsViewBuilder.RouteToNextUnansweredQuestion(this, categorySlug, sectionSlug);
     }
 
+
+    [HttpGet("{categorySlug}/{sectionSlug}/self-assessment/continue", Name = "GetContinueSelfAssessmentPage")]
+    public async Task<IActionResult> GetContinueSelfAssessmentPage(string categorySlug, string sectionSlug)
+    {
+        ArgumentNullException.ThrowIfNullOrWhiteSpace(categorySlug, nameof(categorySlug));
+        ArgumentNullException.ThrowIfNullOrWhiteSpace(sectionSlug, nameof(sectionSlug));
+
+        return await _questionsViewBuilder.RouteToContinueSelfAssessmentPage(this, categorySlug, sectionSlug);
+    }
+
     [LogInvalidModelState]
     [HttpPost("{categorySlug}/{sectionSlug}/self-assessment/{questionSlug}")]
     public async Task<IActionResult> SubmitAnswer(

--- a/src/Dfe.PlanTech.Web/ViewBuilders/Interfaces/IQuestionsViewBuilder.cs
+++ b/src/Dfe.PlanTech.Web/ViewBuilders/Interfaces/IQuestionsViewBuilder.cs
@@ -9,6 +9,7 @@ namespace Dfe.PlanTech.Web.ViewBuilders.Interfaces
         Task<IActionResult> RouteToInterstitialPage(Controller controller, string categorySlug, string sectionSlug);
         Task<IActionResult> RouteByQuestionId(Controller controller, string questionId);
         Task<IActionResult> RouteToNextUnansweredQuestion(Controller controller, string categorySlug, string sectionSlug);
+        Task<IActionResult> RouteToContinueSelfAssessmentPage(Controller controller, string categorySlug, string sectionSlug);
         Task<IActionResult> SubmitAnswerAndRedirect(Controller controller, SubmitAnswerInputViewModel answerViewModel, string categorySlug, string sectionSlug, string questionSlug, string? returnTo);
     }
 }

--- a/src/Dfe.PlanTech.Web/ViewModels/ContinueSelfAssessmentViewModel.cs
+++ b/src/Dfe.PlanTech.Web/ViewModels/ContinueSelfAssessmentViewModel.cs
@@ -1,0 +1,17 @@
+﻿using Dfe.PlanTech.Core.Models;
+
+namespace Dfe.PlanTech.Web.ViewModels
+{
+    public class ContinueSelfAssessmentViewModel
+    {
+        public string TrustName { get; set; } = string.Empty;
+        public DateTime AssessmentStartDate { get; set; }
+        public int AnsweredCount { get; set; }
+        public string TopicName { get; set; } = string.Empty;
+        public int QuestionsCount { get; set; }
+        public List<QuestionWithAnswerModel> Responses { get; set; } = new();
+
+        public string CategorySlug { get; set; } = string.Empty;
+        public string SectionSlug { get; set; } = string.Empty;
+    }
+}

--- a/src/Dfe.PlanTech.Web/Views/Questions/ContinueSelfAssessment.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Questions/ContinueSelfAssessment.cshtml
@@ -1,0 +1,56 @@
+﻿@model ContinueSelfAssessmentViewModel
+
+@section BeforeContent {
+    @{
+        await Html.RenderPartialAsync("BackButton");
+    }
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <span class="govuk-caption-xl">@Model.TopicName</span>
+        <h1 class="govuk-heading-xl">Continue self-assessment</h1>
+
+        <p>
+            Someone in @Model.TrustName
+            started this self-assessment on
+            @Model.AssessmentStartDate.ToString("dd MMMM yyyy")
+            and answered @Model.AnsweredCount out of @Model.QuestionsCount questions.
+        </p>
+
+        <h2 class="govuk-heading-l">Your self-assessment answers</h2>
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+        @foreach (var response in Model.Responses)
+        {
+            <div>
+              
+                <p class="govuk-!-font-weight-bold">@response.QuestionText</p>
+                <p>@response.AnswerText</p>
+                <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-4 govuk-!-margin-bottom-4" />
+            </div>
+        }
+
+        <p>You can continue this self-assessment and answer the remaining questions.</p>
+        <p>If you choose to restart the self-assessment, any previous answers will be replaced.</p>
+
+        <div class="govuk-button-group">
+            <a href="@Url.Action(
+                               nameof(QuestionsController.GetNextUnansweredQuestion),
+                               "Questions",
+                               new { categorySlug = Model.CategorySlug, sectionSlug = Model.SectionSlug })"
+               class="govuk-button"
+               data-module="govuk-button">
+                Continue self-assessment
+            </a>
+
+            <a href="@Url.Action(
+                               nameof(QuestionsController.GetInterstitialPage),
+                               "Questions",
+                               new { categorySlug = Model.CategorySlug, sectionSlug = Model.SectionSlug })"
+               class="govuk-button govuk-button--secondary"
+               data-module="govuk-button">
+                Restart self-assessment
+            </a>
+        </div>
+    </div>
+</div>

--- a/src/Dfe.PlanTech.Web/Views/Shared/Components/CategoryLanding/SectionAssessmentLink.cshtml
+++ b/src/Dfe.PlanTech.Web/Views/Shared/Components/CategoryLanding/SectionAssessmentLink.cshtml
@@ -17,7 +17,7 @@
 			statusText = $"A self-assessment was started on {topic.DateUpdated}. ";
 			linkText = $"Continue your self-assessment for {topicName}";
 			controller = nameof(QuestionsController);
-			action = nameof(QuestionsController.GetNextUnansweredQuestion);
+			action = nameof(QuestionsController.GetContinueSelfAssessmentPage);
 			break;
 		case SectionProgressStatus.Completed:
 			statusText = $"The self-assessment for {topicName} was completed on {topic.LastCompletionDate}.";

--- a/tests/Dfe.PlanTech.Web.UnitTests/Controllers/QuestionsControllerTests.cs
+++ b/tests/Dfe.PlanTech.Web.UnitTests/Controllers/QuestionsControllerTests.cs
@@ -98,6 +98,21 @@ namespace Dfe.PlanTech.Web.Tests.Controllers
         }
 
         [Fact]
+        public async Task GetContinueSelfAssessmentPage_CallsViewBuilder()
+        {
+            var categorySlug = "cat";
+            var sectionSlug = "sec";
+
+            _viewBuilder.RouteToContinueSelfAssessmentPage(_controller, categorySlug, sectionSlug)
+                .Returns(new OkResult());
+
+            var result = await _controller.GetContinueSelfAssessmentPage(categorySlug, sectionSlug);
+
+            await _viewBuilder.Received(1).RouteToContinueSelfAssessmentPage(_controller, categorySlug, sectionSlug);
+            Assert.IsType<OkResult>(result);
+        }
+
+        [Fact]
         public void Constructor_WithNullQuestionsViewBuilder_ThrowsArgumentNullException()
         {
             var logger = Substitute.For<ILogger<QuestionsController>>();


### PR DESCRIPTION
## Overview

Added continue self-assessment page

Addresses ticket [#277969](https://dfe-ssp.visualstudio.com/s190-schools-technology-services/_workitems/edit/277969)

Create continue self-assessment page
Create new unit tests for the questions viewbuilder and controller

The design for the ticket is based on:
https://plantech.herokuapp.com/sprint22/mvp/cyber-security/cyberprocess/continue-self-assessment

<img width="862" height="887" alt="continue page" src="https://github.com/user-attachments/assets/be1d225c-598d-4f2c-8609-802af8f2d7b8" />


- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] PR targets development branch
- [x] Unit tests have been added/updated
- [ ] E2E tests have been added/updated
- [ ] GitHub workflows/actions have been added/updated
- [ ] Terraform has been updated
- [ ] Documentation has been updated where relevant
- [ ] Any Key Vault secrets have been added to the development Key Vault
