### PR TITLE
fix: Error when submitting new self assessment (#284208)

### DIFF
--- a/src/Dfe.PlanTech.Data.Sql/Repositories/SubmissionRepository.cs
+++ b/src/Dfe.PlanTech.Data.Sql/Repositories/SubmissionRepository.cs
@@ -112,7 +112,7 @@ public class SubmissionRepository(PlanTechDbContext dbContext) : ISubmissionRepo
                 erh.EstablishmentId == establishmentId &&
                 erh.MatEstablishmentId == matEstablishmentId
             )
-            .Select(erh => new {erh.RecommendationId, erh.NewStatus, erh.DateCreated})
+            .Select(erh => new { erh.RecommendationId, erh.NewStatus, erh.DateCreated })
             .ToListAsync();
 
         var mostRecentStatusForEachRecommendation = allHistoricalRecommendationsForEstablishment

--- a/src/Dfe.PlanTech.Web/ViewBuilders/ReviewAnswersViewBuilder.cs
+++ b/src/Dfe.PlanTech.Web/ViewBuilders/ReviewAnswersViewBuilder.cs
@@ -141,7 +141,7 @@ public class ReviewAnswersViewBuilder(
         }
         catch (Exception e)
         {
-            Logger.LogError(e, "There was an error while trying to calculate the maturity of submission {SubmissionId}", submissionId);
+            Logger.LogError(e, "There was an error while trying to submit submission {SubmissionId}", submissionId);
             controller.TempData["ErrorMessage"] = InlineRecommendationUnavailableErrorMessage;
             return controller.RedirectToCheckAnswers(categorySlug, sectionSlug, false);
         }

--- a/tests/Dfe.PlanTech.Data.Sql.IntegrationTests/Repositories/SubmissionRepositoryTests.cs
+++ b/tests/Dfe.PlanTech.Data.Sql.IntegrationTests/Repositories/SubmissionRepositoryTests.cs
@@ -1,6 +1,6 @@
-﻿using Dfe.PlanTech.Core.Enums;
-using Dfe.PlanTech.Core.Constants;
+﻿using Dfe.PlanTech.Core.Constants;
 using Dfe.PlanTech.Core.Contentful.Models;
+using Dfe.PlanTech.Core.Enums;
 using Dfe.PlanTech.Data.Sql.Entities;
 using Dfe.PlanTech.Data.Sql.Repositories;
 


### PR DESCRIPTION
## Overview

Addresses ticket #284208

Currently only a single self-assessment seems to be able to be submitted.

The issue appears to be caused by using the recommendation ID as a dictionary key as part of the save process. Given that there can be multiple status entries for a given recommendation (one entry for each change in status), the uniqueness constraint of a dictionary key causes an exception to be thrown:

```csharp
  
var previousStatuses = _db.EstablishmentRecommendationHistories  
    .Where(erh => erh.EstablishmentId == establishmentId &&  
                  erh.MatEstablishmentId == matEstablishmentId)  
    .ToDictionary(r => r.RecommendationId, r => r.NewStatus);
```

```
fail: Dfe.PlanTech.Web.ViewBuilders.BaseViewBuilder[0]
      There was an error while trying to calculate the maturity of submission 12646
      System.ArgumentException: An item with the same key has already been added. Key: 10
         at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
         at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
         at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
         at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector)
         at Dfe.PlanTech.Data.Sql.Repositories.SubmissionRepository.ConfirmCheckAnswersAndUpdateRecommendationsAsync(Int32 establishmentId, Nullable`1 matEstablishmentId, Int32 submissionId, Int32 userId, QuestionnaireSectionEntry section) in C:\dev\sts-plan-technology-for-your-school\src\Dfe.PlanTech.Data.Sql\Repositories\SubmissionRepository.cs:line 109
         at Dfe.PlanTech.Web.ViewBuilders.ReviewAnswersViewBuilder.ConfirmCheckAnswers(Controller controller, String categorySlug, String sectionSlug, String sectionName, Int32 submissionId) in C:\dev\sts-plan-technology-for-your-school\src\Dfe.PlanTech.Web\ViewBuilders\ReviewAnswersViewBuilder.cs:line 134
```

## Checklist

Delete any rows that do not apply to the PR.

- [x] Title uses [Angular commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] PR targets development branch
- [x] Unit tests have been added/updated

